### PR TITLE
MPI parallelization of thermodynamics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,12 @@ set_property(TARGET doctest::doctest PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${D
 
 find_package(Eigen3 3.4 REQUIRED)
 
+option(ENABLE_MPI "Enable distributed-memory parallelization with MPI" OFF)
+if(ENABLE_MPI)
+  find_package(MPI REQUIRED COMPONENTS C CXX)
+endif()
+
+
 # To add netCDF to a target:
 # target_include_directories(target PUBLIC ${netCDF_INCLUDE_DIR})
 # target_link_directories(target PUBLIC ${netCDF_LIB_DIR})
@@ -89,6 +95,10 @@ foreach(compo ${CodeComponents})
 endforeach()
 
 add_library(nextsimlib SHARED ${NextsimSources})
+target_compile_definitions(nextsimlib
+  PRIVATE
+    $<$<BOOL:${ENABLE_MPI}>:USE_MPI>
+)
 target_include_directories(nextsimlib
     PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}"
@@ -97,9 +107,16 @@ target_include_directories(nextsimlib
     "${netCDF_INCLUDE_DIR}"
     )
 target_link_directories(nextsimlib PUBLIC "${netCDF_LIB_DIR}")
-target_link_libraries(nextsimlib PUBLIC Boost::program_options Boost::log "${NSDG_NetCDF_Library}" Eigen3::Eigen)
+target_link_libraries(nextsimlib PUBLIC
+    Boost::program_options Boost::log "${NSDG_NetCDF_Library}" Eigen3::Eigen
+    $<$<BOOL:${ENABLE_MPI}>:MPI::MPI_C> $<$<BOOL:${ENABLE_MPI}>:MPI::MPI_CXX>
+    )
 
 add_executable(nextsim ./core/src/main.cpp)
+target_compile_definitions(nextsim
+  PRIVATE
+    $<$<BOOL:${ENABLE_MPI}>:USE_MPI>
+)
 target_include_directories(nextsim PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}"
     "${NextsimIncludeDirs}"

--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -26,6 +26,10 @@ set(BaseSources
     "${ModelArrayStructure}/ModelArrayDetails.cpp"
     )
 
+set(ParallelNetCDFSources
+    "${CMAKE_CURRENT_SOURCE_DIR}/ParallelNetcdfFile.cpp"
+    )
+
 list(TRANSFORM BaseSources PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
 
 set(ModuleDir "${CMAKE_CURRENT_SOURCE_DIR}/modules")
@@ -66,7 +70,24 @@ set(NextsimSources
     "${NextsimSources}"
     "${BaseSources}"
     "${ModuleSources}"
+    "${ParallelNetCDFSources}"
     PARENT_SCOPE)
+
+if(ENABLE_MPI)
+    set(NextsimSources
+        "${NextsimSources}"
+        "${BaseSources}"
+        "${ModuleSources}"
+        "${ParallelNetCDFSources}"
+        PARENT_SCOPE)
+else()
+    set(NextsimSources
+        "${NextsimSources}"
+        "${BaseSources}"
+        "${ModuleSources}"
+        PARENT_SCOPE)
+endif()
+
 
 set(NextsimIncludeDirs
     "${NextsimIncludeDirs}"

--- a/core/src/Model.cpp
+++ b/core/src/Model.cpp
@@ -2,6 +2,7 @@
  * @file Model.cpp
  * @date 12 Aug 2021
  * @author Tim Spain <timothy.spain@nersc.no>
+ * @author Kacper Kornet <kk562@cam.ac.uk>
  */
 
 #include "include/Model.hpp"
@@ -26,6 +27,9 @@ const std::string Model::restartOptionName = "model.init_file";
 template <>
 const std::map<int, std::string> Configured<Model>::keyMap = {
     { Model::RESTARTFILE_KEY, Model::restartOptionName },
+#ifdef USE_MPI
+    { Model::PARTITIONFILE_KEY, "model.partition_file" },
+#endif
     { Model::STARTTIME_KEY, "model.start" },
     { Model::STOPTIME_KEY, "model.stop" },
     { Model::RUNLENGTH_KEY, "model.run_length" },
@@ -78,6 +82,11 @@ void Model::configure()
     modelStep.init();
     modelStep.setInitFile(initialFileName);
 
+#ifdef USE_MPI
+    std::string partitionFile
+        = Configured::getConfiguration(keyMap.at(PARTITIONFILE_KEY), std::string("partition.nc"));
+#endif
+
     ModelState initialState(StructureFactory::stateFromFile(initialFileName));
     modelStep.setData(pData);
     modelStep.setMetadata(m_etadata);
@@ -115,6 +124,10 @@ Model::HelpMap& Model::getHelpText(HelpMap& map, bool getAll)
             "The file path to the restart file to use for the run." },
         { keyMap.at(MISSINGVALUE_KEY), ConfigType::NUMERIC, { "-∞", "∞" }, "-2³⁰⁰", "",
             "Missing data indicator used for input and output." },
+#ifdef USE_MPI
+        { keyMap.at(PARTITIONFILE_KEY), ConfigType::STRING, {}, "", "",
+            "The file path to the file describing MPI domain decomposition to use for the run." },
+#endif
     };
 
     return map;

--- a/core/src/Model.cpp
+++ b/core/src/Model.cpp
@@ -37,8 +37,16 @@ const std::map<int, std::string> Configured<Model>::keyMap = {
     { Model::MISSINGVALUE_KEY, "model.missing_value" },
 };
 
+#ifdef USE_MPI
+Model::Model(MPI_Comm comm)
+#else
 Model::Model()
+#endif
 {
+#ifdef USE_MPI
+    m_etadata.setMpiMetadata(comm);
+#endif
+
     iterator.setIterant(&modelStep);
 
     finalFileName = "restart.nc";

--- a/core/src/Model.cpp
+++ b/core/src/Model.cpp
@@ -95,7 +95,12 @@ void Model::configure()
         = Configured::getConfiguration(keyMap.at(PARTITIONFILE_KEY), std::string("partition.nc"));
 #endif
 
+#ifdef USE_MPI
+    ModelState initialState(
+        StructureFactory::stateFromFile(initialFileName, partitionFile, m_etadata));
+#else
     ModelState initialState(StructureFactory::stateFromFile(initialFileName));
+#endif
     modelStep.setData(pData);
     modelStep.setMetadata(m_etadata);
     pData.setData(initialState.data);

--- a/core/src/ModelMetadata.cpp
+++ b/core/src/ModelMetadata.cpp
@@ -16,4 +16,13 @@ const std::string& ModelMetadata::structureName() const
     return Module::getImplementation<IStructure>().structureType();
 }
 
+#ifdef USE_MPI
+void ModelMetadata::setMpiMetadata(MPI_Comm comm)
+{
+    mpiComm = comm;
+    MPI_Comm_size(mpiComm, &mpiSize);
+    MPI_Comm_rank(mpiComm, &mpiMyRank);
+}
+#endif
+
 } /* namespace Nextsim */

--- a/core/src/ParallelNetcdfFile.cpp
+++ b/core/src/ParallelNetcdfFile.cpp
@@ -1,0 +1,46 @@
+#include <ncCheck.h>
+#include <netcdf.h>
+#include <netcdf_par.h>
+
+#include "include/ParallelNetcdfFile.hpp"
+
+using namespace netCDF;
+
+// Not sure why it is needed but let's replicate netCDF::ncFile::open
+// in this respect
+extern int g_ncid;
+
+NcFilePar::NcFilePar(
+    const std::string& filePath, const FileMode fMode, MPI_Comm comm, MPI_Info mpiInfo)
+{
+    open_par(filePath, fMode, comm, mpiInfo);
+}
+
+void NcFilePar::open_par(
+    const std::string& filePath, const FileMode fMode, MPI_Comm comm, MPI_Info mpiInfo)
+{
+    if (!nullObject)
+        close();
+
+    switch (fMode) {
+    case NcFile::write:
+        ncCheck(nc_open_par(filePath.c_str(), NC_WRITE, comm, mpiInfo, &myId), __FILE__, __LINE__);
+        break;
+    case NcFile::read:
+        ncCheck(
+            nc_open_par(filePath.c_str(), NC_NOWRITE, comm, mpiInfo, &myId), __FILE__, __LINE__);
+        break;
+    case NcFile::newFile:
+        ncCheck(nc_create_par(filePath.c_str(), NC_NETCDF4 | NC_NOCLOBBER, comm, mpiInfo, &myId),
+            __FILE__, __LINE__);
+        break;
+    case NcFile::replace:
+        ncCheck(nc_create_par(filePath.c_str(), NC_NETCDF4 | NC_CLOBBER, comm, mpiInfo, &myId),
+            __FILE__, __LINE__);
+        break;
+    }
+
+    g_ncid = myId;
+
+    nullObject = false;
+}

--- a/core/src/RectGridIO.cpp
+++ b/core/src/RectGridIO.cpp
@@ -161,6 +161,8 @@ void RectGridIO::readPartitionData(const std::string& partitionFile, ModelMetada
             + std::to_string(nBoxes) + "\n";
         throw std::runtime_error(errorMsg);
     }
+    metadata.globalExtentX = ncFile.getDim("globalX").getSize();
+    metadata.globalExtentY = ncFile.getDim("globalY").getSize();
     netCDF::NcGroup bboxGroup(ncFile.getGroup(bboxName));
     std::vector<size_t> index(1, metadata.mpiMyRank);
     bboxGroup.getVar("global_x").getVar(index, &metadata.localCornerX);

--- a/core/src/RectGridIO.cpp
+++ b/core/src/RectGridIO.cpp
@@ -3,6 +3,7 @@
  *
  * @date Feb 8, 2022
  * @author Tim Spain <timothy.spain@nersc.no>
+ * @author Kacper Kornet <kk562@cam.ac.uk>
  */
 
 #include "include/RectGridIO.hpp"
@@ -46,7 +47,11 @@ void dimensionSetter(
     ModelArray::setDimensions(type, dims);
 }
 
+#ifdef USE_MPI
+ModelState RectGridIO::getModelState(const std::string& filePath, const std::string& partitionFile)
+#else
 ModelState RectGridIO::getModelState(const std::string& filePath)
+#endif
 {
     ModelState state;
     netCDF::NcFile ncFile(filePath, netCDF::NcFile::read);

--- a/core/src/RectGridIO.cpp
+++ b/core/src/RectGridIO.cpp
@@ -48,7 +48,8 @@ void dimensionSetter(
 }
 
 #ifdef USE_MPI
-ModelState RectGridIO::getModelState(const std::string& filePath, const std::string& partitionFile)
+ModelState RectGridIO::getModelState(
+    const std::string& filePath, const std::string& partitionFile, ModelMetadata& metadata)
 #else
 ModelState RectGridIO::getModelState(const std::string& filePath)
 #endif

--- a/core/src/RectGridIO.cpp
+++ b/core/src/RectGridIO.cpp
@@ -45,6 +45,11 @@ void dimensionSetter(const netCDF::NcGroup& dataGroup, const std::string& fieldN
     for (size_t d = 2; d < nDims; ++d) {
         dims[d] = dataGroup.getVar(fieldName).getDim(d).getSize();
     }
+    // The dimensions in the netCDF are in the reverse order compared to ModelArray
+    std::reverse(dims.begin(), dims.end());
+    // A special case for Type::Z: use NZLevels for the third dimension
+    if (type == ModelArray::Type::Z)
+        dims[2] = NZLevels::get();
     ModelArray::setDimensions(type, dims);
 }
 #else
@@ -97,10 +102,10 @@ ModelState RectGridIO::getModelState(const std::string& filePath)
     // on MPI decomposition
     std::vector<size_t> start(2);
     std::vector<size_t> size(2);
-    start[0] = metadata.localCornerX;
-    start[1] = metadata.localCornerY;
-    size[0] = metadata.localExtentX;
-    size[1] = metadata.localExtentY;
+    start[0] = metadata.localCornerY;
+    start[1] = metadata.localCornerX;
+    size[0] = metadata.localExtentY;
+    size[1] = metadata.localExtentX;
 
     state.data[maskName] = ModelArray::HField();
     dataGroup.getVar(maskName).getVar(start, size, &state.data[maskName][0]);
@@ -111,13 +116,6 @@ ModelState RectGridIO::getModelState(const std::string& filePath)
     state.data[hsnowName] = ModelArray::HField();
     dataGroup.getVar(hsnowName).getVar(start, size, &state.data[hsnowName][0]);
 
-    // The domain is not decomposed in z direction so set the extend in this direction
-    // to full range
-    start.push_back(0);
-    size.push_back(dataGroup.getDim("nLayers").getSize());
-
-    state.data[ticeName] = ModelArray::ZField();
-    dataGroup.getVar(ticeName).getVar(start, size, &state.data[ticeName][0]);
 
 #else
     // Get the sizes of the four types of field
@@ -138,6 +136,9 @@ ModelState RectGridIO::getModelState(const std::string& filePath)
     dataGroup.getVar(ciceName).getVar(&state.data[ciceName][0]);
     state.data[hsnowName] = ModelArray::HField();
     dataGroup.getVar(hsnowName).getVar(&state.data[hsnowName][0]);
+#endif
+    // Z direction is outside MPI ifdef as the domain is never decomposed in this direction
+
     // Since the ZFierld might not have the same dimensions as the tice field
     // in the file, a little more work is required.
     state.data[ticeName] = ModelArray::ZField();
@@ -145,7 +146,6 @@ ModelState RectGridIO::getModelState(const std::string& filePath)
     std::vector<size_t> zArrayDims = ModelArray::dimensions(ModelArray::Type::Z);
     std::reverse(zArrayDims.begin(), zArrayDims.end());
     dataGroup.getVar(ticeName).getVar(startVector, zArrayDims, &state.data[ticeName][0]);
-#endif
 
     ncFile.close();
     return state;
@@ -211,16 +211,14 @@ void RectGridIO::dumpModelState(const ModelState& state, const ModelMetadata& me
     std::vector<netCDF::NcDim> dims2 = { yDim, xDim };
     std::vector<netCDF::NcDim> dims3 = { zDim, yDim, xDim };
 #ifdef USE_MPI
+    // Set the origins and extensions for reading 3D data based
+    // on MPI decomposition
+    std::vector<size_t> start3 = { 0, static_cast<size_t>(metadata.localCornerY), static_cast<size_t>(metadata.localCornerX) };
+    std::vector<size_t> size3 = { static_cast<size_t>(nz), static_cast<size_t>(metadata.localExtentY), static_cast<size_t>(metadata.localExtentX) };
     // Set the origins and extensions for reading 2D data based
     // on MPI decomposition
-    std::vector<size_t> start(3);
-    std::vector<size_t> size(3);
-    start[0] = metadata.localCornerX;
-    start[1] = metadata.localCornerY;
-    start[2] = 0;
-    size[0] = metadata.localExtentX;
-    size[1] = metadata.localExtentY;
-    size[2] = nz;
+    std::vector<size_t> start2(start3.begin() + 1, start3.end());
+    std::vector<size_t> size2(size3.begin() + 1, size3.end());
 #endif
 
     for (const auto entry : state.data) {
@@ -229,7 +227,7 @@ void RectGridIO::dumpModelState(const ModelState& state, const ModelMetadata& me
             netCDF::NcVar var(dataGroup.addVar(name, netCDF::ncDouble, dims2));
             var.putAtt(mdiName, netCDF::ncDouble, MissingData::value);
 #ifdef USE_MPI
-            var.putVar(start, size, entry.second.getData());
+            var.putVar(start2, size2, entry.second.getData());
 #else
             var.putVar(entry.second.getData());
 #endif
@@ -237,7 +235,7 @@ void RectGridIO::dumpModelState(const ModelState& state, const ModelMetadata& me
             netCDF::NcVar var(dataGroup.addVar(name, netCDF::ncDouble, dims3));
             var.putAtt(mdiName, netCDF::ncDouble, MissingData::value);
 #ifdef USE_MPI
-            var.putVar(start, size, entry.second.getData());
+            var.putVar(start3, size3, entry.second.getData());
 #else
             var.putVar(entry.second.getData());
 #endif

--- a/core/src/RectGridIO.cpp
+++ b/core/src/RectGridIO.cpp
@@ -90,7 +90,12 @@ ModelState RectGridIO::getModelState(const std::string& filePath)
 void RectGridIO::dumpModelState(const ModelState& state, const ModelMetadata& metadata,
     const std::string& filePath, bool isRestart) const
 {
+#ifdef USE_MPI
+    auto filePathRank = filePath + "_" + std::to_string(metadata.mpiMyRank);
+    netCDF::NcFile ncFile(filePathRank, netCDF::NcFile::replace);
+#else
     netCDF::NcFile ncFile(filePath, netCDF::NcFile::replace);
+#endif
 
     CommonRestartMetadata::writeStructureType(ncFile, metadata);
     netCDF::NcGroup metaGroup = ncFile.addGroup(IStructure::metadataNodeName());

--- a/core/src/RectGridIO.cpp
+++ b/core/src/RectGridIO.cpp
@@ -116,7 +116,6 @@ ModelState RectGridIO::getModelState(const std::string& filePath)
     state.data[hsnowName] = ModelArray::HField();
     dataGroup.getVar(hsnowName).getVar(start, size, &state.data[hsnowName][0]);
 
-
 #else
     // Get the sizes of the four types of field
     // HField from hice
@@ -213,8 +212,10 @@ void RectGridIO::dumpModelState(const ModelState& state, const ModelMetadata& me
 #ifdef USE_MPI
     // Set the origins and extensions for reading 3D data based
     // on MPI decomposition
-    std::vector<size_t> start3 = { 0, static_cast<size_t>(metadata.localCornerY), static_cast<size_t>(metadata.localCornerX) };
-    std::vector<size_t> size3 = { static_cast<size_t>(nz), static_cast<size_t>(metadata.localExtentY), static_cast<size_t>(metadata.localExtentX) };
+    std::vector<size_t> start3 = { 0, static_cast<size_t>(metadata.localCornerY),
+        static_cast<size_t>(metadata.localCornerX) };
+    std::vector<size_t> size3 = { static_cast<size_t>(nz),
+        static_cast<size_t>(metadata.localExtentY), static_cast<size_t>(metadata.localExtentX) };
     // Set the origins and extensions for reading 2D data based
     // on MPI decomposition
     std::vector<size_t> start2(start3.begin() + 1, start3.end());

--- a/core/src/RectGridIO.cpp
+++ b/core/src/RectGridIO.cpp
@@ -30,6 +30,21 @@
 
 namespace Nextsim {
 
+#ifdef USE_MPI
+void dimensionSetter(const netCDF::NcGroup& dataGroup, const std::string& fieldName,
+    ModelArray::Type type, ModelMetadata& metadata)
+{
+    size_t nDims = dataGroup.getVar(fieldName).getDimCount();
+    ModelArray::MultiDim dims;
+    dims.resize(nDims);
+    dims[0] = metadata.localExtentX;
+    dims[1] = metadata.localExtentY;
+    for (size_t d = 2; d < nDims; ++d) {
+        dims[d] = dataGroup.getVar(fieldName).getDim(d).getSize();
+    }
+    ModelArray::setDimensions(type, dims);
+}
+#else
 void dimensionSetter(
     const netCDF::NcGroup& dataGroup, const std::string& fieldName, ModelArray::Type type)
 {
@@ -46,6 +61,7 @@ void dimensionSetter(
         dims[2] = NZLevels::get();
     ModelArray::setDimensions(type, dims);
 }
+#endif
 
 #ifdef USE_MPI
 ModelState RectGridIO::getModelState(
@@ -55,9 +71,52 @@ ModelState RectGridIO::getModelState(const std::string& filePath)
 #endif
 {
     ModelState state;
+#ifdef USE_MPI
+    readPartitionData(partitionFile, metadata);
+    netCDF::NcFilePar ncFile(filePath, netCDF::NcFile::read, metadata.mpiComm);
+#else
     netCDF::NcFile ncFile(filePath, netCDF::NcFile::read);
+#endif
     netCDF::NcGroup dataGroup(ncFile.getGroup(IStructure::dataNodeName()));
 
+#ifdef USE_MPI
+    // Get the sizes of the four types of field
+    // HField from hice
+    dimensionSetter(dataGroup, hiceName, ModelArray::Type::H, metadata);
+    // UField from hice        TODO replace with u velocity once it is present
+    dimensionSetter(dataGroup, hiceName, ModelArray::Type::U, metadata);
+    // VField from hice        TODO replace with v velocity once it is present
+    dimensionSetter(dataGroup, hiceName, ModelArray::Type::V, metadata);
+    // ZField from tice
+    dimensionSetter(dataGroup, ticeName, ModelArray::Type::Z, metadata);
+
+    // Set the origins and extensions for reading 2D data based
+    // on MPI decomposition
+    std::vector<size_t> start(2);
+    std::vector<size_t> size(2);
+    start[0] = metadata.localCornerX;
+    start[1] = metadata.localCornerY;
+    size[0] = metadata.localExtentX;
+    size[1] = metadata.localExtentY;
+
+    state.data[maskName] = ModelArray::HField();
+    dataGroup.getVar(maskName).getVar(start, size, &state.data[maskName][0]);
+    state.data[hiceName] = ModelArray::HField();
+    dataGroup.getVar(hiceName).getVar(start, size, &state.data[hiceName][0]);
+    state.data[ciceName] = ModelArray::HField();
+    dataGroup.getVar(ciceName).getVar(start, size, &state.data[ciceName][0]);
+    state.data[hsnowName] = ModelArray::HField();
+    dataGroup.getVar(hsnowName).getVar(start, size, &state.data[hsnowName][0]);
+
+    // The domain is not decomposed in z direction so set the extend in this direction
+    // to full range
+    start.push_back(0);
+    size.push_back(dataGroup.getDim("nLayers").getSize());
+
+    state.data[ticeName] = ModelArray::ZField();
+    dataGroup.getVar(ticeName).getVar(start, size, &state.data[ticeName][0]);
+
+#else
     // Get the sizes of the four types of field
     // HField from hice
     dimensionSetter(dataGroup, hiceName, ModelArray::Type::H);
@@ -83,10 +142,34 @@ ModelState RectGridIO::getModelState(const std::string& filePath)
     std::vector<size_t> zArrayDims = ModelArray::dimensions(ModelArray::Type::Z);
     std::reverse(zArrayDims.begin(), zArrayDims.end());
     dataGroup.getVar(ticeName).getVar(startVector, zArrayDims, &state.data[ticeName][0]);
+#endif
 
     ncFile.close();
     return state;
 }
+
+#ifdef USE_MPI
+void RectGridIO::readPartitionData(const std::string& partitionFile, ModelMetadata& metadata)
+{
+    static const std::string bboxName = "bounding_boxes";
+
+    netCDF::NcFile ncFile(partitionFile, netCDF::NcFile::read);
+    int sizes = ncFile.getDim("L").getSize();
+    int nBoxes = ncFile.getDim("P").getSize();
+    if (nBoxes != metadata.mpiSize) {
+        std::string errorMsg = "Number of MPI ranks " + std::to_string(metadata.mpiSize) + " <> "
+            + std::to_string(nBoxes) + "\n";
+        throw std::runtime_error(errorMsg);
+    }
+    netCDF::NcGroup bboxGroup(ncFile.getGroup(bboxName));
+    std::vector<size_t> index(1, metadata.mpiMyRank);
+    bboxGroup.getVar("global_x").getVar(index, &metadata.localCornerX);
+    bboxGroup.getVar("global_y").getVar(index, &metadata.localCornerY);
+    bboxGroup.getVar("local_extent_x").getVar(index, &metadata.localExtentX);
+    bboxGroup.getVar("local_extent_y").getVar(index, &metadata.localExtentY);
+    ncFile.close();
+}
+#endif
 
 void RectGridIO::dumpModelState(const ModelState& state, const ModelMetadata& metadata,
     const std::string& filePath, bool isRestart) const

--- a/core/src/StructureFactory.cpp
+++ b/core/src/StructureFactory.cpp
@@ -53,7 +53,7 @@ ModelState StructureFactory::stateFromFile(const std::string& filePath)
         RectangularGrid gridIn;
         gridIn.setIO(new RectGridIO(gridIn));
 #ifdef USE_MPI
-        return gridIn.getModelState(filePath, partitionFile);
+        return gridIn.getModelState(filePath, partitionFile, metadata);
 #else
         return gridIn.getModelState(filePath);
 #endif
@@ -62,7 +62,7 @@ ModelState StructureFactory::stateFromFile(const std::string& filePath)
         ParametricGrid gridIn;
         gridIn.setIO(new ParaGridIO(gridIn));
 #ifdef USE_MPI
-        return gridIn.getModelState(filePath, partitionFile);
+        return gridIn.getModelState(filePath, partitionFile, metadata);
 #else
         return gridIn.getModelState(filePath);
 #endif

--- a/core/src/StructureFactory.cpp
+++ b/core/src/StructureFactory.cpp
@@ -52,12 +52,20 @@ ModelState StructureFactory::stateFromFile(const std::string& filePath)
         Module::setImplementation<IStructure>("RectangularGrid");
         RectangularGrid gridIn;
         gridIn.setIO(new RectGridIO(gridIn));
+#ifdef USE_MPI
+        return gridIn.getModelState(filePath, partitionFile);
+#else
         return gridIn.getModelState(filePath);
+#endif
     } else if (ParametricGrid::structureName == structureName) {
         Module::setImplementation<IStructure>("ParametricGrid");
         ParametricGrid gridIn;
         gridIn.setIO(new ParaGridIO(gridIn));
+#ifdef USE_MPI
+        return gridIn.getModelState(filePath, partitionFile);
+#else
         return gridIn.getModelState(filePath);
+#endif
     } else {
         throw std::invalid_argument(
             std::string("fileFromName: structure not implemented: ") + structureName);

--- a/core/src/StructureFactory.cpp
+++ b/core/src/StructureFactory.cpp
@@ -3,6 +3,7 @@
  *
  * @date Jan 18, 2022
  * @author Tim Spain <timothy.spain@nersc.no>
+ * @author Kacper Kornet <kk562@cam.ac.uk>
  */
 
 #include "include/StructureFactory.hpp"
@@ -38,7 +39,12 @@ std::string structureNameFromFile(const std::string& filePath)
     return structureName;
 }
 
+#ifdef USE_MPI
+ModelState StructureFactory::stateFromFile(
+    const std::string& filePath, const std::string& partitionFile, ModelMetadata& metadata)
+#else
 ModelState StructureFactory::stateFromFile(const std::string& filePath)
+#endif
 {
     std::string structureName = structureNameFromFile(filePath);
     // TODO There must be a better way

--- a/core/src/include/Model.hpp
+++ b/core/src/include/Model.hpp
@@ -24,8 +24,12 @@ namespace Nextsim {
 //! A class that encapsulates the whole of the model
 class Model : public Configured<Model> {
 public:
+#ifdef USE_MPI
+    Model(MPI_Comm comm);
+#else
     Model(); // TODO add arguments to pass the desired
              // environment and configuration to the model
+#endif
     ~Model(); // Finalize the model. Collect data and so on.
 
     void configure() override;

--- a/core/src/include/Model.hpp
+++ b/core/src/include/Model.hpp
@@ -2,6 +2,7 @@
  * @file Model.hpp
  * @date 12 Aug 2021
  * @author Tim Spain <timothy.spain@nersc.no>
+ * @author Kacper Kornet <kk562@cam.ac.uk>
  */
 
 #ifndef MODEL_HPP
@@ -30,6 +31,9 @@ public:
     void configure() override;
     enum {
         RESTARTFILE_KEY,
+#ifdef USE_MPI
+        PARTITIONFILE_KEY,
+#endif
         STARTTIME_KEY,
         STOPTIME_KEY,
         RUNLENGTH_KEY,

--- a/core/src/include/ModelMetadata.hpp
+++ b/core/src/include/ModelMetadata.hpp
@@ -61,6 +61,7 @@ public:
     MPI_Comm mpiComm;
     int mpiSize = 0;
     int mpiMyRank = -1;
+    int localCornerX, localCornerY, localExtentX, localExtentY;
 #endif
 
 private:

--- a/core/src/include/ModelMetadata.hpp
+++ b/core/src/include/ModelMetadata.hpp
@@ -13,6 +13,10 @@
 
 #include <string>
 
+#ifdef USE_MPI
+#include <mpi.h>
+#endif
+
 namespace Nextsim {
 
 class CommonRestartMetadata;
@@ -50,6 +54,14 @@ public:
 
     // The metadata writer should be a friend
     friend CommonRestartMetadata;
+
+#ifdef USE_MPI
+    void setMpiMetadata(MPI_Comm comm);
+
+    MPI_Comm mpiComm;
+    int mpiSize = 0;
+    int mpiMyRank = -1;
+#endif
 
 private:
     TimePoint m_time;

--- a/core/src/include/ModelMetadata.hpp
+++ b/core/src/include/ModelMetadata.hpp
@@ -61,7 +61,7 @@ public:
     MPI_Comm mpiComm;
     int mpiSize = 0;
     int mpiMyRank = -1;
-    int localCornerX, localCornerY, localExtentX, localExtentY;
+    int localCornerX, localCornerY, localExtentX, localExtentY, globalExtentX, globalExtentY;
 #endif
 
 private:

--- a/core/src/include/ParallelNetcdfFile.hpp
+++ b/core/src/include/ParallelNetcdfFile.hpp
@@ -1,0 +1,16 @@
+#include <mpi.h>
+#include <ncFile.h>
+
+namespace netCDF {
+
+class NcFilePar : public netCDF::NcFile {
+public:
+    NcFilePar() = default;
+
+    NcFilePar(const std::string& filePath, const FileMode fMode, MPI_Comm comm,
+        MPI_Info info = MPI_INFO_NULL);
+
+    void open_par(const std::string& path, const FileMode fMode, MPI_Comm comm, MPI_Info info);
+};
+
+}

--- a/core/src/include/RectGridIO.hpp
+++ b/core/src/include/RectGridIO.hpp
@@ -35,6 +35,8 @@ public:
 
 private:
     RectGridIO() = default;
+
+    void readPartitionData(const std::string& partitionFile, ModelMetadata& metadata);
 };
 
 } /* namespace Nextsim */

--- a/core/src/include/RectGridIO.hpp
+++ b/core/src/include/RectGridIO.hpp
@@ -24,8 +24,8 @@ public:
     typedef RectangularGrid::GridDimensions GridDimensions;
 
 #ifdef USE_MPI
-    ModelState getModelState(
-        const std::string& filePath, const std::string& partitionFile) override;
+    ModelState getModelState(const std::string& filePath, const std::string& partitionFile,
+        ModelMetadata& metadata) override;
 #else
     ModelState getModelState(const std::string& filePath) override;
 #endif

--- a/core/src/include/RectGridIO.hpp
+++ b/core/src/include/RectGridIO.hpp
@@ -3,6 +3,7 @@
  *
  * @date Feb 8, 2022
  * @author Tim Spain <timothy.spain@nersc.no>
+ * @author Kacper Kornet <kk562@cam.ac.uk>
  */
 
 #ifndef RECTGRIDIO_HPP
@@ -22,7 +23,12 @@ public:
 
     typedef RectangularGrid::GridDimensions GridDimensions;
 
+#ifdef USE_MPI
+    ModelState getModelState(
+        const std::string& filePath, const std::string& partitionFile) override;
+#else
     ModelState getModelState(const std::string& filePath) override;
+#endif
 
     void dumpModelState(const ModelState& state, const ModelMetadata& metadata,
         const std::string& filePath, bool isRestart) const override;

--- a/core/src/include/StructureFactory.hpp
+++ b/core/src/include/StructureFactory.hpp
@@ -3,6 +3,7 @@
  *
  * @date Jan 18, 2022
  * @author Tim Spain <timothy.spain@nersc.no>
+ * @author Kacper Kornet <kk562@cam.ac.uk>
  */
 
 #ifndef STRUCTUREFACTORY_HPP
@@ -19,12 +20,24 @@ namespace Nextsim {
 
 class StructureFactory {
 public:
+#ifdef USE_MPI
+    /*!
+     * @brief Returns the ModelState of the named restart file.
+     *
+     * @param filePath the name of the file to be read.
+     * @param partitionFile name of file with data for MPI domain decomposition
+     * @param metadata ModelMedata to be used to get MPI parameters
+     */
+    static ModelState stateFromFile(
+        const std::string& filePath, const std::string& partitionFile, ModelMetadata& metadata);
+#else
     /*!
      * @brief Returns the ModelState of the named restart file.
      *
      * @param filePath the name of the file to be read.
      */
     static ModelState stateFromFile(const std::string& filePath);
+#endif
 
     /*!
      * @brief Takes a ModelState and a template file name to write the state

--- a/core/src/main.cpp
+++ b/core/src/main.cpp
@@ -2,9 +2,13 @@
  * @file main.cpp
  * @date 11 Aug 2021
  * @author Tim Spain <timothy.spain@nersc.no>
+ * @author Kacper Kornet <kk562@cam.ac.uk>
  */
 
 #include <iostream>
+#ifdef USE_MPI
+#include <mpi.h>
+#endif
 
 #include "include/CommandLineParser.hpp"
 #include "include/ConfigurationHelpPrinter.hpp"
@@ -15,6 +19,10 @@
 
 int main(int argc, char* argv[])
 {
+#ifdef USE_MPI
+    MPI_Init(&argc, &argv);
+#endif // USE_MPI
+
     // Pass the command line to Configurator to handle
     Nextsim::Configurator::setCommandLine(argc, argv);
     // Extract any config files defined on the command line
@@ -46,6 +54,9 @@ int main(int argc, char* argv[])
         // Run the Model
         model.run();
     }
+#ifdef USE_MPI
+    MPI_Finalize();
+#endif
 
     return 0;
 }

--- a/core/src/main.cpp
+++ b/core/src/main.cpp
@@ -48,7 +48,11 @@ int main(int argc, char* argv[])
         Nextsim::ConfigurationHelpPrinter::print(std::cout, map, cmdLine.configHelp());
     } else {
         // Construct the Model
+#ifdef USE_MPI
+        Nextsim::Model model(MPI_COMM_WORLD);
+#else
         Nextsim::Model model;
+#endif
         // Apply the model configuration
         model.configure();
         // Run the Model

--- a/core/src/modules/SimpleOutput.cpp
+++ b/core/src/modules/SimpleOutput.cpp
@@ -20,6 +20,8 @@ void SimpleOutput::outputState(const ModelMetadata& meta)
     std::stringstream startStream;
     startStream << meta.time();
     std::string timeFileName = m_filePrefix + "." + startStream.str() + ".nc";
+    // Some MPI-IO implemenetations does not like colon in file names
+    std::replace(timeFileName.begin(), timeFileName.end(), ':', '_');
     Logged::info("Outputting "
         + std::to_string(externalNames.size()) + " fields to "
         + timeFileName + "\n");

--- a/core/src/modules/include/IStructure.hpp
+++ b/core/src/modules/include/IStructure.hpp
@@ -44,7 +44,8 @@ public:
      * @brief Returns the ModelState stored in the file
      */
 #ifdef USE_MPI
-    virtual ModelState getModelState(const std::string& filePath, const std::string& filePartition)
+    virtual ModelState getModelState(
+        const std::string& filePath, const std::string& filePartition, ModelMetadata& metadata)
         = 0;
 #else
     virtual ModelState getModelState(const std::string& filePath) = 0;

--- a/core/src/modules/include/IStructure.hpp
+++ b/core/src/modules/include/IStructure.hpp
@@ -3,6 +3,7 @@
  *
  * @date Dec 17, 2021
  * @author Tim Spain <timothy.spain@nersc.no>
+ * @author Kacper Kornet <kk562@cam.ac.uk>
  */
 
 #ifndef ISTRUCTURE_HPP
@@ -42,7 +43,12 @@ public:
     /*!
      * @brief Returns the ModelState stored in the file
      */
+#ifdef USE_MPI
+    virtual ModelState getModelState(const std::string& filePath, const std::string& filePartition)
+        = 0;
+#else
     virtual ModelState getModelState(const std::string& filePath) = 0;
+#endif
 
     //! Returns the structure name that this class will process
     virtual const std::string& structureType() const { return processedStructureName; }

--- a/core/src/modules/include/ParametricGrid.hpp
+++ b/core/src/modules/include/ParametricGrid.hpp
@@ -36,7 +36,8 @@ public:
 
     // Read/write override functions
 #ifdef USE_MPI
-    ModelState getModelState(const std::string& filePath, const std::string& partitionFile) override
+    ModelState getModelState(const std::string& filePath, const std::string& partitionFile,
+        ModelMetadata& metadata) override
     {
         return pio ? pio->getModelState(filePath) : ModelState();
     }

--- a/core/src/modules/include/ParametricGrid.hpp
+++ b/core/src/modules/include/ParametricGrid.hpp
@@ -3,6 +3,7 @@
  *
  * @date Oct 24, 2022
  * @author Tim Spain <timothy.spain@nersc.no>
+ * @author Kacper Kornet <kk562@cam.ac.uk>
  */
 
 #ifndef PARAMETRICGRID_HPP
@@ -34,10 +35,17 @@ public:
     }
 
     // Read/write override functions
+#ifdef USE_MPI
+    ModelState getModelState(const std::string& filePath, const std::string& partitionFile) override
+    {
+        return pio ? pio->getModelState(filePath) : ModelState();
+    }
+#else
     ModelState getModelState(const std::string& filePath) override
     {
         return pio ? pio->getModelState(filePath) : ModelState();
     }
+#endif
 
     void dumpModelState(const ModelState& state, const ModelMetadata& metadata,
         const std::string& filePath, bool isRestart = false) const override

--- a/core/src/modules/include/RectangularGrid.hpp
+++ b/core/src/modules/include/RectangularGrid.hpp
@@ -51,7 +51,7 @@ public:
 #ifdef USE_MPI
     ModelState getModelState(const std::string& filePath, const std::string& partitionFile) override
     {
-        return pio ? pio->getModelState(filePath) : ModelState();
+        return pio ? pio->getModelState(filePath, partitionFile) : ModelState();
     }
 #else
     ModelState getModelState(const std::string& filePath) override
@@ -85,7 +85,13 @@ public:
         }
         virtual ~IRectGridIO() = default;
 
+#ifdef USE_MPI
+        virtual ModelState getModelState(
+            const std::string& filePath, const std::string& partitionFile)
+            = 0;
+#else
         virtual ModelState getModelState(const std::string& filePath) = 0;
+#endif
 
         /*!
          * @brief Dumps the given ModelState to the given file path.

--- a/core/src/modules/include/RectangularGrid.hpp
+++ b/core/src/modules/include/RectangularGrid.hpp
@@ -49,9 +49,10 @@ public:
 
     // Read/write override functions
 #ifdef USE_MPI
-    ModelState getModelState(const std::string& filePath, const std::string& partitionFile) override
+    ModelState getModelState(const std::string& filePath, const std::string& partitionFile,
+        ModelMetadata& metadata) override
     {
-        return pio ? pio->getModelState(filePath, partitionFile) : ModelState();
+        return pio ? pio->getModelState(filePath, partitionFile, metadata) : ModelState();
     }
 #else
     ModelState getModelState(const std::string& filePath) override
@@ -87,7 +88,7 @@ public:
 
 #ifdef USE_MPI
         virtual ModelState getModelState(
-            const std::string& filePath, const std::string& partitionFile)
+            const std::string& filePath, const std::string& partitionFile, ModelMetadata& metadata)
             = 0;
 #else
         virtual ModelState getModelState(const std::string& filePath) = 0;

--- a/core/src/modules/include/RectangularGrid.hpp
+++ b/core/src/modules/include/RectangularGrid.hpp
@@ -3,6 +3,7 @@
  *
  * @date Feb 7, 2022
  * @author Tim Spain <timothy.spain@nersc.no>
+ * @author Kacper Kornet <kk562@cam.ac.uk>
  */
 
 #ifndef RECTANGULARGRID_HPP
@@ -47,10 +48,17 @@ public:
     }
 
     // Read/write override functions
+#ifdef USE_MPI
+    ModelState getModelState(const std::string& filePath, const std::string& partitionFile) override
+    {
+        return pio ? pio->getModelState(filePath) : ModelState();
+    }
+#else
     ModelState getModelState(const std::string& filePath) override
     {
         return pio ? pio->getModelState(filePath) : ModelState();
     }
+#endif
 
     void dumpModelState(
         const ModelState& state, const ModelMetadata& metadata, const std::string& filePath, bool isRestart = false) const override

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -41,13 +41,25 @@ target_link_libraries(testModelArray PRIVATE doctest::doctest Eigen3::Eigen)
 
 set(MODEL_INCLUDE_DIR "../../core/src/discontinuousgalerkin")
 
-add_executable(testRectGrid "RectGrid_test.cpp")
-target_include_directories(testRectGrid PRIVATE ${MODEL_INCLUDE_DIR})
-target_link_libraries(testRectGrid PRIVATE nextsimlib doctest::doctest)
+if(ENABLE_MPI)
+  add_executable(testRectGrid_MPI "RectGrid_test.cpp" "MainMPI.cpp")
+  target_compile_definitions(testRectGrid_MPI PRIVATE USE_MPI)
+  target_include_directories(testRectGrid_MPI PRIVATE ${MODEL_INCLUDE_DIR})
+  target_link_libraries(testRectGrid_MPI PRIVATE nextsimlib doctest::doctest)
+else()
+  add_executable(testRectGrid "RectGrid_test.cpp")
+  target_include_directories(testRectGrid PRIVATE ${MODEL_INCLUDE_DIR})
+  target_link_libraries(testRectGrid PRIVATE nextsimlib doctest::doctest)
+endif()
 
-add_executable(testParaGrid "ParaGrid_test.cpp")
-target_include_directories(testParaGrid PRIVATE ${MODEL_INCLUDE_DIR})
-target_link_libraries(testParaGrid PRIVATE nextsimlib doctest::doctest)
+if(ENABLE_MPI)
+  message(WARNING "testParaGrid has been temporarily disabled when running with MPI enabled")
+else()
+  add_executable(testParaGrid "ParaGrid_test.cpp")
+  target_compile_definitions(testParaGrid PRIVATE TEST_FILE_SOURCE=${CMAKE_CURRENT_SOURCE_DIR})
+  target_include_directories(testParaGrid PRIVATE ${MODEL_INCLUDE_DIR})
+  target_link_libraries(testParaGrid PRIVATE nextsimlib doctest::doctest)
+endif()
 
 add_executable(testModelComponent "ModelComponent_test.cpp")
 target_include_directories(testModelComponent PRIVATE ${MODEL_INCLUDE_DIR})
@@ -62,9 +74,13 @@ add_executable(testPrognosticData "PrognosticData_test.cpp" "DynamicsModuleForPD
 target_include_directories(testPrognosticData PRIVATE ${PHYSICS_INCLUDE_DIRS} ${MODEL_INCLUDE_DIR})
 target_link_libraries(testPrognosticData PRIVATE nextsimlib doctest::doctest)
 
-add_executable(testConfigOutput "ConfigOutput_test.cpp")
-target_include_directories(testConfigOutput PRIVATE ${MODEL_INCLUDE_DIR})
-target_link_libraries(testConfigOutput PRIVATE nextsimlib doctest::doctest)
+if(ENABLE_MPI)
+  message(WARNING "testConfigOutput has been temporarily disabled when running with MPI enabled")
+else()
+  add_executable(testConfigOutput "ConfigOutput_test.cpp")
+  target_include_directories(testConfigOutput PRIVATE ${MODEL_INCLUDE_DIR})
+  target_link_libraries(testConfigOutput PRIVATE nextsimlib doctest::doctest)
+endif()
 
 add_executable(testMonthlyCubicBSpline
     "MonthlyCubicBSpline_test.cpp"

--- a/core/test/MainMPI.cpp
+++ b/core/test/MainMPI.cpp
@@ -1,0 +1,19 @@
+#define DOCTEST_CONFIG_IMPLEMENT
+
+#include <doctest/extensions/doctest_mpi.h>
+
+int main(int argc, char** argv) {
+  doctest::mpi_init_thread(argc,argv,MPI_THREAD_MULTIPLE);
+
+  doctest::Context ctx;
+  ctx.setOption("reporters", "MpiConsoleReporter");
+  ctx.setOption("reporters", "MpiFileReporter");
+  ctx.setOption("force-colors", true);
+  ctx.applyCommandLine(argc, argv);
+
+  int test_result = ctx.run();
+
+  doctest::mpi_finalize();
+
+  return test_result;
+}

--- a/core/test/RectGrid_test.cpp
+++ b/core/test/RectGrid_test.cpp
@@ -5,8 +5,13 @@
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 
+#ifdef USE_MPI
+#include <doctest/extensions/doctest_mpi.h>
+#else
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include <doctest/doctest.h>
+#endif
+
 
 #include "include/CommonRestartMetadata.hpp"
 #include "include/NZLevels.hpp"
@@ -18,10 +23,16 @@
 #include <fstream>
 
 const std::string filename = "RectGrid_test.nc";
+const std::string partition_filename = "partition_metadata_1.nc";
 
 namespace Nextsim {
 TEST_SUITE_BEGIN("RectGrid");
+#ifdef USE_MPI
+// Number of ranks should not be hardcoded here
+MPI_TEST_CASE("Write and read a ModelState-based RectGrid restart file", 1)
+#else
 TEST_CASE("Write and read a ModelState-based RectGrid restart file")
+#endif
 {
     RectangularGrid grid;
     grid.setIO(new RectGridIO(grid));
@@ -68,6 +79,15 @@ TEST_CASE("Write and read a ModelState-based RectGrid restart file")
     ModelMetadata metadata;
     metadata.setTime(TimePoint("2000-01-01T00:00:00Z"));
 
+#ifdef USE_MPI
+    metadata.setMpiMetadata(test_comm);
+    metadata.globalExtentX = nx;
+    metadata.globalExtentY = ny;
+    metadata.localCornerX = 0;
+    metadata.localCornerY = 0;
+    metadata.localExtentX = nx;
+    metadata.localExtentY = ny;
+#endif
     grid.dumpModelState(state, metadata, filename);
 
     ModelArray::setDimensions(ModelArray::Type::H, { 1, 1 });
@@ -77,7 +97,11 @@ TEST_CASE("Write and read a ModelState-based RectGrid restart file")
     size_t targetY = 7;
 
     gridIn.setIO(new RectGridIO(grid));
+#ifdef USE_MPI
+    ModelState ms = gridIn.getModelState(filename, partition_filename, metadata);
+#else
     ModelState ms = gridIn.getModelState(filename);
+#endif
 
     REQUIRE(ModelArray::dimensions(ModelArray::Type::H)[0] == nx);
     REQUIRE(ModelArray::dimensions(ModelArray::Type::H)[1] == ny);

--- a/lib/doctest/extensions/doctest_mpi.h
+++ b/lib/doctest/extensions/doctest_mpi.h
@@ -1,0 +1,169 @@
+#ifndef DOCTEST_MPI_H
+#define DOCTEST_MPI_H
+
+#ifdef DOCTEST_CONFIG_IMPLEMENT
+
+#include "doctest/extensions/mpi_sub_comm.h"
+#include "mpi_reporter.h"
+#include <unordered_map>
+
+namespace doctest {
+
+// Each time a MPI_TEST_CASE is executed on N procs,
+// we need a sub-communicator of N procs to execute it.
+// It is then registered here and can be re-used
+// by other tests that requires a sub-comm of the same size
+std::unordered_map<int,mpi_sub_comm> sub_comms_by_size;
+
+// Record if at least one MPI_TEST_CASE was registered "skipped"
+// because there is not enought procs to execute it
+int nb_test_cases_skipped_insufficient_procs = 0;
+
+
+std::string thread_level_to_string(int thread_lvl);
+int mpi_init_thread(int argc, char *argv[], int required_thread_support);
+void mpi_finalize();
+
+
+// Can be safely called before MPI_Init()
+//   This is needed for MPI_TEST_CASE because we use doctest::skip()
+//   to prevent execution of tests where there is not enough procs,
+//   but doctest::skip() is called during test registration, that is, before main(), and hence before MPI_Init()
+int mpi_comm_world_size() {
+  #if defined(OPEN_MPI)
+    const char* size_str = std::getenv("OMPI_COMM_WORLD_SIZE");
+  #elif defined(I_MPI_VERSION) || defined(MPI_VERSION) // Intel MPI + MPICH (at least)
+    const char* size_str = std::getenv("PMI_SIZE"); // see https://community.intel.com/t5/Intel-oneAPI-HPC-Toolkit/Environment-variables-defined-by-intel-mpirun/td-p/1096703
+  #else
+    #error "Unknown MPI implementation: please submit an issue or a PR to doctest. Meanwhile, you can look at the output of e.g. `mpirun -np 3 env` to search for an environnement variable that contains the size of MPI_COMM_WORLD and extend this code accordingly"
+  #endif
+  if (size_str==nullptr) return 1; // not launched with mpirun/mpiexec, so assume only one process
+  return std::stoi(size_str);
+}
+
+// Record size of MPI_COMM_WORLD with mpi_comm_world_size()
+int world_size_before_init = mpi_comm_world_size();
+
+
+std::string thread_level_to_string(int thread_lvl) {
+  switch (thread_lvl) {
+    case MPI_THREAD_SINGLE:     return "MPI_THREAD_SINGLE";
+    case MPI_THREAD_FUNNELED:   return "MPI_THREAD_FUNNELED";
+    case MPI_THREAD_SERIALIZED: return "MPI_THREAD_SERIALIZED";
+    case MPI_THREAD_MULTIPLE:   return "MPI_THREAD_MULTIPLE";
+    default: return "Invalid MPI thread level";
+  }
+}
+int mpi_init_thread(int argc, char *argv[], int required_thread_support) {
+  int provided_thread_support;
+  MPI_Init_thread(&argc, &argv, required_thread_support, &provided_thread_support);
+
+  int world_size;
+  MPI_Comm_size(MPI_COMM_WORLD,&world_size);
+  if (world_size_before_init != world_size) {
+    DOCTEST_INTERNAL_ERROR(
+      "doctest found "+std::to_string(world_size_before_init)+" MPI processes before `MPI_Init_thread`,"
+      " but MPI_COMM_WORLD is actually of size "+std::to_string(world_size)+".\n"
+      "This is most likely due to your MPI implementation not being well supported by doctest. Please report this issue on GitHub"
+    );
+  }
+
+  if (provided_thread_support!=required_thread_support) {
+    std::cout <<
+        "WARNING: " + thread_level_to_string(required_thread_support) + " was asked, "
+      + "but only " + thread_level_to_string(provided_thread_support) + " is provided by the MPI library\n";
+  }
+  return provided_thread_support;
+}
+void mpi_finalize() {
+  // We need to destroy all created sub-communicators before calling MPI_Finalize()
+  doctest::sub_comms_by_size.clear();
+  MPI_Finalize();
+}
+
+} // doctest
+
+#else // DOCTEST_CONFIG_IMPLEMENT
+
+#include "doctest/extensions/mpi_sub_comm.h"
+#include <unordered_map>
+#include <exception>
+
+namespace doctest {
+
+extern std::unordered_map<int,mpi_sub_comm> sub_comms_by_size;
+extern int nb_test_cases_skipped_insufficient_procs;
+extern int world_size_before_init;
+int mpi_comm_world_size();
+
+int mpi_init_thread(int argc, char *argv[], int required_thread_support);
+void mpi_finalize();
+
+template<int nb_procs, class F>
+void execute_mpi_test_case(F func) {
+  auto it = sub_comms_by_size.find(nb_procs);
+  if (it==end(sub_comms_by_size)) {
+    bool was_emplaced = false;
+    std::tie(it,was_emplaced) = sub_comms_by_size.emplace(std::make_pair(nb_procs,mpi_sub_comm(nb_procs)));
+    assert(was_emplaced);
+  }
+  const mpi_sub_comm& sub = it->second;
+  if (sub.comm != MPI_COMM_NULL) {
+    func(sub.rank,nb_procs,sub.comm,std::integral_constant<int,nb_procs>{});
+  };
+}
+
+inline bool
+insufficient_procs(int test_nb_procs) {
+  static const int world_size = mpi_comm_world_size();
+  bool insufficient = test_nb_procs>world_size;
+  if (insufficient) {
+    ++nb_test_cases_skipped_insufficient_procs;
+  }
+  return insufficient;
+}
+
+} // doctest
+
+
+#define DOCTEST_MPI_GEN_ASSERTION(rank_to_test, assertion, ...) \
+  static_assert(rank_to_test<test_nb_procs_as_int_constant.value,"Trying to assert on a rank greater than the number of procs of the test!"); \
+  if(rank_to_test == test_rank) assertion(__VA_ARGS__)
+
+#define DOCTEST_MPI_WARN(rank_to_test, ...)  DOCTEST_MPI_GEN_ASSERTION(rank_to_test,DOCTEST_WARN,__VA_ARGS__)
+#define DOCTEST_MPI_CHECK(rank_to_test, ...)  DOCTEST_MPI_GEN_ASSERTION(rank_to_test,DOCTEST_CHECK,__VA_ARGS__)
+#define DOCTEST_MPI_REQUIRE(rank_to_test, ...)  DOCTEST_MPI_GEN_ASSERTION(rank_to_test,DOCTEST_REQUIRE,__VA_ARGS__)
+#define DOCTEST_MPI_WARN_FALSE(rank_to_test, ...)  DOCTEST_MPI_GEN_ASSERTION(rank_to_test,DOCTEST_WARN_FALSE,__VA_ARGS__)
+#define DOCTEST_MPI_CHECK_FALSE(rank_to_test, ...)  DOCTEST_MPI_GEN_ASSERTION(rank_to_test,DOCTEST_CHECK_FALSE,__VA_ARGS__)
+#define DOCTEST_MPI_REQUIRE_FALSE(rank_to_test, ...)  DOCTEST_MPI_GEN_ASSERTION(rank_to_test,DOCTEST_REQUIRE_FALSE,__VA_ARGS__)
+
+#define DOCTEST_CREATE_MPI_TEST_CASE(name,nb_procs,func) \
+  static void func(DOCTEST_UNUSED int test_rank, DOCTEST_UNUSED int test_nb_procs, DOCTEST_UNUSED MPI_Comm test_comm, DOCTEST_UNUSED std::integral_constant<int,nb_procs>); \
+  TEST_CASE(name * doctest::description("MPI_TEST_CASE") * doctest::skip(doctest::insufficient_procs(nb_procs))) { \
+    doctest::execute_mpi_test_case<nb_procs>(func); \
+  } \
+  static void func(DOCTEST_UNUSED int test_rank, DOCTEST_UNUSED int test_nb_procs, DOCTEST_UNUSED MPI_Comm test_comm, DOCTEST_UNUSED std::integral_constant<int,nb_procs> test_nb_procs_as_int_constant)
+  // DOC: test_rank, test_nb_procs, and test_comm are available UNDER THESE SPECIFIC NAMES in the body of the unit test
+  // DOC: test_nb_procs_as_int_constant is equal to test_nb_procs, but as a compile time value
+  //          (used in CHECK-like macros to assert the checked rank exists)
+
+#define DOCTEST_MPI_TEST_CASE(name,nb_procs) \
+  DOCTEST_CREATE_MPI_TEST_CASE(name,nb_procs,DOCTEST_ANONYMOUS(DOCTEST_MPI_FUNC))
+
+
+// == SHORT VERSIONS OF THE MACROS
+#if !defined(DOCTEST_CONFIG_NO_SHORT_MACRO_NAMES)
+#define MPI_WARN           DOCTEST_MPI_WARN
+#define MPI_CHECK          DOCTEST_MPI_CHECK
+#define MPI_REQUIRE        DOCTEST_MPI_REQUIRE
+#define MPI_WARN_FALSE     DOCTEST_MPI_WARN_FALSE
+#define MPI_CHECK_FALSE    DOCTEST_MPI_CHECK_FALSE
+#define MPI_REQUIRE_FALSE  DOCTEST_MPI_REQUIRE_FALSE
+
+#define MPI_TEST_CASE      DOCTEST_MPI_TEST_CASE
+#endif // DOCTEST_CONFIG_NO_SHORT_MACRO_NAMES
+
+
+#endif // DOCTEST_CONFIG_IMPLEMENT
+
+#endif // DOCTEST_MPI_H

--- a/lib/doctest/extensions/doctest_util.h
+++ b/lib/doctest/extensions/doctest_util.h
@@ -1,0 +1,37 @@
+//
+// doctest_util.h - an accompanying extensions header to the main doctest.h header
+//
+// Copyright (c) 2016-2023 Viktor Kirilov
+//
+// Distributed under the MIT Software License
+// See accompanying file LICENSE.txt or copy at
+// https://opensource.org/licenses/MIT
+//
+// The documentation can be found at the library's page:
+// https://github.com/doctest/doctest/blob/master/doc/markdown/readme.md
+//
+
+#ifndef DOCTEST_UTIL_H
+#define DOCTEST_UTIL_H
+
+#ifndef DOCTEST_LIBRARY_INCLUDED
+#include "../doctest.h"
+#endif
+
+#include <memory>
+#include <vector>
+#include <string>
+
+namespace doctest {
+
+    inline void applyCommandLine(doctest::Context& ctx, const std::vector<std::string>& args) {
+        auto doctest_args = std::make_unique<const char*[]>(args.size());
+        for (size_t i = 0; i < args.size(); ++i) {
+            doctest_args[i] = args[i].c_str();
+        }
+        ctx.applyCommandLine(args.size(), doctest_args.get());
+    }
+
+} // namespace doctest
+
+#endif // DOCTEST_UTIL_H

--- a/lib/doctest/extensions/mpi_reporter.h
+++ b/lib/doctest/extensions/mpi_reporter.h
@@ -1,0 +1,271 @@
+#ifndef DOCTEST_MPI_REPORTER_H
+#define DOCTEST_MPI_REPORTER_H
+
+// #include <doctest/doctest.h>
+#include <fstream>
+#include <string>
+#include "mpi.h"
+
+
+#include <vector>
+#include <mutex>
+
+namespace doctest {
+
+extern int nb_test_cases_skipped_insufficient_procs;
+int mpi_comm_world_size();
+
+namespace {
+
+// https://stackoverflow.com/a/11826666/1583122
+struct NullBuffer : std::streambuf {
+  int overflow(int c) { return c; }
+};
+class NullStream : public std::ostream {
+  public:
+    NullStream()
+      : std::ostream(&nullBuff)
+    {}
+  private:
+    NullBuffer nullBuff = {};
+};
+static NullStream nullStream;
+
+
+/* \brief Extends the ConsoleReporter of doctest
+ *        Each process writes its results to its own file
+ *        Intended to be used when a test assertion fails and the user wants to know exactly what happens on which process
+ */
+struct MpiFileReporter : public ConsoleReporter {
+  std::ofstream logfile_stream = {};
+
+  MpiFileReporter(const ContextOptions& co)
+    : ConsoleReporter(co,logfile_stream)
+  {
+    int rank = 0;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    std::string logfile_name = "doctest_" + std::to_string(rank) + ".log";
+
+    logfile_stream = std::ofstream(logfile_name.c_str(), std::fstream::out);
+  }
+};
+
+
+/* \brief Extends the ConsoleReporter of doctest
+ *        Allows to manage the execution of tests in a parallel framework
+ *        All results are collected on rank 0
+ */
+struct MpiConsoleReporter : public ConsoleReporter {
+private:
+  static std::ostream& replace_by_null_if_not_rank_0(std::ostream* os) {
+    int rank = 0;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    if (rank==0) {
+      return *os;
+    } else {
+      return nullStream;
+    }
+  }
+  std::vector<std::pair<std::string, int>> m_failure_str_queue = {};
+public:
+  MpiConsoleReporter(const ContextOptions& co)
+    : ConsoleReporter(co,replace_by_null_if_not_rank_0(co.cout))
+  {}
+
+  std::string file_line_to_string(const char* file, int line,
+                                  const char* tail = ""){
+    std::stringstream ss;
+    ss << skipPathFromFilename(file)
+    << (opt.gnu_file_line ? ":" : "(")
+    << (opt.no_line_numbers ? 0 : line) // 0 or the real num depending on the option
+    << (opt.gnu_file_line ? ":" : "):") << tail;
+    return ss.str();
+  }
+
+  void test_run_end(const TestRunStats& p) override {
+    ConsoleReporter::test_run_end(p);
+
+    const bool anythingFailed = p.numTestCasesFailed > 0 || p.numAssertsFailed > 0;
+
+    // -----------------------------------------------------
+    // > Gather information in rank 0
+    int n_rank, rank;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &n_rank);
+
+    int g_numAsserts         = 0;
+    int g_numAssertsFailed   = 0;
+    int g_numTestCasesFailed = 0;
+
+    MPI_Reduce(&p.numAsserts        , &g_numAsserts        , 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
+    MPI_Reduce(&p.numAssertsFailed  , &g_numAssertsFailed  , 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
+    MPI_Reduce(&p.numTestCasesFailed, &g_numTestCasesFailed, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
+
+    std::vector<int> numAssertsFailedByRank;
+    if(rank == 0){
+      numAssertsFailedByRank.resize(static_cast<std::size_t>(n_rank));
+    }
+
+    MPI_Gather(&p.numAssertsFailed, 1, MPI_INT, numAssertsFailedByRank.data(), 1, MPI_INT, 0, MPI_COMM_WORLD);
+
+    if(rank == 0) {
+      separator_to_stream();
+      s << Color::Cyan << "[doctest] " << Color::None << "assertions on all processes: " << std::setw(6)
+        << g_numAsserts << " | "
+        << ((g_numAsserts == 0 || anythingFailed) ? Color::None : Color::Green)
+        << std::setw(6) << (g_numAsserts - g_numAssertsFailed) << " passed" << Color::None
+        << " | " << (g_numAssertsFailed > 0 ? Color::Red : Color::None) << std::setw(6)
+        << g_numAssertsFailed << " failed" << Color::None << " |\n";
+      if (nb_test_cases_skipped_insufficient_procs>0) {
+        s << Color::Cyan << "[doctest] " << Color::Yellow << "WARNING: Skipped ";
+        if (nb_test_cases_skipped_insufficient_procs>1) {
+          s << nb_test_cases_skipped_insufficient_procs << " tests requiring more than ";
+        } else {
+          s << nb_test_cases_skipped_insufficient_procs << " test requiring more than ";
+        }
+        if (mpi_comm_world_size()>1) {
+          s << mpi_comm_world_size() << " MPI processes to run\n";
+        } else {
+          s << mpi_comm_world_size() << " MPI process to run\n";
+        }
+      }
+
+      separator_to_stream();
+      if(g_numAssertsFailed > 0){
+
+        s << Color::Cyan << "[doctest] " << Color::None << "fail on rank:" << std::setw(6) << "\n";
+        for(std::size_t i = 0; i < numAssertsFailedByRank.size(); ++i){
+          if( numAssertsFailedByRank[i] > 0 ){
+            s << std::setw(16) << " -> On rank [" << i << "] with " << numAssertsFailedByRank[i] << " test failed" << std::endl;
+          }
+        }
+      }
+      s << Color::Cyan << "[doctest] " << Color::None
+        << "Status: " << (g_numTestCasesFailed > 0 ? Color::Red : Color::Green)
+        << ((g_numTestCasesFailed > 0) ? "FAILURE!" : "SUCCESS!") << Color::None << std::endl;
+    }
+  }
+
+  void test_case_end(const CurrentTestCaseStats& st) override {
+    if (is_mpi_test_case()) {
+      // function called by every rank at the end of a test
+      // if failed assertions happened, they have been sent to rank 0
+      // here rank zero gathers them and prints them all
+
+      int rank;
+      MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+      std::vector<MPI_Request> requests;
+      requests.reserve(m_failure_str_queue.size());  // avoid realloc & copy of MPI_Request
+      for (const std::pair<std::string, int> &failure : m_failure_str_queue)
+      {
+        const std::string & failure_str = failure.first;
+        const int failure_line = failure.second;
+
+        int failure_msg_size = static_cast<int>(failure_str.size());
+
+        requests.push_back(MPI_REQUEST_NULL);
+        MPI_Isend(failure_str.c_str(), failure_msg_size, MPI_BYTE,
+                 0, failure_line, MPI_COMM_WORLD, &requests.back()); // Tag = file line
+      }
+
+
+      // Compute the number of assert with fail among all procs
+      const int nb_fail_asserts = static_cast<int>(m_failure_str_queue.size());
+      int nb_fail_asserts_glob = 0;
+      MPI_Reduce(&nb_fail_asserts, &nb_fail_asserts_glob, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
+
+      if(rank == 0) {
+        MPI_Status status;
+        MPI_Status status_recv;
+
+        using id_string = std::pair<int,std::string>;
+        std::vector<id_string> msgs(static_cast<std::size_t>(nb_fail_asserts_glob));
+
+        for (std::size_t i=0; i<static_cast<std::size_t>(nb_fail_asserts_glob); ++i) {
+          MPI_Probe(MPI_ANY_SOURCE, MPI_ANY_TAG, MPI_COMM_WORLD, &status);
+
+          int count;
+          MPI_Get_count(&status, MPI_BYTE, &count);
+
+          std::string recv_msg(static_cast<std::size_t>(count),'\0');
+          void* recv_msg_data = const_cast<char*>(recv_msg.data()); // const_cast needed. Non-const .data() exists in C++11 though...
+          MPI_Recv(recv_msg_data, count, MPI_BYTE, status.MPI_SOURCE,
+                   status.MPI_TAG, MPI_COMM_WORLD, &status_recv);
+
+          msgs[i] = {status.MPI_SOURCE,recv_msg};
+        }
+
+        std::sort(begin(msgs),end(msgs),[](const id_string& x, const id_string& y){ return x.first < y.first; });
+
+        // print
+        if (nb_fail_asserts_glob>0) {
+          separator_to_stream();
+          file_line_to_stream(tc->m_file.c_str(), static_cast<int>(tc->m_line), "\n");
+          if(tc->m_test_suite && tc->m_test_suite[0] != '\0')
+            s << Color::Yellow << "TEST SUITE: " << Color::None << tc->m_test_suite << "\n";
+          if(strncmp(tc->m_name, "  Scenario:", 11) != 0)
+            s << Color::Yellow << "TEST CASE:  ";
+          s << Color::None << tc->m_name << "\n\n";
+          for(const auto& msg : msgs) {
+            s << msg.second;
+          }
+          s << "\n";
+        }
+      }
+
+      MPI_Waitall(static_cast<int>(requests.size()), requests.data(), MPI_STATUSES_IGNORE);
+      m_failure_str_queue.clear();
+    }
+
+    ConsoleReporter::test_case_end(st);
+  }
+
+  bool is_mpi_test_case() const {
+    return tc->m_description != nullptr
+        && std::string(tc->m_description) == std::string("MPI_TEST_CASE");
+  }
+
+  void log_assert(const AssertData& rb) override {
+    if (!is_mpi_test_case()) {
+      ConsoleReporter::log_assert(rb);
+    } else {
+      int rank;
+      MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+
+      if(!rb.m_failed && !opt.success)
+        return;
+
+      std::lock_guard<std::mutex> lock(mutex);
+
+      std::stringstream failure_msg;
+      failure_msg << Color::Red << "On rank [" << rank << "] : " << Color::None;
+      failure_msg << file_line_to_string(rb.m_file, rb.m_line, " ");
+
+      if((rb.m_at & (assertType::is_throws_as | assertType::is_throws_with)) ==0){
+        failure_msg << Color::Cyan
+                    << assertString(rb.m_at)
+                    << "( " << rb.m_expr << " ) "
+                    << Color::None
+
+                    << (!rb.m_failed ? "is correct!\n" : "is NOT correct!\n")
+                    << "  values: "
+                    << assertString(rb.m_at)
+                    << "( " << rb.m_decomp.c_str() << " )\n";
+      }
+
+      m_failure_str_queue.push_back({failure_msg.str(), rb.m_line});
+    }
+  }
+}; // MpiConsoleReporter
+
+// "1" is the priority - used for ordering when multiple reporters/listeners are used
+REGISTER_REPORTER("MpiConsoleReporter", 1, MpiConsoleReporter);
+REGISTER_REPORTER("MpiFileReporter", 1, MpiFileReporter);
+
+} // anonymous
+} // doctest
+
+#endif // DOCTEST_REPORTER_H

--- a/lib/doctest/extensions/mpi_sub_comm.h
+++ b/lib/doctest/extensions/mpi_sub_comm.h
@@ -1,0 +1,84 @@
+#ifndef DOCTEST_MPI_SUB_COMM_H
+#define DOCTEST_MPI_SUB_COMM_H
+
+#include "mpi.h"
+#include "doctest/doctest.h"
+#include <cassert>
+#include <string>
+
+namespace doctest {
+
+inline
+int mpi_world_nb_procs() {
+  int n;
+  MPI_Comm_size(MPI_COMM_WORLD, &n);
+  return n;
+}
+
+struct mpi_sub_comm {
+  int nb_procs;
+  int rank;
+  MPI_Comm comm;
+
+  mpi_sub_comm( mpi_sub_comm const& ) = delete;
+  mpi_sub_comm& operator=( mpi_sub_comm const& ) = delete;
+
+  mpi_sub_comm(int nb_prcs) noexcept
+    : nb_procs(nb_prcs)
+    , rank(-1)
+    , comm(MPI_COMM_NULL)
+  {
+    int comm_world_rank;
+    MPI_Comm_rank(MPI_COMM_WORLD, &comm_world_rank);
+    if (nb_procs>mpi_world_nb_procs()) {
+      if (comm_world_rank==0) {
+        MESSAGE(
+          "Unable to run test: need ", std::to_string(nb_procs), " procs",
+          " but program launched with only ", std::to_string(doctest::mpi_world_nb_procs()), "."
+        );
+        CHECK(nb_procs<=mpi_world_nb_procs());
+      }
+    } else {
+      int color = MPI_UNDEFINED;
+      if(comm_world_rank < nb_procs){
+        color = 0;
+      }
+      MPI_Comm_split(MPI_COMM_WORLD, color, comm_world_rank, &comm);
+
+      if(comm != MPI_COMM_NULL){
+        MPI_Comm_rank(comm, &rank);
+        assert(rank==comm_world_rank);
+      }
+    }
+  }
+
+  void destroy_comm() {
+    if(comm != MPI_COMM_NULL){
+      MPI_Comm_free(&comm);
+    }
+  }
+  
+  mpi_sub_comm(mpi_sub_comm&& x)
+    : nb_procs(x.nb_procs)
+    , rank(x.rank)
+    , comm(x.comm)
+  {
+    x.comm = MPI_COMM_NULL;
+  }
+  mpi_sub_comm& operator=(mpi_sub_comm&& x) {
+    destroy_comm();
+    nb_procs = x.nb_procs;
+    rank = x.rank;
+    comm = x.comm;
+    x.comm = MPI_COMM_NULL;
+    return *this;
+  }
+
+  ~mpi_sub_comm() {
+    destroy_comm();
+  }
+};
+
+} // doctest
+
+#endif // DOCTEST_SUB_COMM_H


### PR DESCRIPTION
## Background 
This PR is part of #120, where the basis of strategy for MPI parallelisation is described.

## Change description
As all thermodynamics operations are local to a grid cell all required MPI communication, is handled by NetCDF4 library. Therefore the only required steps are:

- [x] Initialize and finalize MPI stack
- [x] Read decomposition metadata on each rank
- [x] Read and write the necessary part of the grid on each rank (depends on #330)
- [x] Tests for parallel I/O 

**NOTE** PR #432 should be merged into this branch before it is merged into develop 

To run `run_simple_example.sh` you will need to generate the following netcdf file

```
$ ncdump partition.nc 
netcdf partition {
dimensions:
        P = 1 ;
        L = 1 ;
        globalX = 30 ;
        globalY = 30 ;

group: bounding_boxes {
  variables:
        int global_x(P) ;
        int global_y(P) ;
        int local_extent_x(P) ;
        int local_extent_y(P) ;
  data:

   global_x = 0 ;

   global_y = 0 ;

   local_extent_x = 30 ;

   local_extent_y = 30 ;
  } // group bounding_boxes
}

```