### PR TITLE
Explicitly correct the restart file land mask.

### DIFF
--- a/run/make_init25kmNH.py
+++ b/run/make_init25kmNH.py
@@ -160,7 +160,11 @@ if __name__ == "__main__":
     mask = datagrp.createVariable("mask", "f8", field_dims)
     sst_data = topaz4_interpolate(element_lon, element_lat, source_file["temperature"][0, :, :].squeeze(), lat_array)
     mask[:, :] = 1 - ma.getmask(sst_data)
-    mask[100, 95] = 0.0 # Ad-hoc fix for the westernmost point of the New Siberian Islands
+    # Despite having the same data source, the restart file generation script 
+    # and forcing generation script have a consistent, one pixel difference
+    # at the western tip of the New Siberian Islands (100, 95).
+    # Force the land mask to be consistent.
+    mask[100, 95] = 0.0
     
     # Ice concentration and thickness
     cice_data = topaz4_interpolate(element_lon, element_lat, source_file["fice"][0, :, :].squeeze(), lat_array)

--- a/run/make_init25kmNH.py
+++ b/run/make_init25kmNH.py
@@ -160,7 +160,8 @@ if __name__ == "__main__":
     mask = datagrp.createVariable("mask", "f8", field_dims)
     sst_data = topaz4_interpolate(element_lon, element_lat, source_file["temperature"][0, :, :].squeeze(), lat_array)
     mask[:, :] = 1 - ma.getmask(sst_data)
-
+    mask[100, 95] = 0.0 # Ad-hoc fix for the westernmost point of the New Siberian Islands
+    
     # Ice concentration and thickness
     cice_data = topaz4_interpolate(element_lon, element_lat, source_file["fice"][0, :, :].squeeze(), lat_array)
     hice_data = topaz4_interpolate(element_lon, element_lat, source_file["hice"][0, :, :].squeeze(), lat_array)


### PR DESCRIPTION
# Explicitly correct the restart file land mask
## Fixes \#440

Despite having the same data source, the restart file generation script and forcing generation script have a consistent, one pixel difference at the grid point [100, 95], the western tip of the New Siberian Islands.

After much work trying to reconcile the forcing generation and restart file generation script, I do not seem able to get the two to agree, despite using the same data source files and, as best as I can see, the same code to interpolate between grids. Hence, I am explicitly patching the land mask in the restart file generation script. This removes the discrepancy and my headache.

Even if it is a bit of a hack.