### PR TITLE
Duration defaults

### DIFF
--- a/core/src/DevStep.cpp
+++ b/core/src/DevStep.cpp
@@ -49,7 +49,6 @@ void DevStep::setRestartDetails(const Duration& restartPeriod, const std::string
 {
     /*
      * A restart period of zero means zero intermediate restart files.
-     * Use 10 000 years as the period.
      */
     m_restartPeriod = restartPeriod;
     m_restartFileName = fileName;

--- a/core/src/DevStep.cpp
+++ b/core/src/DevStep.cpp
@@ -8,16 +8,14 @@
 #include "include/DevStep.hpp"
 
 #include "include/ConfiguredModule.hpp"
-#include "include/DiagnosticOutputModule.hpp"
-
+#include "include/IDiagnosticOutput.hpp"
+#include "include/Module.hpp"
 namespace Nextsim {
-
-const Duration DevStep::myriadJulianYears = Duration(3.15576e11);
 
 DevStep::DevStep()
     : pData(nullptr)
     , mData(nullptr)
-    , m_restartPeriod(3.1536e11) // 10 000 years of 365 days
+    , m_restartPeriod(0)
 {
 }
 
@@ -36,7 +34,7 @@ void DevStep::iterate(const TimestepTime& tst)
     // The state of the model has now advanced by one timestep, so update the
     // model metadata timestamp.
     mData->incrementTime(tst.step);
-    if (mData->time() >= lastOutput + m_restartPeriod) {
+    if ((m_restartPeriod.seconds() > 0) && (mData->time() >= lastOutput + m_restartPeriod)) {
         std::string currentFileName = mData->time().format(m_restartFileName);
         pData->writeRestartFile(currentFileName);
         lastOutput = mData->time();
@@ -53,7 +51,7 @@ void DevStep::setRestartDetails(const Duration& restartPeriod, const std::string
      * A restart period of zero means zero intermediate restart files.
      * Use 10 000 years as the period.
      */
-    m_restartPeriod = (restartPeriod.seconds() != 0 ? restartPeriod : myriadJulianYears);
+    m_restartPeriod = restartPeriod;
     m_restartFileName = fileName;
 }
 

--- a/core/src/DevStep.cpp
+++ b/core/src/DevStep.cpp
@@ -12,6 +12,8 @@
 
 namespace Nextsim {
 
+const Duration DevStep::myriadJulianYears = Duration(3.15576e11);
+
 DevStep::DevStep()
     : pData(nullptr)
     , mData(nullptr)
@@ -47,7 +49,11 @@ void DevStep::iterate(const TimestepTime& tst)
 
 void DevStep::setRestartDetails(const Duration& restartPeriod, const std::string& fileName)
 {
-    m_restartPeriod = restartPeriod;
+    /*
+     * A restart period of zero means zero intermediate restart files.
+     * Use 10 000 years as the period.
+     */
+    m_restartPeriod = (restartPeriod.seconds() != 0 ? restartPeriod : myriadJulianYears);
     m_restartFileName = fileName;
 }
 

--- a/core/src/Model.cpp
+++ b/core/src/Model.cpp
@@ -164,9 +164,10 @@ Model::HelpMap& Model::getHelpText(HelpMap& map, bool getAll)
             "Model physics timestep, formatted as an ISO8601 duration (P prefix). " },
         { keyMap.at(RESTARTFILE_KEY), ConfigType::STRING, {}, "", "",
             "The file path to the restart file to use for the run." },
-        { keyMap.at(RESTARTPERIOD_KEY), ConfigType::STRING, {}, "", "",
+        { keyMap.at(RESTARTPERIOD_KEY), ConfigType::STRING, {}, "0", "",
             "The period between restart file outputs, formatted as an ISO8601 duration (P prefix) "
-            "or number of seconds." },
+            "or number of seconds. A value of zero defaults to 10 000 years to ensure no "
+            "intermediate restart files are written." },
         { keyMap.at(MISSINGVALUE_KEY), ConfigType::NUMERIC, { "-∞", "∞" }, "-2³⁰⁰", "",
             "Missing data indicator used for input and output." },
 #ifdef USE_MPI

--- a/core/src/Model.cpp
+++ b/core/src/Model.cpp
@@ -165,9 +165,9 @@ Model::HelpMap& Model::getHelpText(HelpMap& map, bool getAll)
         { keyMap.at(RESTARTFILE_KEY), ConfigType::STRING, {}, "", "",
             "The file path to the restart file to use for the run." },
         { keyMap.at(RESTARTPERIOD_KEY), ConfigType::STRING, {}, "0", "",
-            "The period between restart file outputs, formatted as an ISO8601 duration (P prefix) "
-            "or number of seconds. A value of zero defaults to 10 000 years to ensure no "
-            "intermediate restart files are written." },
+            "The period between restart file outputs, formatted as an ISO8601 "
+            "duration (P prefix) or number of seconds. A value of zero "
+            "ensures no intermediate restart files are written." },
         { keyMap.at(MISSINGVALUE_KEY), ConfigType::NUMERIC, { "-∞", "∞" }, "-2³⁰⁰", "",
             "Missing data indicator used for input and output." },
 #ifdef USE_MPI

--- a/core/src/Model.cpp
+++ b/core/src/Model.cpp
@@ -130,7 +130,7 @@ void Model::configure()
 
     // The period with which to write restart files.
     std::string restartPeriodStr
-        = Configured::getConfiguration(keyMap.at(RESTARTPERIOD_KEY), std::string());
+        = Configured::getConfiguration(keyMap.at(RESTARTPERIOD_KEY), std::string("0"));
     restartPeriod = Duration(restartPeriodStr);
 
     // Get the coordinates from the ModelState for persistence

--- a/core/src/include/DevStep.hpp
+++ b/core/src/include/DevStep.hpp
@@ -46,8 +46,10 @@ private:
     PrognosticData* pData;
     ModelMetadata* mData;
     Duration m_restartPeriod;
-    TimePoint lastOutput;
+    TimePoint lastOutput; // The time a restart file was last output
     std::string m_restartFileName;
+    // If no intermediate restart files are required, set the restart period to a very long time.
+    static const Duration myriadJulianYears;
 };
 
 } /* namespace Nextsim */

--- a/core/src/include/DevStep.hpp
+++ b/core/src/include/DevStep.hpp
@@ -48,8 +48,6 @@ private:
     Duration m_restartPeriod;
     TimePoint lastOutput; // The time a restart file was last output
     std::string m_restartFileName;
-    // If no intermediate restart files are required, set the restart period to a very long time.
-    static const Duration myriadJulianYears;
 };
 
 } /* namespace Nextsim */

--- a/core/test/Time_test.cpp
+++ b/core/test/Time_test.cpp
@@ -164,6 +164,7 @@ TEST_CASE("Durations")
     Duration dur;
     // Basic values
     REQUIRE_THROWS(dur.parse("0-0-0T0:0:1"));
+    REQUIRE_THROWS(dur.parse(""));
     REQUIRE(dur.parse("P0-1").seconds() == 1 * days);
     REQUIRE(dur.parse("P0-0T0:0:1").seconds() == 1);
     REQUIRE(dur.parse("P-0-0T0:0:1").seconds() == -1);


### PR DESCRIPTION
# Duration defaults
## Fixes \#473

With the introduction of the intermediate restart file period (issue #239), the default value from the configuration file was an empty string. This is not parsed correctly by `Duration::parse()`.

Change the configuration default to "0", a duration of 0 seconds. This will then result in a restart file being written every timestep. So if the Duration between restart files is set to zero, instead set it to 10 000 years. I think it is safe to assume that if someone is doing a multi-10 000 year run, then they will want restart files with a shorter period than that.

---
# Test Description

Added a test condition to ensure that Duration::parse("") throws.
The single column thermodynamics configuration is intended as a test, and that is once again working, so tests this.

---
# Documentation Impact

Added text about the default behaviour to the online help system for the relevant option.
