### PR TITLE
Free drift dynamics

### DIFF
--- a/dynamics/src/cgParametricMomentum.cpp
+++ b/dynamics/src/cgParametricMomentum.cpp
@@ -564,6 +564,23 @@ void CGParametricMomentum<CG>::MEBStep(const MEBParameters& params,
     avg_vx += vx/NT_meb;
     avg_vy += vy/NT_meb;   
   }
+
+template <int CG>
+template <int DG>
+void CGParametricMomentum<CG>::FreeDriftStep(const FDParameters& params, size_t nt_fd,
+        double dt_adv, const DGVector<DG>& H, const DGVector<DG>& A, DGVector<DG>& D)
+{
+#pragma omp parallel for
+    for (int i = 0; i < vx.rows(); ++i) {
+        // Ice velocity is equal to ocean velocity
+        vx(i) = ox(i);
+        vy(i) = oy(i);
+    }
+    DirichletZero();
+    avg_vx = vx;
+    avg_vy = vy;
+}
+
   // --------------------------------------------------
 
   template class CGParametricMomentum<1>;

--- a/dynamics/src/include/cgParametricMomentum.hpp
+++ b/dynamics/src/include/cgParametricMomentum.hpp
@@ -184,6 +184,15 @@ public:
     void BBMStep(const MEBParameters& vpparameters, size_t NT_meb,
         double dt_adv, const DGVector<DG>& H, const DGVector<DG>& A, DGVector<DG>& D);
 
+    // An empty structure so that the free drift step function signature
+    // matches the other step functions.
+    struct FDParameters {
+    };
+
+    //! Performs one step of freedrift dynamics
+    template<int DG>
+    void FreeDriftStep(const FDParameters& params, size_t nt_fd,
+            double dt_adv, const DGVector<DG>& H, const DGVector<DG>& A, DGVector<DG>& D);
 
     /*!
      * The following functions take care of the interpolation and projection


### PR DESCRIPTION
# Free drift dynamics
## Fixes \#453

---

# Change Description

Add a free drift equivalent to MEVPStep and BBMStep. Running this depends on implementing the dynamics switcher (closing #378).

---

# Test Description

Not yet. Should be tested once this form of dynamics can be tested.

---

# Documentation Impact

The free drift dynamics step needs to be documented along with the other available dynamics steps.
