### PR TITLE
Issue 275  Correct array order in python scripts

### DIFF
--- a/run/era5_topaz4_maker.py
+++ b/run/era5_topaz4_maker.py
@@ -408,8 +408,8 @@ if __name__ == "__main__":
                 data[target_t_index, :, :] = time_data
         
     # Ocean currents
-    udata = datagrp.createVariable("u", "f8", ("time", "x", "y"))
-    vdata = datagrp.createVariable("v", "f8", ("time", "x", "y"))
+    udata = datagrp.createVariable("u", "f8", timefield_dims)
+    vdata = datagrp.createVariable("v", "f8", timefield_dims)
     for target_t_index in range (len(unix_times_t)):
         u_source_file = netCDF4.Dataset(topaz4_source_file_name("u", unix_times_t[target_t_index]), "r")
         v_source_file = netCDF4.Dataset(topaz4_source_file_name("v", unix_times_t[target_t_index]), "r")

--- a/run/era5_topaz4_maker.py
+++ b/run/era5_topaz4_maker.py
@@ -199,9 +199,9 @@ if __name__ == "__main__":
     # assume lon and lat are 0 and 1 coords
     node_lon = node_coords[:, :, 0]
     node_lat = node_coords[:, :, 1]
-    nx = node_lon.shape[0] - 1
-    ny = node_lon.shape[1] - 1
-    element_shape = (nx, ny)
+    ny = node_lon.shape[0] - 1
+    nx = node_lon.shape[1] - 1
+    element_shape = (ny, nx)
     element_lon = np.zeros(element_shape)
     element_lat = np.zeros(element_shape)
     # interpolate lon and lat from nodes to elements, to leave nx x ny arrays
@@ -282,7 +282,7 @@ if __name__ == "__main__":
                 time_index = target_time - source_times[0]
                 source_data = source_file[era5_field][time_index, :, :]
                 # Now interpolate the source data to the target grid
-                time_data = np.zeros((nx, ny))
+                time_data = np.zeros((ny, nx))
                 time_data = era5_interpolate(element_lon, element_lat, source_data, source_lons, source_lats)
                 if era5_field in kelvin_fields:
                     time_data -= zero_C_in_kelvin
@@ -312,9 +312,9 @@ if __name__ == "__main__":
                     u_data_source[:, -1] = u_data_source[:, -2]
                     v_data_source[:, -1] = u_data_source[:, -2]
                 # Now interpolate the source data to the target grid
-                u_data_target = np.zeros((nx, ny))
+                u_data_target = np.zeros((ny, nx))
                 u_data_target = era5_interpolate(element_lon, element_lat, u_data_source, source_lons, source_lats)
-                v_data_target = np.zeros((nx, ny))
+                v_data_target = np.zeros((ny, nx))
                 v_data_target = era5_interpolate(element_lon, element_lat, v_data_source, source_lons, source_lats)
                 speed_data = np.hypot(u_data_target, v_data_target)
                 data[target_t_index, :, :] = speed_data

--- a/run/era5_topaz4_maker.py
+++ b/run/era5_topaz4_maker.py
@@ -204,7 +204,7 @@ if __name__ == "__main__":
     element_shape = (ny, nx)
     element_lon = np.zeros(element_shape)
     element_lat = np.zeros(element_shape)
-    # interpolate lon and lat from nodes to elements, to leave nx x ny arrays
+    # interpolate lon and lat from nodes to elements, to leave ny x nx arrays
     node_x = np.cos(np.radians(node_lon)) * np.cos(np.radians(node_lat))
     node_y = np.sin(np.radians(node_lon)) * np.cos(np.radians(node_lat))
     node_z = np.sin(np.radians(node_lat))

--- a/run/make_init25kmNH.py
+++ b/run/make_init25kmNH.py
@@ -4,12 +4,6 @@ import numpy.ma as ma
 import time
 import math
 
-<<<<<<< issue275_3_arrayorderwithavengeance
-import sys # FIXME remove me
-=======
-#import sys # FIXME remove me
->>>>>>> f5ca18d Swap the array indices.
-
 topaz_mdi = -32767
 
 # Returns the file name that holds the TOPAZ data for a given field at a given time


### PR DESCRIPTION
# Correct array order in python scripts
## Fixes \#275

The array-ordering changes to the python scripts that generate the netCDF restart files were missed out of the array-ordering PR #373. They are now included here.