### PR TITLE
add libs to CMakeLists.txt to remove build duplication

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,13 +88,20 @@ foreach(compo ${CodeComponents})
     add_subdirectory("${compo}")
 endforeach()
 
-# Link the model
-add_executable(nextsim "${NextsimSources}")
+add_library(nextsimlib SHARED ${NextsimSources})
+target_include_directories(nextsimlib
+    PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}"
+    "${NextsimIncludeDirs}"
+    PUBLIC
+    "${netCDF_INCLUDE_DIR}"
+    )
+target_link_directories(nextsimlib PUBLIC "${netCDF_LIB_DIR}")
+target_link_libraries(nextsimlib PUBLIC Boost::program_options Boost::log "${NSDG_NetCDF_Library}" Eigen3::Eigen)
 
+add_executable(nextsim ./core/src/main.cpp)
 target_include_directories(nextsim PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}"
     "${NextsimIncludeDirs}"
-    "${netCDF_INCLUDE_DIR}"
     )
-target_link_directories(nextsim PUBLIC "${netCDF_LIB_DIR}")
-target_link_libraries(nextsim LINK_PUBLIC Boost::program_options Boost::log "${NSDG_NetCDF_Library}" Eigen3::Eigen)
+target_link_libraries(nextsim PUBLIC nextsimlib)

--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -1,7 +1,6 @@
 # Sources for the main neXtSIM model
 
 set(BaseSources
-    "main.cpp"
     "Logged.cpp"
     "Timer.cpp"
     "Model.cpp"

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -37,7 +37,7 @@ set(MODEL_INCLUDE_DIR "./testmodelarraydetails")
 
 add_executable(testModelArray "ModelArray_test.cpp" "../src/ModelArray.cpp" "${MODEL_INCLUDE_DIR}/ModelArrayDetails.cpp")
 target_include_directories(testModelArray PRIVATE "../src" "${MODEL_INCLUDE_DIR}")
-target_link_libraries(testModelArray PRIVATE doctest::doctest Eigen3::Eigen)
+target_link_libraries(testModelArray PRIVATE doctest::doctest)
 
 set(MODEL_INCLUDE_DIR "../../core/src/discontinuousgalerkin")
 

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -37,7 +37,7 @@ set(MODEL_INCLUDE_DIR "./testmodelarraydetails")
 
 add_executable(testModelArray "ModelArray_test.cpp" "../src/ModelArray.cpp" "${MODEL_INCLUDE_DIR}/ModelArrayDetails.cpp")
 target_include_directories(testModelArray PRIVATE "../src" "${MODEL_INCLUDE_DIR}")
-target_link_libraries(testModelArray PRIVATE doctest::doctest)
+target_link_libraries(testModelArray PRIVATE doctest::doctest Eigen3::Eigen)
 
 set(MODEL_INCLUDE_DIR "../../core/src/discontinuousgalerkin")
 

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -33,35 +33,35 @@ target_link_libraries(testScopedTimer PRIVATE nextsimlib doctest::doctest)
 add_executable(testTimeClasses "Time_test.cpp")
 target_link_libraries(testTimeClasses PRIVATE nextsimlib doctest::doctest)
 
-set(MODEL_INCLUDE_DIRS "./testmodelarraydetails")
+set(MODEL_INCLUDE_DIR "./testmodelarraydetails")
 
-add_executable(testModelArray "ModelArray_test.cpp" "testmodelarraydetails/ModelArrayDetails.cpp")
-target_include_directories(testModelArray PRIVATE ${MODEL_INCLUDE_DIRS})
-target_link_libraries(testModelArray PRIVATE nextsimlib doctest::doctest)
+add_executable(testModelArray "ModelArray_test.cpp" "../src/ModelArray.cpp" "${MODEL_INCLUDE_DIR}/ModelArrayDetails.cpp")
+target_include_directories(testModelArray PRIVATE "../src" "${MODEL_INCLUDE_DIR}")
+target_link_libraries(testModelArray PRIVATE doctest::doctest Eigen3::Eigen)
 
-set(MODEL_INCLUDE_DIRS "../../core/src/discontinuousgalerkin")
+set(MODEL_INCLUDE_DIR "../../core/src/discontinuousgalerkin")
 
 add_executable(testDevGrid "DevGrid_test.cpp")
-target_include_directories(testDevGrid PRIVATE ${MODEL_INCLUDE_DIRS})
+target_include_directories(testDevGrid PRIVATE ${MODEL_INCLUDE_DIR})
 target_link_libraries(testDevGrid PRIVATE nextsimlib doctest::doctest)
 
 add_executable(testRectGrid "RectGrid_test.cpp")
-target_include_directories(testRectGrid PRIVATE ${MODEL_INCLUDE_DIRS})
+target_include_directories(testRectGrid PRIVATE ${MODEL_INCLUDE_DIR})
 target_link_libraries(testRectGrid PRIVATE nextsimlib doctest::doctest)
 
 add_executable(testParaGrid "ParaGrid_test.cpp")
-target_include_directories(testParaGrid PRIVATE ${MODEL_INCLUDE_DIRS})
+target_include_directories(testParaGrid PRIVATE ${MODEL_INCLUDE_DIR})
 target_link_libraries(testParaGrid PRIVATE nextsimlib doctest::doctest)
 
 add_executable(testModelComponent "ModelComponent_test.cpp")
-target_include_directories(testModelComponent PRIVATE ${MODEL_INCLUDE_DIRS})
+target_include_directories(testModelComponent PRIVATE ${MODEL_INCLUDE_DIR})
 target_link_libraries(testModelComponent PRIVATE nextsimlib doctest::doctest)
 
 add_executable(testModelArrayRef "ModelArrayRef_test.cpp")
-target_include_directories(testModelArrayRef PRIVATE ${MODEL_INCLUDE_DIRS})
+target_include_directories(testModelArrayRef PRIVATE ${MODEL_INCLUDE_DIR})
 target_link_libraries(testModelArrayRef PRIVATE nextsimlib doctest::doctest)
 
 # PrognosticData (and hopefully that alone) requires code from the physics tree
 add_executable(testPrognosticData "PrognosticData_test.cpp" "DynamicsModuleForPDtest.cpp")
-target_include_directories(testPrognosticData PRIVATE ${PHYSICS_INCLUDE_DIRS} ${MODEL_INCLUDE_DIRS})
+target_include_directories(testPrognosticData PRIVATE ${PHYSICS_INCLUDE_DIRS} ${MODEL_INCLUDE_DIR})
 target_link_libraries(testPrognosticData PRIVATE nextsimlib doctest::doctest)

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -1,234 +1,67 @@
-# Build the unit, integration and model tests for neXtSIM
-
-set(CoreSrc "../src")
-set(SRC_DIR "${CoreSrc}")
-set(INCLUDE_DIR "${CoreSrc}/include")
-set(CoreModulesDir "${CoreSrc}/modules")
-set(ModelArrayDetails "testmodelarraydetails")
-set(FVModelArrayDetails "${CoreSrc}/finitevolume")
-
-# add_executable(testexe
-#   test/TestSrc.cpp
-#   otherSource.cpp)
-#target_link_libraries(testexe PRIVATE doctest::doctest)
-
-include_directories(${INCLUDE_DIR})
-
-add_executable(testIterator
-    "Iterator_test.cpp"
-    "${SRC_DIR}/Iterator.cpp"
-    "${SRC_DIR}/Time.cpp"
-    "${SRC_DIR}/Timer.cpp"
-    "${SRC_DIR}/Logged.cpp"
-    "${SRC_DIR}/Configurator.cpp"
-    
-    )
-target_include_directories(testIterator PUBLIC "${SRC_DIR}")
-target_link_libraries(testIterator PRIVATE doctest::doctest Boost::program_options Boost::log)
-
-add_executable(testCommandLineParser
-    "CommandLineParser_test.cpp"
-    "ArgV.cpp"
-    "${SRC_DIR}/CommandLineParser.cpp"
-    "${SRC_DIR}/ConfigurationHelpPrinter.cpp"
-    )
-target_include_directories(testCommandLineParser PUBLIC "${SRC_DIR}")
-target_link_libraries(testCommandLineParser LINK_PUBLIC Boost::program_options Boost::log doctest::doctest)
-
-add_executable(testConfigurator
-    "Configurator_test.cpp"
-    "ArgV.cpp"
-    "${SRC_DIR}/Configurator.cpp"
-    )
-target_include_directories(testConfigurator PUBLIC "${SRC_DIR}")
-target_link_libraries(testConfigurator LINK_PUBLIC Boost::program_options Boost::log doctest::doctest)
-
-add_executable(testConfiguredModule
-    "ConfiguredModule_test.cpp"
-    "ArgV.cpp"
-    "${SRC_DIR}/Configurator.cpp"
-    "${SRC_DIR}/ConfiguredModule.cpp"
-)
-target_include_directories(testConfiguredModule PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}" "${SRC_DIR}")
-target_link_libraries(testConfiguredModule PRIVATE doctest::doctest Boost::program_options Boost::log)
-
-add_executable(testTimer
-    "Timer_test.cpp"
-    "${SRC_DIR}/Timer.cpp"
-    )
-target_link_libraries(testTimer PRIVATE doctest::doctest)
-target_include_directories(testTimer PRIVATE "${SRC_DIR}")
-
-add_executable(testScopedTimer
-    "ScopedTimer_test.cpp"
-    "${SRC_DIR}/Timer.cpp"
-    "${SRC_DIR}/ScopedTimer.cpp"
-    )
-target_link_libraries(testScopedTimer PRIVATE doctest::doctest)
-target_include_directories(testScopedTimer PRIVATE "${SRC_DIR}")
-
-add_executable(testModelArray
-    "ModelArray_test.cpp"
-    "${CoreSrc}/ModelArray.cpp"
-    "${ModelArrayDetails}/ModelArrayDetails.cpp"
+set(COMMON_INCLUDE_DIRS
+    "../src/include"
+    "../../core/src"
+    "../../core/src/modules"
+    "../../core/src/include"
     )
 
-target_include_directories(testModelArray PRIVATE "${CoreSrc}" "${ModelArrayDetails}")
-target_link_libraries(testModelArray PRIVATE doctest::doctest Eigen3::Eigen)
-
-add_executable(testDevGrid
-    "DevGrid_test.cpp"
-    "${CoreModulesDir}/DevGrid.cpp"
-    "${CoreModulesDir}/IStructureModule.cpp"
-    "${CoreModulesDir}/RectangularGrid.cpp"
-    "${CoreModulesDir}/ParametricGrid.cpp"
-    "${SRC_DIR}/CommonRestartMetadata.cpp"
-    "${SRC_DIR}/Configurator.cpp"
-    "${SRC_DIR}/ConfiguredModule.cpp"
-    "${SRC_DIR}/DevGridIO.cpp"
-    "${SRC_DIR}/MissingData.cpp"
-    "${SRC_DIR}/ModelArray.cpp"
-    "${SRC_DIR}/ModelMetadata.cpp"
-    "${SRC_DIR}/NZLevels.cpp"
-    "${SRC_DIR}/Time.cpp"
-    "${CoreSrc}/${ModelArrayStructure}/ModelArrayDetails.cpp"
+set(PHYSICS_INCLUDE_DIRS
+    "../../physics/src"
+    "../../physics/src/modules"
     )
 
-target_include_directories(testDevGrid PUBLIC "${SRC_DIR}" "${CoreModulesDir}" "${PhysicsDir}" "${PhysicsModulesDir}" "${netCDF_INCLUDE_DIR}" "${CoreSrc}/${ModelArrayStructure}")
-target_link_directories(testDevGrid PUBLIC "${netCDF_LIB_DIR}")
-target_link_libraries(testDevGrid LINK_PUBLIC Boost::program_options Boost::log doctest::doctest "${NSDG_NetCDF_Library}" Eigen3::Eigen)
+include_directories(${COMMON_INCLUDE_DIRS})
 
-add_executable(testRectGrid
-    "RectGrid_test.cpp"
-    "${CoreModulesDir}/RectangularGrid.cpp"
-    "${CoreModulesDir}/DevGrid.cpp"
-    "${CoreModulesDir}/ParametricGrid.cpp"
-    "${CoreModulesDir}/IStructureModule.cpp"
-    "${SRC_DIR}/CommonRestartMetadata.cpp"
-    "${SRC_DIR}/Configurator.cpp"
-    "${SRC_DIR}/ConfiguredModule.cpp"
-    "${SRC_DIR}/RectGridIO.cpp"
-    "${SRC_DIR}/MissingData.cpp"
-    "${SRC_DIR}/ModelArray.cpp"
-    "${SRC_DIR}/ModelMetadata.cpp"
-    "${SRC_DIR}/NZLevels.cpp"
-    "${SRC_DIR}/Time.cpp"
-    "${CoreSrc}/${ModelArrayStructure}/ModelArrayDetails.cpp"
-    )
+add_executable(testIterator "Iterator_test.cpp")
+target_link_libraries(testIterator PRIVATE nextsimlib doctest::doctest)
 
-target_include_directories(testRectGrid PUBLIC "${SRC_DIR}" "${CoreModulesDir}" "${PhysicsDir}" "${PhysicsModulesDir}" "${netCDF_INCLUDE_DIR}" "${CoreSrc}/${ModelArrayStructure}")
-target_link_directories(testRectGrid PUBLIC "${netCDF_LIB_DIR}")
-target_link_libraries(testRectGrid LINK_PUBLIC Boost::program_options doctest::doctest "${NSDG_NetCDF_Library}" Eigen3::Eigen)
+add_executable(testCommandLineParser "CommandLineParser_test.cpp" "ArgV.cpp")
+target_link_libraries(testCommandLineParser PRIVATE nextsimlib doctest::doctest)
 
-add_executable(testParaGrid
-    "ParaGrid_test.cpp"
-    "${CoreModulesDir}/ParametricGrid.cpp"
-    "${CoreModulesDir}/RectangularGrid.cpp"
-    "${CoreModulesDir}/DevGrid.cpp"
-    "${CoreModulesDir}/IStructureModule.cpp"
-    "${SRC_DIR}/CommonRestartMetadata.cpp"
-    "${SRC_DIR}/Configurator.cpp"
-    "${SRC_DIR}/ConfiguredModule.cpp"
-    "${SRC_DIR}/ParaGridIO.cpp"
-    "${SRC_DIR}/MissingData.cpp"
-    "${SRC_DIR}/ModelArray.cpp"
-    "${SRC_DIR}/ModelMetadata.cpp"
-    "${SRC_DIR}/NZLevels.cpp"
-    "${SRC_DIR}/Time.cpp"
-    "${CoreSrc}/${ModelArrayStructure}/ModelArrayDetails.cpp"
-    )
-target_compile_definitions(testParaGrid PRIVATE TEST_FILE_SOURCE=${CMAKE_CURRENT_SOURCE_DIR})
-target_include_directories(testParaGrid PUBLIC "${SRC_DIR}" "${CoreModulesDir}" "${PhysicsDir}" "${PhysicsModulesDir}" "${netCDF_INCLUDE_DIR}" "${CoreSrc}/${ModelArrayStructure}")
-target_link_directories(testParaGrid PUBLIC "${netCDF_LIB_DIR}")
-target_link_libraries(testParaGrid LINK_PUBLIC Boost::program_options doctest::doctest "${NSDG_NetCDF_Library}" Eigen3::Eigen)
- 
-add_executable(testModelComponent
-    "ModelComponent_test.cpp"
-    "${CoreSrc}/ModelComponent.cpp"
-    "${CoreSrc}/MissingData.cpp"
-    "${CoreSrc}/ModelArray.cpp"
-    "${CoreSrc}/${ModelArrayStructure}/ModelArrayDetails.cpp"
-)
+add_executable(testConfigurator "Configurator_test.cpp" "ArgV.cpp")
+target_link_libraries(testConfigurator PRIVATE nextsimlib doctest::doctest)
 
-target_include_directories(testModelComponent PRIVATE "${CoreSrc}" "${CoreSrc}/${ModelArrayStructure}")
-target_link_libraries(testModelComponent PRIVATE Boost::program_options doctest::doctest Eigen3::Eigen)
+add_executable(testConfiguredModule "ConfiguredModule_test.cpp" "ArgV.cpp")
+target_link_libraries(testConfiguredModule PRIVATE nextsimlib doctest::doctest)
 
-add_executable(testTimeClasses
-    "Time_test.cpp"
-    "${CoreSrc}/Time.cpp"
-)
-target_include_directories(testTimeClasses PRIVATE "${CoreSrc}")
-target_link_libraries(testTimeClasses PRIVATE doctest::doctest)
+add_executable(testTimer "Timer_test.cpp")
+target_link_libraries(testTimer PRIVATE nextsimlib doctest::doctest)
 
-add_executable(testModelArrayRef
-    "ModelArrayRef_test.cpp"
-    "${CoreSrc}/ModelArray.cpp"
-    "${CoreSrc}/${ModelArrayStructure}/ModelArrayDetails.cpp"
-)
-target_include_directories(testModelArrayRef PRIVATE "${CoreSrc}" "${CoreSrc}/${ModelArrayStructure}")
-target_link_libraries(testModelArrayRef PRIVATE doctest::doctest Eigen3::Eigen)
+add_executable(testScopedTimer "ScopedTimer_test.cpp" "../src/ScopedTimer.cpp")
+target_link_libraries(testScopedTimer PRIVATE nextsimlib doctest::doctest)
+
+add_executable(testTimeClasses "Time_test.cpp")
+target_link_libraries(testTimeClasses PRIVATE nextsimlib doctest::doctest)
+
+set(MODEL_INCLUDE_DIRS "./testmodelarraydetails")
+
+add_executable(testModelArray "ModelArray_test.cpp" "testmodelarraydetails/ModelArrayDetails.cpp")
+target_include_directories(testModelArray PRIVATE ${MODEL_INCLUDE_DIRS})
+target_link_libraries(testModelArray PRIVATE nextsimlib doctest::doctest)
+
+set(MODEL_INCLUDE_DIRS "../../core/src/discontinuousgalerkin")
+
+add_executable(testDevGrid "DevGrid_test.cpp")
+target_include_directories(testDevGrid PRIVATE ${MODEL_INCLUDE_DIRS})
+target_link_libraries(testDevGrid PRIVATE nextsimlib doctest::doctest)
+
+add_executable(testRectGrid "RectGrid_test.cpp")
+target_include_directories(testRectGrid PRIVATE ${MODEL_INCLUDE_DIRS})
+target_link_libraries(testRectGrid PRIVATE nextsimlib doctest::doctest)
+
+add_executable(testParaGrid "ParaGrid_test.cpp")
+target_include_directories(testParaGrid PRIVATE ${MODEL_INCLUDE_DIRS})
+target_link_libraries(testParaGrid PRIVATE nextsimlib doctest::doctest)
+
+add_executable(testModelComponent "ModelComponent_test.cpp")
+target_include_directories(testModelComponent PRIVATE ${MODEL_INCLUDE_DIRS})
+target_link_libraries(testModelComponent PRIVATE nextsimlib doctest::doctest)
+
+add_executable(testModelArrayRef "ModelArrayRef_test.cpp")
+target_include_directories(testModelArrayRef PRIVATE ${MODEL_INCLUDE_DIRS})
+target_link_libraries(testModelArrayRef PRIVATE nextsimlib doctest::doctest)
 
 # PrognosticData (and hopefully that alone) requires code from the physics tree
-set(PhysSourceDir "${CoreSrc}/../../physics/src/")
-set(PhysModulesDir "${CoreSrc}/../../physics/src/modules")
-set(DynModulesDir "${CoreSrc}/../../dynamics/src/modules")
-set(DynSourceDir "${CoreSrc}/../../dynamics/src/")
-
-add_executable(testPrognosticData
-    "PrognosticData_test.cpp"
-    "${CoreSrc}/PrognosticData.cpp"
-    "${CoreSrc}/CommonRestartMetadata.cpp"
-    "${CoreSrc}/Configurator.cpp"
-    "${CoreSrc}/ConfiguredModule.cpp"
-    "${CoreSrc}/ModelArray.cpp"
-    "${CoreSrc}/ModelComponent.cpp"
-    "${CoreSrc}/ModelMetadata.cpp"
-    "${CoreSrc}/MissingData.cpp"
-    "${CoreSrc}/ParaGridIO.cpp"
-    "${CoreModulesDir}/IFreezingPointModule.cpp"
-    "${CoreModulesDir}/IStructureModule.cpp"
-    "${CoreModulesDir}/DevGrid.cpp"
-    "${CoreModulesDir}/ParametricGrid.cpp"
-    "${CoreModulesDir}/RectangularGrid.cpp"
-    "${CoreSrc}/${ModelArrayStructure}/ModelArrayDetails.cpp"
-    "DynamicsModuleForPDtest.cpp"
-    "${CoreSrc}/NZLevels.cpp"
-    "${PhysSourceDir}/IceGrowth.cpp"
-    "${PhysSourceDir}/IceMinima.cpp"
-    "${PhysSourceDir}/SlabOcean.cpp"
-    "${PhysModulesDir}/FiniteElementFluxes.cpp"
-    "${PhysModulesDir}/FiniteElementSpecHum.cpp"
-    "${PhysModulesDir}/FluxCalculationModule.cpp"
-    "${PhysModulesDir}/OceanBoundaryModule.cpp"
-    "${PhysModulesDir}/ConstantOceanBoundary.cpp"
-    "${PhysModulesDir}/ConfiguredOcean.cpp"
-    "${PhysModulesDir}/FluxConfiguredOcean.cpp"
-    "${PhysModulesDir}/TOPAZOcean.cpp"
-    "${PhysModulesDir}/AtmosphereBoundaryModule.cpp"
-    "${PhysModulesDir}/ConstantAtmosphereBoundary.cpp"
-    "${PhysModulesDir}/ConfiguredAtmosphere.cpp"
-    "${PhysModulesDir}/FluxConfiguredAtmosphere.cpp"
-    "${PhysModulesDir}/ERA5Atmosphere.cpp"
-    "${PhysModulesDir}/LateralIceSpreadModule.cpp"
-    "${PhysModulesDir}/HiblerSpread.cpp"
-    "${PhysModulesDir}/IceThermodynamicsModule.cpp"
-    "${PhysModulesDir}/ThermoIce0.cpp"
-    "${PhysModulesDir}/ThermoWinton.cpp"
-    "${PhysModulesDir}/IceOceanHeatFluxModule.cpp"
-    "${PhysModulesDir}/BasicIceOceanHeatFlux.cpp"
-    "${PhysModulesDir}/IIceAlbedoModule.cpp"
-    "${PhysModulesDir}/SMUIceAlbedo.cpp"
-    "${PhysModulesDir}/CCSMIceAlbedo.cpp"
-    "${PhysModulesDir}/SMU2IceAlbedo.cpp"
-    "${CoreSrc}/Time.cpp"
-    )
-target_include_directories(testPrognosticData PRIVATE
-    "${CoreSrc}"
-    "${CoreSrc}/${ModelArrayStructure}"
-    "${CoreModulesDir}"
-    "${PhysSourceDir}"
-    "${PhysModulesDir}"
-    "${netCDF_INCLUDE_DIR}"
-    )
-target_link_directories(testPrognosticData PUBLIC "${netCDF_LIB_DIR}")
-target_link_libraries(testPrognosticData PRIVATE Boost::program_options Boost::log doctest::doctest Eigen3::Eigen "${NSDG_NetCDF_Library}")
+add_executable(testPrognosticData "PrognosticData_test.cpp" "DynamicsModuleForPDtest.cpp")
+target_include_directories(testPrognosticData PRIVATE ${PHYSICS_INCLUDE_DIRS} ${MODEL_INCLUDE_DIRS})
+target_link_libraries(testPrognosticData PRIVATE nextsimlib doctest::doctest)

--- a/dynamics/tests/CMakeLists.txt
+++ b/dynamics/tests/CMakeLists.txt
@@ -1,23 +1,15 @@
-# Include dynamics headers
-set(DynamicsSrc "../src")
-set(SRC_DIR "${DynamicsSrc}")
-set(INCLUDE_DIR "${DynamicsSrc}/include")
-set(CoreDir "../../core/src/")
-
-include_directories(${INCLUDE_DIR})
-
-add_executable(dgma_test
-    "DGModelArray_test.cpp"
-    "${CoreDir}/ModelArray.cpp"
-    "${CoreDir}/${ModelArrayStructure}/ModelArrayDetails.cpp"
+set(COMMON_INCLUDE_DIRS
+    "../../core/src/discontinuousgalerkin"
+    "../../core/src"
+    "../../core/src/modules"
+    "../src"
+    "../src/include"
     )
-target_include_directories(dgma_test PRIVATE "${CoreDir}" "${SRC_DIR}" "${CoreDir}/${ModelArrayStructure}")
-target_link_libraries(dgma_test LINK_PUBLIC doctest::doctest Eigen3::Eigen)
 
-add_executable(cgma_test
-    "CGModelArray_test.cpp"
-    "${CoreDir}/ModelArray.cpp"
-    "${CoreDir}/${ModelArrayStructure}/ModelArrayDetails.cpp"
-    )
-target_include_directories(cgma_test PRIVATE "${CoreDir}" "${SRC_DIR}" "${CoreDir}/${ModelArrayStructure}")
-target_link_libraries(cgma_test LINK_PUBLIC doctest::doctest Eigen3::Eigen)
+add_executable(dgma_test "DGModelArray_test.cpp")
+target_include_directories(dgma_test PRIVATE ${COMMON_INCLUDE_DIRS})
+target_link_libraries(dgma_test PRIVATE nextsimlib doctest::doctest)
+
+add_executable(cgma_test "CGModelArray_test.cpp")
+target_include_directories(cgma_test PRIVATE ${COMMON_INCLUDE_DIRS})
+target_link_libraries(cgma_test PRIVATE nextsimlib doctest::doctest)

--- a/physics/test/CMakeLists.txt
+++ b/physics/test/CMakeLists.txt
@@ -1,278 +1,48 @@
-# Build the unit, integration and model tests for neXtSIM
-
-set(CoreSourceDir "${PROJECT_SOURCE_DIR}/core/src")
-set(CoreModulesDir "${CoreSourceDir}/modules")
-set(SourceDir "../src")
-set(ModulesDir "${SourceDir}/modules")
-
-# add_executable(testexe
-#   test/TestSrc.cpp
-#   otherSource.cpp)
-#target_link_libraries(testexe PRIVATE doctest::doctest)
-
-add_executable(testIceGrowth
-    "IceGrowth_test.cpp"
-    "${SourceDir}/IceGrowth.cpp"
-    "${SourceDir}/IceMinima.cpp"
-    "${CoreSourceDir}/Configurator.cpp"
-    "${CoreSourceDir}/ConfiguredModule.cpp"
-    "${CoreSourceDir}/ModelArray.cpp"
-    "${CoreSourceDir}/ModelComponent.cpp"
-    "${CoreSourceDir}/MissingData.cpp"
-    "${CoreSourceDir}/${ModelArrayStructure}/ModelArrayDetails.cpp"
-    "${CoreSourceDir}/NZLevels.cpp"
-    "${ModulesDir}/IceThermodynamicsModule.cpp"
-    "${ModulesDir}/LateralIceSpreadModule.cpp"
-    "${ModulesDir}/HiblerSpread.cpp"
-    "${ModulesDir}/ThermoIce0.cpp"
-    "${ModulesDir}/ThermoWinton.cpp"
-    "${CoreModulesDir}/IFreezingPointModule.cpp"
-    "${CoreSourceDir}/Time.cpp"
+set(COMMON_INCLUDE_DIRS
+    "../../core/src/discontinuousgalerkin"
+    "../../core/src"
+    "../../core/src/modules"
+    "../src"
+    "../src/modules"
     )
-target_include_directories(testIceGrowth PRIVATE
-    "${CoreSourceDir}"
-    "${CoreSourceDir}/${ModelArrayStructure}"
-    "${CoreModulesDir}"
-    "${SourceDir}"
-    "${ModulesDir}"
-    )
-target_link_libraries(testIceGrowth PRIVATE Boost::program_options Boost::log doctest::doctest Eigen3::Eigen)
 
-add_executable(testThermoWinton
-    "ThermoWintonTemperature_test.cpp"
-    "${CoreSourceDir}/Configurator.cpp"
-    "${CoreSourceDir}/ConfiguredModule.cpp"
-    "${CoreSourceDir}/ModelArray.cpp"
-    "${CoreSourceDir}/${ModelArrayStructure}/ModelArrayDetails.cpp"
-    "${CoreSourceDir}/ModelComponent.cpp"
-    "${CoreSourceDir}/MissingData.cpp"
-    "${CoreSourceDir}/NZLevels.cpp"
-    "${SourceDir}/IceMinima.cpp"
-    "${ModulesDir}/LateralIceSpreadModule.cpp"
-    "${ModulesDir}/HiblerSpread.cpp"
-    "${ModulesDir}/ThermoWinton.cpp"
-    "${CoreModulesDir}/IFreezingPointModule.cpp"
-    "${CoreSourceDir}/Time.cpp"
-    )
-target_include_directories(testThermoWinton PRIVATE
-    "${CoreSourceDir}"
-    "${CoreSourceDir}/${ModelArrayStructure}"
-    "${CoreModulesDir}"
-    "${SourceDir}"
-    "${ModulesDir}"
-    )
-target_link_libraries(testThermoWinton PRIVATE Boost::program_options Boost::log doctest::doctest Eigen3::Eigen)
+include_directories(${COMMON_INCLUDE_DIRS})
 
-add_executable(testFEFluxes
-    "FiniteElementFluxes_test.cpp"
-    "${CoreSourceDir}/Configurator.cpp"
-    "${CoreSourceDir}/ConfiguredModule.cpp"
-    "${CoreSourceDir}/ModelArray.cpp"
-    "${CoreSourceDir}/ModelComponent.cpp"
-    "${CoreSourceDir}/MissingData.cpp"
-    "${CoreModulesDir}/IFreezingPointModule.cpp"
-    "${CoreSourceDir}/${ModelArrayStructure}/ModelArrayDetails.cpp"
-    "${ModulesDir}/FiniteElementFluxes.cpp"
-    "${ModulesDir}/FiniteElementSpecHum.cpp"
-    "${ModulesDir}/IIceAlbedoModule.cpp"
-    "${ModulesDir}/SMUIceAlbedo.cpp"
-    "${ModulesDir}/CCSMIceAlbedo.cpp"
-    "${ModulesDir}/SMU2IceAlbedo.cpp"
-    "${CoreSourceDir}/Time.cpp"
-    )
-target_include_directories(testFEFluxes PRIVATE
-    "${CoreSourceDir}"
-    "${CoreSourceDir}/${ModelArrayStructure}"
-    "${CoreModulesDir}"
-    "${SourceDir}"
-    "${ModulesDir}"
-    )
-target_link_libraries(testFEFluxes PRIVATE Boost::program_options Boost::log doctest::doctest Eigen3::Eigen)
+add_executable(testIceGrowth "IceGrowth_test.cpp")
+target_link_libraries(testIceGrowth PRIVATE nextsimlib doctest::doctest)
 
+add_executable(testThermoWinton "ThermoWintonTemperature_test.cpp")
+target_link_libraries(testThermoWinton PRIVATE nextsimlib doctest::doctest)
 
-add_executable(testERA5Atm
-    "ERA5Atm_test.cpp"
-    "${ModulesDir}/ERA5Atmosphere.cpp"
-    "${CoreSourceDir}/Configurator.cpp"
-    "${CoreSourceDir}/ConfiguredModule.cpp"
-    "${CoreSourceDir}/CommonRestartMetadata.cpp"
-    "${CoreSourceDir}/ModelArray.cpp"
-    "${CoreSourceDir}/${ModelArrayStructure}/ModelArrayDetails.cpp"
-    "${CoreSourceDir}/ModelComponent.cpp"
-    "${CoreSourceDir}/ModelMetadata.cpp"
-    "${CoreSourceDir}/MissingData.cpp"
-    "${CoreSourceDir}/NZLevels.cpp"
-    "${CoreSourceDir}/ParaGridIO.cpp"
-    "${CoreModulesDir}/IFreezingPointModule.cpp"
-    "${CoreModulesDir}/IStructureModule.cpp"
-    "${CoreModulesDir}/RectangularGrid.cpp"
-    "${CoreModulesDir}/DevGrid.cpp"
-    "${CoreModulesDir}/ParametricGrid.cpp"
-    "${ModulesDir}/FiniteElementFluxes.cpp"
-    "${ModulesDir}/FiniteElementSpecHum.cpp"
-    "${ModulesDir}/FluxCalculationModule.cpp"
-    "${ModulesDir}/IIceAlbedoModule.cpp"
-    "${ModulesDir}/SMUIceAlbedo.cpp"
-    "${ModulesDir}/CCSMIceAlbedo.cpp"
-    "${ModulesDir}/SMU2IceAlbedo.cpp"
-    "${CoreSourceDir}/Time.cpp"
-    )
+add_executable(testFEFluxes "FiniteElementFluxes_test.cpp")
+target_link_libraries(testFEFluxes PRIVATE nextsimlib doctest::doctest)
+
+add_executable(testBIOHFluxes "BasicIceOceanFlux_test.cpp")
+target_link_libraries(testBIOHFluxes PRIVATE nextsimlib doctest::doctest)
+
+add_executable(testSpecHum "SpecificHumidity_test.cpp")
+target_link_libraries(testSpecHum PRIVATE nextsimlib doctest::doctest)
+
+add_executable(testConstantOcn "ConstantOceanBoundary_test.cpp")
+target_link_libraries(testConstantOcn PRIVATE nextsimlib doctest::doctest)
+
+add_executable(testSlabOcn "SlabOcean_test.cpp")
+target_link_libraries(testSlabOcn PRIVATE nextsimlib doctest::doctest)
+
+add_executable(testThermoIce0 "ThermoIce0_test.cpp")
+target_link_libraries(testThermoIce0 PRIVATE nextsimlib doctest::doctest)
+
+add_executable(testIceMinima "IceMinima_test.cpp")
+target_link_libraries(testIceMinima PRIVATE nextsimlib doctest::doctest)
+
+add_executable(testERA5Atm "ERA5Atm_test.cpp")
 target_compile_definitions(testERA5Atm PRIVATE TEST_FILE_SOURCE=${CMAKE_CURRENT_SOURCE_DIR})
-target_include_directories(testERA5Atm PRIVATE
-    "${CoreSourceDir}"
-    "${CoreSourceDir}/${ModelArrayStructure}"
-    "${CoreModulesDir}"
-    "${SourceDir}"
-    "${ModulesDir}"
-    )
-target_link_directories(testERA5Atm PUBLIC "${netCDF_LIB_DIR}")
-target_link_libraries(testERA5Atm PRIVATE Boost::program_options Boost::log doctest::doctest Eigen3::Eigen "${NSDG_NetCDF_Library}")
+target_link_libraries(testERA5Atm PRIVATE nextsimlib doctest::doctest)
 file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/era5_test128x128.nc"
      DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
 
-add_executable(testTOPAZOcn
-    "TOPAZOcn_test.cpp"
-    "${ModulesDir}/TOPAZOcean.cpp"
-    "${SourceDir}/SlabOcean.cpp"
-    "${CoreSourceDir}/Configurator.cpp"
-    "${CoreSourceDir}/ConfiguredModule.cpp"
-    "${CoreSourceDir}/CommonRestartMetadata.cpp"
-    "${CoreSourceDir}/ModelArray.cpp"
-    "${CoreSourceDir}/${ModelArrayStructure}/ModelArrayDetails.cpp"
-    "${CoreSourceDir}/ModelComponent.cpp"
-    "${CoreSourceDir}/ModelMetadata.cpp"
-    "${CoreSourceDir}/MissingData.cpp"
-    "${CoreSourceDir}/NZLevels.cpp"
-    "${CoreSourceDir}/ParaGridIO.cpp"
-    "${CoreModulesDir}/IFreezingPointModule.cpp"
-    "${CoreModulesDir}/IStructureModule.cpp"
-    "${CoreModulesDir}/DevGrid.cpp"
-    "${CoreModulesDir}/RectangularGrid.cpp"
-    "${CoreModulesDir}/ParametricGrid.cpp"
-    "${CoreSourceDir}/Time.cpp"
-    "${ModulesDir}/IceOceanHeatFluxModule.cpp"
-    "${ModulesDir}/BasicIceOceanHeatFlux.cpp"
-    )
+add_executable(testTOPAZOcn "TOPAZOcn_test.cpp")
 target_compile_definitions(testTOPAZOcn PRIVATE TEST_FILE_SOURCE=${CMAKE_CURRENT_SOURCE_DIR})
-target_include_directories(testTOPAZOcn PRIVATE
-    "${CoreSourceDir}"
-    "${CoreSourceDir}/${ModelArrayStructure}"
-    "${CoreModulesDir}"
-    "${SourceDir}"
-    "${ModulesDir}"
-    )
-target_link_directories(testTOPAZOcn PUBLIC "${netCDF_LIB_DIR}")
-target_link_libraries(testTOPAZOcn PRIVATE Boost::program_options Boost::log doctest::doctest Eigen3::Eigen "${NSDG_NetCDF_Library}")
+target_link_libraries(testTOPAZOcn PRIVATE nextsimlib doctest::doctest)
 file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/topaz_test128x128.nc"
      DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
-
-add_executable(testBIOHFluxes
-    "BasicIceOceanFlux_test.cpp"
-    "${ModulesDir}/BasicIceOceanHeatFlux.cpp"
-    "${CoreSourceDir}/Configurator.cpp"
-    "${CoreSourceDir}/ConfiguredModule.cpp"
-    "${CoreSourceDir}/ModelArray.cpp"
-    "${CoreSourceDir}/ModelComponent.cpp"
-    "${CoreSourceDir}/MissingData.cpp"
-    "${CoreModulesDir}/IFreezingPointModule.cpp"
-    "${CoreSourceDir}/Time.cpp"
-    "${CoreSourceDir}/${ModelArrayStructure}/ModelArrayDetails.cpp"
-    )
-target_include_directories(testBIOHFluxes PRIVATE
-    "${CoreSourceDir}"
-    "${CoreSourceDir}/${ModelArrayStructure}"
-    "${CoreModulesDir}"
-    "${SourceDir}"
-    "${ModulesDir}"
-    )
-target_link_libraries(testBIOHFluxes PRIVATE Boost::program_options Boost::log doctest::doctest Eigen3::Eigen)
-
-add_executable(testSpecHum
-    "SpecificHumidity_test.cpp"
-    "${ModulesDir}/FiniteElementSpecHum.cpp"
-    )
-target_include_directories(testSpecHum PRIVATE
-    "${ModulesDir}"
-    )
-target_link_libraries(testSpecHum PRIVATE doctest::doctest)
-
-add_executable(testConstantOcn
-    "ConstantOceanBoundary_test.cpp"
-    "${ModulesDir}/ConstantOceanBoundary.cpp"
-    "${CoreSourceDir}/Configurator.cpp"
-    "${CoreSourceDir}/ConfiguredModule.cpp"
-    "${CoreSourceDir}/ModelArray.cpp"
-    "${CoreSourceDir}/ModelComponent.cpp"
-    "${CoreSourceDir}/MissingData.cpp"
-    "${CoreModulesDir}/IFreezingPointModule.cpp"
-    "${CoreSourceDir}/${ModelArrayStructure}/ModelArrayDetails.cpp"
-    "${ModulesDir}/FiniteElementFluxes.cpp"
-    "${ModulesDir}/FiniteElementSpecHum.cpp"
-    "${ModulesDir}/FluxCalculationModule.cpp"
-    "${ModulesDir}/IceOceanHeatFluxModule.cpp"
-    "${ModulesDir}/BasicIceOceanHeatFlux.cpp"
-    "${ModulesDir}/IIceAlbedoModule.cpp"
-    "${ModulesDir}/SMUIceAlbedo.cpp"
-    "${ModulesDir}/CCSMIceAlbedo.cpp"
-    "${ModulesDir}/SMU2IceAlbedo.cpp"
-    "${CoreSourceDir}/Time.cpp"
-    )
-target_include_directories(testConstantOcn PRIVATE
-    "${CoreSourceDir}"
-    "${CoreSourceDir}/${ModelArrayStructure}"
-    "${CoreModulesDir}"
-    "${SourceDir}"
-    "${ModulesDir}"
-    )
-target_link_libraries(testConstantOcn PRIVATE Boost::program_options Boost::log doctest::doctest Eigen3::Eigen)
-
-add_executable(testSlabOcn
-    "SlabOcean_test.cpp"
-    "${SourceDir}/SlabOcean.cpp"
-    "${CoreSourceDir}/Configurator.cpp"
-    "${CoreSourceDir}/ConfiguredModule.cpp"
-    "${CoreSourceDir}/ModelArray.cpp"
-    "${CoreSourceDir}/ModelComponent.cpp"
-    "${CoreSourceDir}/MissingData.cpp"
-    "${CoreModulesDir}/IFreezingPointModule.cpp"
-    "${CoreSourceDir}/${ModelArrayStructure}/ModelArrayDetails.cpp"
-    "${CoreSourceDir}/Time.cpp"
-    )
-target_include_directories(testSlabOcn PRIVATE
-    "${CoreSourceDir}"
-    "${CoreSourceDir}/${ModelArrayStructure}"
-    "${CoreModulesDir}"
-    "${SourceDir}"
-    "${ModulesDir}"
-    )
-target_link_libraries(testSlabOcn PRIVATE Boost::program_options Boost::log doctest::doctest Eigen3::Eigen)
-
-add_executable(testThermoIce0
-    "ThermoIce0_test.cpp"
-    "${ModulesDir}/ThermoIce0.cpp"
-    "${SourceDir}/IceMinima.cpp"
-    "${CoreSourceDir}/Configurator.cpp"
-    "${CoreSourceDir}/ConfiguredModule.cpp"
-    "${CoreSourceDir}/ModelArray.cpp"
-    "${CoreSourceDir}/ModelComponent.cpp"
-    "${CoreSourceDir}/MissingData.cpp"
-    "${CoreSourceDir}/NZLevels.cpp"
-    "${CoreModulesDir}/IFreezingPointModule.cpp"
-    "${CoreSourceDir}/Time.cpp"
-    "${CoreSourceDir}/${ModelArrayStructure}/ModelArrayDetails.cpp"
-    )
-target_include_directories(testThermoIce0 PRIVATE
-    "${CoreSourceDir}"
-    "${CoreSourceDir}/${ModelArrayStructure}"
-    "${CoreModulesDir}"
-    "${SourceDir}"
-    "${ModulesDir}"
-    )
-target_link_libraries(testThermoIce0 PRIVATE Boost::program_options Boost::log doctest::doctest Eigen3::Eigen)
-
-add_executable(testIceMinima
-    "IceMinima_test.cpp"
-    "${SourceDir}/IceMinima.cpp"
-    )
-target_include_directories(testIceMinima PRIVATE "${SourceDir}")
-target_link_libraries(testIceMinima PRIVATE doctest::doctest)


### PR DESCRIPTION
# Pull Request Title

## Fixes \#347 and fixes \#210

---
# Change Description

* Previous build of code base took ~45 mins (e.g. see [github actions](https://github.com/nextsimdg/nextsimdg/actions/runs/5855514762))
* I have modified the `CMakeLists.txt` files
* They should be a lot simpler to read and faster to compile.
* I have removed build duplication by linking against a compiled lib rather than rebuilding every cpp file for each executable (there are many tests, each are separate exe's)

* In my first attempt I have created one main library containing the majority of nextsimdg code (`nextsimlib`)
* This library could be split into modular libraries depending on use-case in future

* **My primary goal was to improve build time not necessarily thinking about how best to structure the code into libraries. This can be discussed at a later stage.**