### PR TITLE
Rename bare class name to include MEVP

### DIFF
--- a/core/src/modules/DynamicsModule/MEVPDynamics.cpp
+++ b/core/src/modules/DynamicsModule/MEVPDynamics.cpp
@@ -1,12 +1,12 @@
 /*!
- * @file Dynamics.cpp
+ * @file MEVPDynamics.cpp
  *
  * @date 7 Sep 2023
  * @author Tim Spain <timothy.spain@nersc.no>
  * @author Piotr Minakowski <piotr.minakowski@ovgu.de>
  */
 
-#include "include/Dynamics.hpp"
+#include "include/MEVPDynamics.hpp"
 
 #include "include/gridNames.hpp"
 
@@ -17,14 +17,14 @@
 namespace Nextsim {
 
 static const std::vector<std::string> namedFields = { hiceName, ciceName, uName, vName };
-Dynamics::Dynamics()
+MEVPDynamics::MEVPDynamics()
         : IDynamics()
 {
     getStore().registerArray(Protected::ICE_U, &uice, RO);
     getStore().registerArray(Protected::ICE_V, &vice, RO);
 }
 
-void Dynamics::setData(const ModelState::DataMap& ms)
+void MEVPDynamics::setData(const ModelState::DataMap& ms)
 {
     IDynamics::setData(ms);
 
@@ -70,7 +70,7 @@ void Dynamics::setData(const ModelState::DataMap& ms)
     }
 }
 
-void Dynamics::update(const TimestepTime& tst)
+void MEVPDynamics::update(const TimestepTime& tst)
 {
     std::cout << tst.start << std::endl;
 

--- a/core/src/modules/DynamicsModule/include/Dynamics.hpp
+++ b/core/src/modules/DynamicsModule/include/Dynamics.hpp
@@ -9,9 +9,9 @@
 #ifndef DYNAMICS_HPP
 #define DYNAMICS_HPP
 
+#include "include/MEVPDynamicsKernel.hpp"
 #include "include/IDynamics.hpp"
 
-#include "../../../../../dynamics/src/include/DynamicsKernel.hpp"
 #include "include/ModelArray.hpp"
 #include "include/ModelComponent.hpp"
 
@@ -26,7 +26,7 @@ public:
     void setData(const ModelState::DataMap&) override;
 private:
     // TODO: How to get the template parameters here?
-    DynamicsKernel<2, 6> kernel;
+    MEVPDynamicsKernel<2, 6> kernel;
 };
 }
 

--- a/core/src/modules/DynamicsModule/include/MEVPDynamics.hpp
+++ b/core/src/modules/DynamicsModule/include/MEVPDynamics.hpp
@@ -1,5 +1,5 @@
 /*!
- * @file Dynamics.hpp
+ * @file MEVPDynamics.hpp
  *
  * @date 27 Mar 2023
  * @author Tim Spain <timothy.spain@nersc.no>
@@ -16,9 +16,9 @@
 #include "include/ModelComponent.hpp"
 
 namespace Nextsim {
-class Dynamics : public IDynamics {
+class MEVPDynamics : public IDynamics {
 public:
-    Dynamics();
+    MEVPDynamics();
 
     std::string getName() const override { return "Dynamics"; }
     void update(const TimestepTime& tst) override;

--- a/core/src/modules/DynamicsModule/module.cfg
+++ b/core/src/modules/DynamicsModule/module.cfg
@@ -12,7 +12,7 @@ description = No dynamics calculations.
 has_help = false
 is_default = true
 
-[Nextsim::Dynamics]
-file_prefix = Dynamics
+[Nextsim::MEVPDynamics]
+file_prefix = MEVPDynamics
 description = Discontinuous Galerkin dynamics with mEVP rheology.
 has_help = false

--- a/dynamics/src/MEVPDynamicsKernel.cpp
+++ b/dynamics/src/MEVPDynamicsKernel.cpp
@@ -6,12 +6,12 @@
  * @author Piotr Minakowski <piotr.minakowski@ovgu.de>
  */
 
-#include "include/DynamicsKernel.hpp"
+#include "include/MEVPDynamicsKernel.hpp"
 
 namespace Nextsim {
 
 template <int CGdegree, int DGadvection>
-const std::unordered_map<std::string, ModelArray::Type> DynamicsKernel<CGdegree, DGadvection>::fieldType = {
+const std::unordered_map<std::string, ModelArray::Type> MEVPDynamicsKernel<CGdegree, DGadvection>::fieldType = {
 
 };
 

--- a/dynamics/src/include/MEVPDynamicsKernel.hpp
+++ b/dynamics/src/include/MEVPDynamicsKernel.hpp
@@ -6,8 +6,8 @@
  * @author Piotr Minakowski <piotr.minakowski@ovgu.de>
  */
 
-#ifndef DYNAMICSKERNEL_HPP
-#define DYNAMICSKERNEL_HPP
+#ifndef MEVPDYNAMICSKERNEL_HPP
+#define MEVPDYNAMICSKERNEL_HPP
 
 #include "DGTransport.hpp"
 #include "Interpolations.hpp"
@@ -34,7 +34,7 @@
 
 namespace Nextsim {
 
-template <int CGdegree, int DGadvection> class DynamicsKernel {
+template <int CGdegree, int DGadvection> class MEVPDynamicsKernel {
 public:
     void initialisation(const ModelArray& coords, bool isSpherical, const ModelArray& mask)
     {
@@ -229,4 +229,4 @@ private:
 
 } /* namespace Nextsim */
 
-#endif /* DYNAMICSKERNEL_HPP */
+#endif /* MEVPDYNAMICSKERNEL_HPP */

--- a/run/config_dynamics_benchmark.cfg
+++ b/run/config_dynamics_benchmark.cfg
@@ -6,7 +6,7 @@ time_step = P0-0T00:02:00
 
 [Modules]
 DiagnosticOutputModule = Nextsim::ConfigOutput
-DynamicsModule = Nextsim::Dynamics
+DynamicsModule = Nextsim::MEVPDynamics
 IceThermodynamicsModule = Nextsim::DummyIceThermodynamics
 LateralIceSpreadModule = Nextsim::DummyIceSpread
 AtmosphereBoundaryModule = Nextsim::BenchmarkAtmosphere


### PR DESCRIPTION
# Rename bare class name to include MEVP
## Fixes \#378

---
# Change Description

Part of implementing the dynamics switcher is renaming the 'Dynamics' classes to include MEVP in their name. Several different issue branches related to the dynamics will touch these files, so it will be easier to have the renaming changes included in develop for basing the branches off.

---
# Test Description

N/A, only renames existing classes.
