### PR TITLE
Fix the crash at the end (issue #476)

### DIFF
--- a/core/src/include/Timer.hpp
+++ b/core/src/include/Timer.hpp
@@ -39,7 +39,7 @@ public:
      * @param rootKey Name of the root node.
      */
     Timer(const Key& rootKey);
-    virtual ~Timer() = default;
+    ~Timer() { reset(); }
 
     /*!
      * @brief Starts a named timer.

--- a/core/src/include/Timer.hpp
+++ b/core/src/include/Timer.hpp
@@ -39,7 +39,7 @@ public:
      * @param rootKey Name of the root node.
      */
     Timer(const Key& rootKey);
-    ~Timer() { reset(); }
+    ~Timer() = default;
 
     /*!
      * @brief Starts a named timer.


### PR DESCRIPTION
# Fix a crash at the end
## Fixes \#476

### Task List
- [ ] Defined the tests that specify a complete and functioning change (*It may help to create a [design specification & test specification](../../../wiki/Specification-Template)*)
- [ ] Implemented the source code change that satisfies the tests
- [ ] Documented the feature by providing worked example
- [ ] Updated the README or other documentation
- [ ] Completed the pre-Request checklist below

---
# Change Description

I fix the crash at the end by replacing the destructor of Timer (in Timer.hpp). This seems to work, but I wonder if there are side effects because there are two constructors, Timer() and Timer(const Key& rootKey), and because the destructor is no longer a virtual function.

---
# Test Description

Run cmake with CMAKE_BUILD_TYPE=Release, and compile the model from scratch. Run either the thermodynamics or june23 integration tests. These should run to the end, but end with a segmentation fault (signal 11).

---
# Documentation Impact

None

---
# Other Details

None

---
### Pre-Request Checklist

- [ ] The requirements of this pull request are fully captured in an issue or design specification and are linked and summarised in the description of this PR
- [ ] No new warnings are generated
- [ ] The documentation has been updated (or an issue has been created to track the corresponding change)
- [ ] Methods and Tests are commented such that they can be understood without having to obtain additional context
- [ ] This PR/Issue is labelled as a bug/feature/enhancement/breaking change
- [ ] File dates have been updated to reflect modification date
- [ ] This change conforms to the conventions described in the README
