### PR TITLE
A const return value makes no sense.

### DIFF
--- a/core/src/include/ModelArray.hpp
+++ b/core/src/include/ModelArray.hpp
@@ -238,7 +238,7 @@ public:
     //! Returns a const reference to the Eigen data
     const DataType& data() const { return m_data; }
     //! Returns the (enum of) the ModelArray::Type of this.
-    const Type getType() const { return type; }
+    Type getType() const { return type; }
 
     /*!
      * @brief Sets the number and size of the dimensions of a specified type of


### PR DESCRIPTION
# A const return value makes no sense.
## Fixes \#325

> When compiling any target that depends on a source which includes ModelArray.hpp when using compiler 'mpiicpc' you get a warning.
> 
> Syndrome:
> 
>```
> [ 22%] Building CXX object CMakeFiles/nextsim.dir/core/src/DevGridIO.cpp.o
> In file included from /home/jbloggs/nextsim/xios_write/core/src/include/ModelState.hpp(11),
> from /home/jbloggs/nextsim/xios_write/core/src/include/IDevGridIO.hpp(12),
> from /home/jbloggs/nextsim/xios_write/core/src/include/DevGridIO.hpp(11),
> from /home/jbloggs/nextsim/xios_write/core/src/DevGridIO.cpp(8):
> /home/jbloggs/nextsim/xios_write/core/src/include/ModelArray.hpp(241): warning #858: type qualifier on return type is meaningless
> const Type getType() const { return type; }
> ^
>```
> 
> Reproduction Steps:
> 
> Repeat install steps but replace the cmake line with
> cmake . -DCMAKE_CXX_COMPILER="mpiicpc"
> 
> make step should trigger the warnings
> 
> Severity & Frequency:
> 
> Low impact. UX and only at compile (but for many many files). Have not investigated compile speed impact. Remove bug label at triage if inappropriate (readme isn't specific).
> 

Remove the const label.