### PR TITLE
Fix and tidy tests

### DIFF
--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -28,7 +28,7 @@ template <>
 const std::map<int, std::string> Configured<Xios>::keyMap
     = { { Xios::ENABLED_KEY, "xios.enable" } };
 
-Xios::Xios(int argc, char* argv[])
+Xios::Xios()
 {
 
     m_isConfigured = false;
@@ -363,9 +363,7 @@ cxios_duration Xios::convertStringToXiosDuration(std::string timestep_str)
         }
     }
 
-    // std::cout << "Duration Year: " << dduration.year << std::endl;
-    // std::cout << "Duration Month: " << dduration.month << std::endl;
-    // std::cout << "Duration Day: " << dduration.day << std::endl;
+    dduration.timestep = 0;
 
     // TODO: This needs testing like.............
     return dduration;

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -21,7 +21,7 @@ namespace Nextsim {
 //! Class to handle interfacing with the XIOS library
 class Xios : public Configured<Xios> {
 public:
-    Xios(int argc, char* argv[]); //, bool manual_enable=false);
+    Xios(); //, bool manual_enable=false);
     ~Xios();
 
     // void initialise();//int argc, char* argv[]);

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -139,7 +139,7 @@ add_executable(testParaGrid
 
 target_include_directories(testParaGrid PUBLIC "${SRC_DIR}" "${CoreModulesDir}" "${PhysicsDir}" "${PhysicsModulesDir}" "${netCDF_INCLUDE_DIR}" "${CoreSrc}/${ModelArrayStructure}")
 target_link_directories(testParaGrid PUBLIC "${netCDF_LIB_DIR}")
-target_link_libraries(testParaGrid LINK_PUBLIC Boost::program_options doctest::doctest "${NSDG_NetCDF_Library}" Eigen3::Eigen)
+target_link_libraries(testParaGrid LINK_PUBLIC Boost::program_options doctest::doctest "${NSDG_NetCDF_Library}" Eigen3::Eigen "-lstdc++fs")
 
 add_executable(testModelComponent
     "ModelComponent_test.cpp"

--- a/core/test/XiosBuild_test.cpp
+++ b/core/test/XiosBuild_test.cpp
@@ -21,7 +21,7 @@ TEST_CASE("Full XIOS method sweep")
 {
     // Configure the XIOS server
     Nextsim::Xios *xios;
-    xios = new Nextsim::Xios::Xios(NULL, NULL);
+    xios = new Nextsim::Xios;
     xios->initialise();
 
     // Validate

--- a/core/test/XiosDisabled_test.cpp
+++ b/core/test/XiosDisabled_test.cpp
@@ -42,7 +42,7 @@ int main( int argc, char* argv[] ) {
 
     // XIOS Class Init --- Initialises server. Unknown error if initialised per test.
     // TODO: Investigate and find workaround
-    xios_handler = new Nextsim::Xios::Xios(NULL, NULL);
+    xios_handler = new Nextsim::Xios;
 
     int result = Catch::Session().run( argc, argv );
 

--- a/core/test/XiosInit_test.cpp
+++ b/core/test/XiosInit_test.cpp
@@ -53,7 +53,7 @@ int main( int argc, char* argv[] ) {
 
     // XIOS Class Init --- Initialises server. Unknown error if initialised per test.
     // TODO: Investigate and find workaround
-    xios_handler = new Nextsim::Xios(NULL, NULL);
+    xios_handler = new Nextsim::Xios;
 
     //int result = Catch::Session().run( argc, argv );
     int result = context.run();// argc, argv );

--- a/physics/test/CMakeLists.txt
+++ b/physics/test/CMakeLists.txt
@@ -127,7 +127,7 @@ target_include_directories(testERA5Atm PRIVATE
     "${netCDF_INCLUDE_DIR}"
     )
 target_link_directories(testERA5Atm PUBLIC "${netCDF_LIB_DIR}")
-target_link_libraries(testERA5Atm PRIVATE Boost::program_options Boost::log doctest::doctest Eigen3::Eigen "${NSDG_NetCDF_Library}")
+target_link_libraries(testERA5Atm PRIVATE Boost::program_options Boost::log doctest::doctest Eigen3::Eigen "${NSDG_NetCDF_Library}" "-lstdc++fs")
 file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/era5_test128x128.nc"
      DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
 
@@ -164,7 +164,7 @@ target_include_directories(testTOPAZOcn PRIVATE
     "${netCDF_INCLUDE_DIR}"
     )
 target_link_directories(testTOPAZOcn PUBLIC "${netCDF_LIB_DIR}")
-target_link_libraries(testTOPAZOcn PRIVATE Boost::program_options Boost::log doctest::doctest Eigen3::Eigen "${NSDG_NetCDF_Library}")
+target_link_libraries(testTOPAZOcn PRIVATE Boost::program_options Boost::log doctest::doctest Eigen3::Eigen "${NSDG_NetCDF_Library}" "-lstdc++fs")
 file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/topaz_test128x128.nc"
      DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
 

--- a/physics/test/CMakeLists.txt
+++ b/physics/test/CMakeLists.txt
@@ -124,6 +124,7 @@ target_include_directories(testERA5Atm PRIVATE
     "${CoreModulesDir}"
     "${SourceDir}"
     "${ModulesDir}"
+    "${netCDF_INCLUDE_DIR}"
     )
 target_link_directories(testERA5Atm PUBLIC "${netCDF_LIB_DIR}")
 target_link_libraries(testERA5Atm PRIVATE Boost::program_options Boost::log doctest::doctest Eigen3::Eigen "${NSDG_NetCDF_Library}")
@@ -160,6 +161,7 @@ target_include_directories(testTOPAZOcn PRIVATE
     "${CoreModulesDir}"
     "${SourceDir}"
     "${ModulesDir}"
+    "${netCDF_INCLUDE_DIR}"
     )
 target_link_directories(testTOPAZOcn PUBLIC "${netCDF_LIB_DIR}")
 target_link_libraries(testTOPAZOcn PRIVATE Boost::program_options Boost::log doctest::doctest Eigen3::Eigen "${NSDG_NetCDF_Library}")


### PR DESCRIPTION
# fix and tidy XIOS tests
## Fixes #415

The `testXiosInit` test was failing to run when compiled with `gnu` compiler. It worked for `intel` compiler and my suspicion is that `intel` compilers will often initialize uninitialized variables to zero. This is not the case for `gcc`. This meant that `dduration.timestep` was not being properly set and it led to the bug in #415.

This has been resolved and I have also tidied the test cases.