### PR TITLE
Persist the grid coordinates

### DIFF
--- a/core/src/Model.cpp
+++ b/core/src/Model.cpp
@@ -101,6 +101,10 @@ void Model::configure()
 #else
     ModelState initialState(StructureFactory::stateFromFile(initialFileName));
 #endif
+
+    // Get the coordinates from the ModelState for persistence
+    m_etadata.extractCoordinates(initialState);
+
     modelStep.setData(pData);
     modelStep.setMetadata(m_etadata);
     pData.setData(initialState.data);
@@ -165,7 +169,10 @@ void Model::writeRestartFile()
     modelConfig.merge(pData.getStateRecursive(true).config);
     modelConfig.merge(ConfiguredModule::getAllModuleConfigurations());
     m_etadata.setConfig(modelConfig);
-    StructureFactory::fileFromState(pData.getState(), m_etadata, finalFileName, true);
+    // Get the model state from PrognosticData and add the coordinates.
+    ModelState state = pData.getState();
+    m_etadata.affixCoordinates(state);
+    StructureFactory::fileFromState(state, m_etadata, finalFileName, true);
 }
 
 ModelMetadata& Model::metadata() { return m_etadata; }

--- a/core/src/ModelMetadata.cpp
+++ b/core/src/ModelMetadata.cpp
@@ -28,7 +28,9 @@ void ModelMetadata::setMpiMetadata(MPI_Comm comm)
 
 const ModelState& ModelMetadata::extractCoordinates(const ModelState& state)
 {
-    m_vertexCoords = state.data.at(coordsName);
+    if (state.data.count(coordsName) > 0) {
+        m_vertexCoords = state.data.at(coordsName);
+    }
 
     isCartesian = state.data.count(xName);
     if (isCartesian) {
@@ -47,7 +49,9 @@ const ModelState& ModelMetadata::extractCoordinates(const ModelState& state)
 
 ModelState& ModelMetadata::affixCoordinates(ModelState& state) const
 {
-    state.data[coordsName] = m_vertexCoords;
+    if (m_vertexCoords.trueSize() > 0) {
+        state.data[coordsName] = m_vertexCoords;
+    }
 
     if (isCartesian) {
         state.data[xName] = m_coord1;

--- a/core/src/ModelMetadata.cpp
+++ b/core/src/ModelMetadata.cpp
@@ -28,20 +28,23 @@ void ModelMetadata::setMpiMetadata(MPI_Comm comm)
 
 const ModelState& ModelMetadata::extractCoordinates(const ModelState& state)
 {
+    // More sophisticated grids include both vertex coordinates and grid azimuth values.
     if (state.data.count(coordsName) > 0) {
         m_vertexCoords = state.data.at(coordsName);
+        m_gridAzimuth = state.data.at(gridAzimuthName);
+        hasParameters = true;
+    } else {
+        // else don't resize the arrays
+        hasParameters = false;
     }
 
     isCartesian = state.data.count(xName);
     if (isCartesian) {
         m_coord1 = state.data.at(xName);
         m_coord2 = state.data.at(yName);
-        m_gridAzimuth.resize();
-        m_gridAzimuth = 0;
     } else {
         m_coord1 = state.data.at(longitudeName);
         m_coord2 = state.data.at(latitudeName);
-        m_gridAzimuth = state.data.at(gridAzimuthName);
     }
 
     return state;
@@ -49,8 +52,9 @@ const ModelState& ModelMetadata::extractCoordinates(const ModelState& state)
 
 ModelState& ModelMetadata::affixCoordinates(ModelState& state) const
 {
-    if (m_vertexCoords.trueSize() > 0) {
+    if (hasParameters) {
         state.data[coordsName] = m_vertexCoords;
+        state.data[gridAzimuthName] = m_gridAzimuth;
     }
 
     if (isCartesian) {
@@ -59,7 +63,6 @@ ModelState& ModelMetadata::affixCoordinates(ModelState& state) const
     } else {
         state.data[longitudeName] = m_coord1;
         state.data[latitudeName] = m_coord2;
-        state.data[gridAzimuthName] = m_gridAzimuth;
     }
     return state;
 }

--- a/core/src/ModelMetadata.cpp
+++ b/core/src/ModelMetadata.cpp
@@ -7,8 +7,8 @@
 
 #include "include/ModelMetadata.hpp"
 
-#include "include/gridNames.hpp"
 #include "include/StructureModule.hpp"
+#include "include/gridNames.hpp"
 
 namespace Nextsim {
 

--- a/core/src/ModelMetadata.cpp
+++ b/core/src/ModelMetadata.cpp
@@ -7,6 +7,7 @@
 
 #include "include/ModelMetadata.hpp"
 
+#include "include/gridNames.hpp"
 #include "include/StructureModule.hpp"
 
 namespace Nextsim {
@@ -25,4 +26,37 @@ void ModelMetadata::setMpiMetadata(MPI_Comm comm)
 }
 #endif
 
+const ModelState& ModelMetadata::extractCoordinates(const ModelState& state)
+{
+    m_vertexCoords = state.data.at(coordsName);
+
+    isCartesian = state.data.count(xName);
+    if (isCartesian) {
+        m_coord1 = state.data.at(xName);
+        m_coord2 = state.data.at(yName);
+        m_gridAzimuth.resize();
+        m_gridAzimuth = 0;
+    } else {
+        m_coord1 = state.data.at(longitudeName);
+        m_coord2 = state.data.at(latitudeName);
+        m_gridAzimuth = state.data.at(gridAzimuthName);
+    }
+
+    return state;
+}
+
+ModelState& ModelMetadata::affixCoordinates(ModelState& state) const
+{
+    state.data[coordsName] = m_vertexCoords;
+
+    if (isCartesian) {
+        state.data[xName] = m_coord1;
+        state.data[yName] = m_coord2;
+    } else {
+        state.data[longitudeName] = m_coord1;
+        state.data[latitudeName] = m_coord2;
+        state.data[gridAzimuthName] = m_gridAzimuth;
+    }
+    return state;
+}
 } /* namespace Nextsim */

--- a/core/src/ParaGridIO.cpp
+++ b/core/src/ParaGridIO.cpp
@@ -221,8 +221,8 @@ void ParaGridIO::dumpModelState(
     }
 
     std::set<std::string> restartFields = { hiceName, ciceName, hsnowName, ticeName, sstName,
-        sssName, maskName, coordsName }; // TODO and others
-    // Loop through either the above list (isRestart) or all provided fields(!isRestart)
+        sssName, maskName, coordsName, xName, yName, longitudeName, latitudeName, gridAzimuthName }; // TODO and others
+    // If the above fields are found in the supplied ModelState, output them
     for (auto entry : state.data) {
         if (restartFields.count(entry.first)) {
             // Get the type, then relevant vector of NetCDF dimensions

--- a/core/src/ParaGridIO.cpp
+++ b/core/src/ParaGridIO.cpp
@@ -220,8 +220,9 @@ void ParaGridIO::dumpModelState(
         dimMap.at(entry.second).push_back(ncFromMAMap.at(entry.first));
     }
 
-    std::set<std::string> restartFields = { hiceName, ciceName, hsnowName, ticeName, sstName,
-        sssName, maskName, coordsName, xName, yName, longitudeName, latitudeName, gridAzimuthName }; // TODO and others
+    std::set<std::string> restartFields
+        = { hiceName, ciceName, hsnowName, ticeName, sstName, sssName, maskName, coordsName, xName,
+              yName, longitudeName, latitudeName, gridAzimuthName }; // TODO and others
     // If the above fields are found in the supplied ModelState, output them
     for (auto entry : state.data) {
         if (restartFields.count(entry.first)) {

--- a/core/src/RectGridIO.cpp
+++ b/core/src/RectGridIO.cpp
@@ -118,7 +118,7 @@ ModelState RectGridIO::getModelState(const std::string& filePath)
     size[0] = metadata.localExtentY;
     size[1] = metadata.localExtentX;
 #else
-    std::vector<size_t> start = {0, 0};
+    std::vector<size_t> start = { 0, 0 };
     std::vector<size_t> size = ModelArray::dimensions(ModelArray::Type::H);
     std::reverse(size.begin(), size.end());
 #endif
@@ -131,7 +131,7 @@ ModelState RectGridIO::getModelState(const std::string& filePath)
     state.data[hsnowName] = ModelArray::HField();
     dataGroup.getVar(hsnowName).getVar(start, size, &state.data[hsnowName][0]);
     // coordinates on the H grid
-    if (dataGroup.getVars().count(xName) > 0){
+    if (dataGroup.getVars().count(xName) > 0) {
         state.data[xName] = ModelArray::HField();
         dataGroup.getVar(xName).getVar(start, size, &state.data[xName][0]);
         state.data[yName] = ModelArray::HField();

--- a/core/src/RectGridIO.cpp
+++ b/core/src/RectGridIO.cpp
@@ -130,7 +130,21 @@ ModelState RectGridIO::getModelState(const std::string& filePath)
     dataGroup.getVar(ciceName).getVar(start, size, &state.data[ciceName][0]);
     state.data[hsnowName] = ModelArray::HField();
     dataGroup.getVar(hsnowName).getVar(start, size, &state.data[hsnowName][0]);
-
+    // coordinates on the H grid
+    if (dataGroup.getVars().count(xName) > 0){
+        state.data[xName] = ModelArray::HField();
+        dataGroup.getVar(xName).getVar(start, size, &state.data[xName][0]);
+        state.data[yName] = ModelArray::HField();
+        dataGroup.getVar(yName).getVar(start, size, &state.data[yName][0]);
+    } else {
+        state.data[longitudeName] = ModelArray::HField();
+        dataGroup.getVar(longitudeName).getVar(start, size, &state.data[longitudeName][0]);
+        state.data[latitudeName] = ModelArray::HField();
+        dataGroup.getVar(latitudeName).getVar(start, size, &state.data[latitudeName][0]);
+        state.data[gridAzimuthName] = ModelArray::HField();
+        dataGroup.getVar(gridAzimuthName).getVar(start, size, &state.data[gridAzimuthName][0]);
+    }
+    // Need to read coords as VERTEX type, correctly partitioned
 
     // Z direction is outside MPI ifdef as the domain is never decomposed in this direction
 

--- a/core/src/RectGridIO.cpp
+++ b/core/src/RectGridIO.cpp
@@ -141,10 +141,7 @@ ModelState RectGridIO::getModelState(const std::string& filePath)
         dataGroup.getVar(longitudeName).getVar(start, size, &state.data[longitudeName][0]);
         state.data[latitudeName] = ModelArray::HField();
         dataGroup.getVar(latitudeName).getVar(start, size, &state.data[latitudeName][0]);
-        state.data[gridAzimuthName] = ModelArray::HField();
-        dataGroup.getVar(gridAzimuthName).getVar(start, size, &state.data[gridAzimuthName][0]);
     }
-    // Need to read coords as VERTEX type, correctly partitioned
 
     // Z direction is outside MPI ifdef as the domain is never decomposed in this direction
 

--- a/core/src/RectGridIO.cpp
+++ b/core/src/RectGridIO.cpp
@@ -96,25 +96,6 @@ ModelState RectGridIO::getModelState(const std::string& filePath)
     dimensionSetter(dataGroup, hiceName, ModelArray::Type::V, metadata);
     // ZField from tice
     dimensionSetter(dataGroup, ticeName, ModelArray::Type::Z, metadata);
-
-    // Set the origins and extensions for reading 2D data based
-    // on MPI decomposition
-    std::vector<size_t> start(2);
-    std::vector<size_t> size(2);
-    start[0] = metadata.localCornerY;
-    start[1] = metadata.localCornerX;
-    size[0] = metadata.localExtentY;
-    size[1] = metadata.localExtentX;
-
-    state.data[maskName] = ModelArray::HField();
-    dataGroup.getVar(maskName).getVar(start, size, &state.data[maskName][0]);
-    state.data[hiceName] = ModelArray::HField();
-    dataGroup.getVar(hiceName).getVar(start, size, &state.data[hiceName][0]);
-    state.data[ciceName] = ModelArray::HField();
-    dataGroup.getVar(ciceName).getVar(start, size, &state.data[ciceName][0]);
-    state.data[hsnowName] = ModelArray::HField();
-    dataGroup.getVar(hsnowName).getVar(start, size, &state.data[hsnowName][0]);
-
 #else
     // Get the sizes of the four types of field
     // HField from hice
@@ -125,16 +106,32 @@ ModelState RectGridIO::getModelState(const std::string& filePath)
     dimensionSetter(dataGroup, hiceName, ModelArray::Type::V);
     // ZField from tice
     dimensionSetter(dataGroup, ticeName, ModelArray::Type::Z);
-
-    state.data[maskName] = ModelArray::HField();
-    dataGroup.getVar(maskName).getVar(&state.data[maskName][0]);
-    state.data[hiceName] = ModelArray::HField();
-    dataGroup.getVar(hiceName).getVar(&state.data[hiceName][0]);
-    state.data[ciceName] = ModelArray::HField();
-    dataGroup.getVar(ciceName).getVar(&state.data[ciceName][0]);
-    state.data[hsnowName] = ModelArray::HField();
-    dataGroup.getVar(hsnowName).getVar(&state.data[hsnowName][0]);
 #endif
+
+#ifdef USE_MPI
+    // Set the origins and extensions for reading 2D data based
+    // on MPI decomposition
+    std::vector<size_t> start(2);
+    std::vector<size_t> size(2);
+    start[0] = metadata.localCornerY;
+    start[1] = metadata.localCornerX;
+    size[0] = metadata.localExtentY;
+    size[1] = metadata.localExtentX;
+#else
+    std::vector<size_t> start = {0, 0};
+    std::vector<size_t> size = ModelArray::dimensions(ModelArray::Type::H);
+    std::reverse(size.begin(), size.end());
+#endif
+    state.data[maskName] = ModelArray::HField();
+    dataGroup.getVar(maskName).getVar(start, size, &state.data[maskName][0]);
+    state.data[hiceName] = ModelArray::HField();
+    dataGroup.getVar(hiceName).getVar(start, size, &state.data[hiceName][0]);
+    state.data[ciceName] = ModelArray::HField();
+    dataGroup.getVar(ciceName).getVar(start, size, &state.data[ciceName][0]);
+    state.data[hsnowName] = ModelArray::HField();
+    dataGroup.getVar(hsnowName).getVar(start, size, &state.data[hsnowName][0]);
+
+
     // Z direction is outside MPI ifdef as the domain is never decomposed in this direction
 
     // Since the ZFierld might not have the same dimensions as the tice field

--- a/core/src/finitevolume/ModelArrayDetails.cpp
+++ b/core/src/finitevolume/ModelArrayDetails.cpp
@@ -18,6 +18,8 @@ std::map<ModelArray::Dimension, ModelArray::DimensionSpec> ModelArray::definedDi
     { ModelArray::Dimension::X, { "x", 0 } },
     { ModelArray::Dimension::Y, { "y", 0 } },
     { ModelArray::Dimension::Z, { "z", 1 } },
+    { ModelArray::Dimension::XVERTEX, { "xvertex", 1 } }, // defined as x + 1
+    { ModelArray::Dimension::YVERTEX, { "yvertex", 1 } }, // defined as y + 1
 };
 
 ModelArray::TypeDimensions ModelArray::typeDimensions = {
@@ -42,6 +44,11 @@ ModelArray::TypeDimensions ModelArray::typeDimensions = {
             ModelArray::Dimension::Y,
             ModelArray::Dimension::Z,
         } },
+        { ModelArray::Type::VERTEX,
+            {
+                ModelArray::Dimension::XVERTEX,
+                ModelArray::Dimension::YVERTEX,
+            } },
 };
 
 const std::map<ModelArray::Type, std::string> ModelArray::typeNames = {
@@ -49,6 +56,7 @@ const std::map<ModelArray::Type, std::string> ModelArray::typeNames = {
     { ModelArray::Type::U, "UField" },
     { ModelArray::Type::V, "VField" },
     { ModelArray::Type::Z, "ZField" },
+    { ModelArray::Type::VERTEX, "VertexField" },
 };
 
 ModelArray::ModelArray()
@@ -56,10 +64,10 @@ ModelArray::ModelArray()
 {
 }
 
-bool ModelArray::hasDoF(const Type type) { return false; }
+bool ModelArray::hasDoF(const Type type) { return type == Type::VERTEX; }
 
 ModelArray::SizeMap::SizeMap()
-    : m_sizes({ { Type::H, 0 }, { Type::U, 0 }, { Type::V, 0 }, { Type::Z, 0 } })
+    : m_sizes({ { Type::H, 0 }, { Type::U, 0 }, { Type::V, 0 }, { Type::Z, 0 },  { Type::VERTEX, 1 }, })
 {
 }
 
@@ -69,10 +77,15 @@ ModelArray::DimensionMap::DimensionMap()
         { Type::U, { 0 } },
         { Type::V, { 0 } },
         { Type::Z, { 0, 1 } },
+        { Type::VERTEX, { 1, 1 } },
     })
 {
 }
 
-const std::map<ModelArray::Type, ModelArray::Dimension> ModelArray::componentMap = {};
+const size_t ModelArray::nCoords = 2;
+
+const std::map<ModelArray::Type, ModelArray::Dimension> ModelArray::componentMap = {
+        { Type::VERTEX, Dimension::NCOORDS },
+};
 
 }

--- a/core/src/finitevolume/include/ModelArrayDetails.hpp
+++ b/core/src/finitevolume/include/ModelArrayDetails.hpp
@@ -14,18 +14,22 @@
 // Should be grouped with a consistent ModelArrayTypedefs.hpp and
 // ModelArrayDetails.cpp
 
-enum class Dimension { X, Y, Z, COUNT };
+enum class Dimension { X, Y, Z, XVERTEX, YVERTEX, COUNT };
 
 enum class Type {
     H,
     U,
     V,
     Z,
+    VERTEX,
 };
 
 static ModelArray HField() { return ModelArray(Type::H); }
 static ModelArray UField() { return ModelArray(Type::U); }
 static ModelArray VField() { return ModelArray(Type::V); }
 static ModelArray ZField() { return ModelArray(Type::Z); }
+static ModelArray VertexField() { return ModelArray(Type::VERTEX); }
+
+const static size_t nCoords;
 
 #endif /* MODELARRAYDETAILS_HPP */

--- a/core/src/finitevolume/include/ModelArrayTypedefs.hpp
+++ b/core/src/finitevolume/include/ModelArrayTypedefs.hpp
@@ -14,3 +14,4 @@ typedef ModelArray HField;
 typedef ModelArray UField;
 typedef ModelArray VField;
 typedef ModelArray ZField;
+typedef ModelArray VertexField;

--- a/core/src/include/ModelArray.hpp
+++ b/core/src/include/ModelArray.hpp
@@ -234,7 +234,6 @@ public:
     //! Returns the size of a dimension
     static size_t size(Dimension dim) { return definedDimensions.at(dim).length; }
 
-
     //! Returns a read-only pointer to the underlying data buffer.
     const double* getData() const { return m_data.data(); }
 

--- a/core/src/include/ModelArray.hpp
+++ b/core/src/include/ModelArray.hpp
@@ -231,6 +231,9 @@ public:
     static size_t size(Type type) { return m_sz.at(type); }
     //! Returns the size of the data array of this object.
     size_t trueSize() const { return m_data.rows(); }
+    //! Returns the size of a dimension
+    static size_t size(Dimension dim) { return definedDimensions.at(dim).length; }
+
 
     //! Returns a read-only pointer to the underlying data buffer.
     const double* getData() const { return m_data.data(); }

--- a/core/src/include/ModelMetadata.hpp
+++ b/core/src/include/ModelMetadata.hpp
@@ -93,7 +93,6 @@ private:
     ModelArray m_gridAzimuth;
     // Are the coordinates Cartesian? x & y versus longitude and latitude
     bool isCartesian;
-
 };
 
 } /* namespace Nextsim */

--- a/core/src/include/ModelMetadata.hpp
+++ b/core/src/include/ModelMetadata.hpp
@@ -93,6 +93,8 @@ private:
     ModelArray m_gridAzimuth;
     // Are the coordinates Cartesian? x & y versus longitude and latitude
     bool isCartesian;
+    // Are the more complex coordinates stored?
+    bool hasParameters;
 };
 
 } /* namespace Nextsim */

--- a/core/src/include/ModelMetadata.hpp
+++ b/core/src/include/ModelMetadata.hpp
@@ -10,6 +10,7 @@
 
 #include "include/ConfigMap.hpp"
 #include "include/ModelArray.hpp"
+#include "include/ModelState.hpp"
 #include "include/Time.hpp"
 
 #include <string>
@@ -56,6 +57,20 @@ public:
     // The metadata writer should be a friend
     friend CommonRestartMetadata;
 
+    /*!
+     * @brief Extracts and sets the coordinate metadata from the given ModelState.
+     *
+     * @param state The given ModelState.
+     */
+    const ModelState& extractCoordinates(const ModelState& state);
+
+    /*!
+     * @brief Adds the coordinate metadata to the given ModelState.
+     *
+     * @param state The given ModelState.
+     */
+    ModelState& affixCoordinates(ModelState& state) const;
+
 #ifdef USE_MPI
     void setMpiMetadata(MPI_Comm comm);
 
@@ -76,6 +91,9 @@ private:
     ModelArray m_coord2;
     // Angle from model reference to grid north (+y for grids) TODO: what for meshes? N/A?
     ModelArray m_gridAzimuth;
+    // Are the coordinates Cartesian? x & y versus longitude and latitude
+    bool isCartesian;
+
 };
 
 } /* namespace Nextsim */

--- a/core/src/include/ModelMetadata.hpp
+++ b/core/src/include/ModelMetadata.hpp
@@ -9,6 +9,7 @@
 #define MODELMETADATA_HPP
 
 #include "include/ConfigMap.hpp"
+#include "include/ModelArray.hpp"
 #include "include/Time.hpp"
 
 #include <string>
@@ -67,6 +68,14 @@ public:
 private:
     TimePoint m_time;
     ConfigMap m_config;
+
+    // position coordinates on vertices
+    ModelArray m_vertexCoords;
+    // position coordinates of elements
+    ModelArray m_coord1;
+    ModelArray m_coord2;
+    // Angle from model reference to grid north (+y for grids) TODO: what for meshes? N/A?
+    ModelArray m_gridAzimuth;
 };
 
 } /* namespace Nextsim */

--- a/core/src/include/gridNames.hpp
+++ b/core/src/include/gridNames.hpp
@@ -33,6 +33,7 @@ static const std::string latitudeName = "latitude";
 static const std::string longitudeName = "longitude";
 static const std::string xName = "x";
 static const std::string yName = "y";
+static const std::string gridAzimuthName = "grid_azimuth";
 
 static const std::string mdiName = "missing_value";
 

--- a/core/src/include/gridNames.hpp
+++ b/core/src/include/gridNames.hpp
@@ -29,6 +29,10 @@ static const std::string uOceanName = "uocean";
 static const std::string vOceanName = "vocean";
 
 static const std::string coordsName = "coords";
+static const std::string latitudeName = "latitude";
+static const std::string longitudeName = "longitude";
+static const std::string xName = "x";
+static const std::string yName = "y";
 
 static const std::string mdiName = "missing_value";
 


### PR DESCRIPTION
# Persist the grid coordinates
## Fixes \#367

# Change Description

Store the coordinate data from the initial file in `ModelMetadata` and output it again in diagnostic and restart files.

---

# Test Description

Add assertions testing the writing and reading of the coordinates to the `RectGrid` and `ParaGrid` tests.
