### PR TITLE
fix build for gfortran

### DIFF
--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -261,11 +261,11 @@ set(XIOS_LIBRARY_LIST
     Eigen3::Eigen 
     Boost::program_options
     Boost::log
-    "${NSDG_NetCDF_Library}"
     MPI::MPI_CXX
     xios
+    "${NSDG_NetCDF_Library}"
     HDF5::HDF5
-    ifcore
+    "-lgfortran"
 )
 
 add_executable(testXiosInit

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -21,7 +21,6 @@ add_executable(testIterator
     "${SRC_DIR}/Timer.cpp"
     "${SRC_DIR}/Logged.cpp"
     "${SRC_DIR}/Configurator.cpp"
-    
     )
 target_include_directories(testIterator PUBLIC "${SRC_DIR}")
 target_link_libraries(testIterator PRIVATE doctest::doctest Boost::program_options Boost::log)
@@ -247,25 +246,25 @@ target_link_libraries(testPrognosticData PRIVATE Boost::program_options Boost::l
 
 #XIOS Tests
 
-set(XIOS_INCLUDE_LIST 
-    "${CoreSrc}" 
-    "${netCDF_INCLUDE_DIR}" 
-    "${MPI_CXX_INCLUDE_PATH}" 
+set(XIOS_INCLUDE_LIST
+    "${CoreSrc}"
+    "${netCDF_INCLUDE_DIR}"
+    "${MPI_CXX_INCLUDE_PATH}"
     "${xios_INCLUDES}"
     "${xios_EXTERNS}/blitz/"
     "${xios_EXTERNS}/rapidxml/include"
     )
 
-set(XIOS_LIBRARY_LIST 
+set(XIOS_LIBRARY_LIST
     doctest::doctest
-    Eigen3::Eigen 
+    Eigen3::Eigen
     Boost::program_options
     Boost::log
     MPI::MPI_CXX
     xios
     "${NSDG_NetCDF_Library}"
     HDF5::HDF5
-    "-lgfortran"
+    "${FORTRAN_RUNTIME_LIB}"
 )
 
 add_executable(testXiosInit
@@ -273,7 +272,7 @@ add_executable(testXiosInit
     "${CoreSrc}/Xios.cpp"
     "${CoreSrc}/Configurator.cpp"
 )
-target_include_directories(testXiosInit PRIVATE "${XIOS_INCLUDE_LIST}" "${ModuleDir}") 
+target_include_directories(testXiosInit PRIVATE "${XIOS_INCLUDE_LIST}" "${ModuleDir}")
 target_link_directories(testXiosInit PUBLIC "${netCDF_LIB_DIR}" "${xios_LIBRARIES}")
 target_link_libraries(testXiosInit PRIVATE "${XIOS_LIBRARY_LIST}")
 
@@ -283,7 +282,7 @@ add_executable(testXiosBuild
     "${CoreSrc}/Xios.cpp"
     "${CoreSrc}/Configurator.cpp"
 )
-target_include_directories(testXiosBuild PRIVATE "${XIOS_INCLUDE_LIST}" "${ModuleDir}") 
+target_include_directories(testXiosBuild PRIVATE "${XIOS_INCLUDE_LIST}" "${ModuleDir}")
 target_link_directories(testXiosBuild PUBLIC "${netCDF_LIB_DIR}" "${xios_LIBRARIES}")
 target_link_libraries(testXiosBuild PRIVATE "${XIOS_LIBRARY_LIST}")
 
@@ -292,6 +291,6 @@ add_executable(testXiosDisabled
     "${CoreSrc}/Xios.cpp"
     "${CoreSrc}/Configurator.cpp"
 )
-target_include_directories(testXiosDisabled PRIVATE "${XIOS_INCLUDE_LIST}" "${ModuleDir}") 
+target_include_directories(testXiosDisabled PRIVATE "${XIOS_INCLUDE_LIST}" "${ModuleDir}")
 target_link_directories(testXiosDisabled PUBLIC "${netCDF_LIB_DIR}" "${xios_LIBRARIES}")
 target_link_libraries(testXiosDisabled PRIVATE "${XIOS_LIBRARY_LIST}")

--- a/core/test/XiosInit_test.cpp
+++ b/core/test/XiosInit_test.cpp
@@ -53,7 +53,7 @@ int main( int argc, char* argv[] ) {
 
     // XIOS Class Init --- Initialises server. Unknown error if initialised per test.
     // TODO: Investigate and find workaround
-    xios_handler = new Nextsim::Xios::Xios(NULL, NULL);
+    xios_handler = new Nextsim::Xios(NULL, NULL);
 
     //int result = Catch::Session().run( argc, argv );
     int result = context.run();// argc, argv );


### PR DESCRIPTION
~I have manually changed lib `ifcore` to `lgfortran`. This will need to fixed properly for intel and gnu compiler and not hard-coded.~

~this is a **temporary fix**.~

The order of libs is also incorrect for `XIOS_LIBRARY_LIST`. `xios` depends on `netcdf` so it should come second.

There was an erroneous `::Xios` for the constructor when creating `xios_handler`.

fixes #413 