### PR TITLE
Fix the ERA5 polar winds

### DIFF
--- a/run/era5_topaz4_maker.py
+++ b/run/era5_topaz4_maker.py
@@ -301,6 +301,15 @@ if __name__ == "__main__":
                 time_index = target_time - source_times[0]
                 u_data_source = u_file["u10"][time_index, :, :]
                 v_data_source = v_file["v10"][time_index, :, :]
+                # Fix the polar row winds by copying the pole-adjacent row
+                # Pole in the first row
+                if abs(source_lats[0]) == 90.:
+                    u_data_source[:, 0] = u_data_source[:, 1]
+                    v_data_source[:, 0] = u_data_source[:, 1]
+                # Pole in the last row
+                if abs(source_lats[-1]) == 90.:
+                    u_data_source[:, -1] = u_data_source[:, -2]
+                    v_data_source[:, -1] = u_data_source[:, -2]
                 # Now interpolate the source data to the target grid
                 u_data_target = np.zeros((nx, ny))
                 u_data_target = era5_interpolate(element_lon, element_lat, u_data_source, source_lons, source_lats)


### PR DESCRIPTION
# Fix the ERA5 polar winds
## Fixes \#368

---
# Change Description

The base ERA5 data files have a polar row in the wind data that is set to a constant for all longitudes for each component. This is clearly incorrect. A consistent value of the wind in a long-lat grid can be represented as a pair of sinusoidal functions in longitude, in quadrature for each component. The polar adjacent row shows almost exactly this behaviour as the variation in the true wind is not that great over the 25 km radius circle this row represents.

When interpolating the wind vector components to the model grid, this wind vector interpolation makes the pole very obvious as a point inconsistent with the rest of the wind field. The ERA5 pre-processing python script should be altered so that polar point is interpolated correctly to give a smooth wind field.

The fix is to check the latitudes of the first and the last row. If the absolute value of the latitude is `90.`, then copy the wind from the adjacent row. This is close enough to give a correct wind value.
