### PR TITLE
Coordinates for the 'simple rectangular' test

### DIFF
--- a/core/src/CommandLineParser.cpp
+++ b/core/src/CommandLineParser.cpp
@@ -63,7 +63,6 @@ CommandLineParser::CommandLineParser(int argc, char* argv[])
     }
 
     m_configHelp.clear();
-    std::cerr << "cleared m_configHelp" << std::endl;
     // Store the config file names in order. The variables_map does not.
     for (auto& lionOption : parsed.options) {
         if (lionOption.string_key == oneConfigFile || lionOption.string_key == manyConfigFiles) {

--- a/run/config_simple_example.cfg
+++ b/run/config_simple_example.cfg
@@ -3,3 +3,4 @@ init_file = init_rect30x30.nc
 start = 2010-04-01T00:00:00Z
 stop = 2010-04-02T00:00:00Z
 time_step = P0-0T0:10:0
+missing_value = -3.40282346638e+38

--- a/run/make_init.py
+++ b/run/make_init.py
@@ -30,6 +30,9 @@ datagrp = root.createGroup("data")
 x_dim = datagrp.createDimension("x", nx)
 y_dim = datagrp.createDimension("y", ny)
 z_dim = datagrp.createDimension("z", nLayers)
+xvertex_dim = datagrp.createDimension("xvertex", nx + 1)
+yvertex_dim = datagrp.createDimension("yvertex", ny + 1)
+coords_dim = datagrp.createDimension("ncoords", n_coords)
 
 hfield_dims = ("y", "x")
 
@@ -114,5 +117,28 @@ hsnow[:,:] = hsnow[:,:] * mask[:,:] + antimask * mdi
 hsnow.missing_value = mdi
 tice[0,:,:] = tice[0,:,:] * mask[:,:] + antimask * mdi
 tice.missing_value = mdi
+
+# coordinates
+# element centres
+x_var = datagrp.createVariable("x", "f8", hfield_dims)
+y_var = datagrp.createVariable("y", "f8", hfield_dims)
+
+d_distance = 150000 # 150 km element spacing
+
+for j in range(0, ny):
+    y = (j + 0.5) * d_distance
+    for i in range(0, nx):
+        x = (i + 0.5) * d_distance
+        x_var[j, i] = x
+        y_var[j, i] = y
+
+coords = datagrp.createVariable("coords", "f8", ("yvertex", "xvertex", "ncoords"))
+
+for j in range(0, ny + 1):
+    y = j * d_distance
+    for i in range(0, nx + 1):
+        x = i * d_distance
+        coords[j, i, 0] = x
+        coords[j, i, 1] = y
 
 root.close()

--- a/run/make_init.py
+++ b/run/make_init.py
@@ -7,6 +7,7 @@ import netCDF4
 nx = 30
 ny = 30
 nLayers = 1
+n_coords = 2
 
 root = netCDF4.Dataset(f"init_rect{nx}x{ny}.nc", "w", format="NETCDF4")
 
@@ -26,9 +27,9 @@ formatted[0] = "2000-01-01T00:00:00Z"
 
 datagrp = root.createGroup("data")
 
-xDim = datagrp.createDimension("x", nx)
-yDim = datagrp.createDimension("y", ny)
-nLay = datagrp.createDimension("nLayers", nLayers)
+x_dim = datagrp.createDimension("x", nx)
+y_dim = datagrp.createDimension("y", ny)
+z_dim = datagrp.createDimension("z", nLayers)
 
 hfield_dims = ("y", "x")
 
@@ -100,7 +101,7 @@ hice = datagrp.createVariable("hice", "f8", hfield_dims)
 hice[:,:] = cice[:,:] * 2
 hsnow = datagrp.createVariable("hsnow", "f8", hfield_dims)
 hsnow[:,:] = cice[:,:] / 2
-tice = datagrp.createVariable("tice", "f8", ("nLayers", "y", "x"))
+tice = datagrp.createVariable("tice", "f8", ("z", "y", "x"))
 tice[0,:,:] = -0.5 - cice[:,:]
 
 mdi = -3.40282347e38 # Minus float max

--- a/run/make_init.py
+++ b/run/make_init.py
@@ -103,7 +103,7 @@ hsnow[:,:] = cice[:,:] / 2
 tice = datagrp.createVariable("tice", "f8", ("nLayers", "y", "x"))
 tice[0,:,:] = -0.5 - cice[:,:]
 
-mdi = -2.**300
+mdi = -3.40282347e38 # Minus float max
 # mask data
 cice[:,:] = cice[:,:] * mask[:,:] + antimask * mdi
 cice.missing_value = mdi


### PR DESCRIPTION
# Coordinates for the 'simple rectangular' test
## Fixes \#485
---
# Change Description

Add coordinates to the `init_rect30x30.nc` restart file so that it is a valid restart file once again. The coordinates are generated in the `make_init.py` Python script along with the rest of the file. They consist of an `x` and a `y` array for element centres and a `coords` array containing the _x_ and _y_ coordinates of the vertices. The origin is the bottom left vertex of element (0, 0) so all coordinates are non-negative. The grid spacing is 150 km.

Also remove an errant debug print statement from the command line parser.

---
# Test Description

Running the `run_simple_example.sh` script works once again.
