### PR TITLE
Issue483 mpi doc

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -29,8 +29,8 @@ To compile neXtSIM, you need to install first some libraries :
   - `Boost`_
   - `CMake`_
 
-Compilation on MAC OS
----------------------
+Installing dependencies on on MAC OS
+------------------------------------
 
 If your package manager is `Homebrew`_ :
 
@@ -40,14 +40,9 @@ If your package manager is `Homebrew`_ :
         brew install boost
         brew install cmake
         
-        cd nextsimdg
-        mkdir -p build
-        cd build
-        cmake ..
-        make
         
-Compilation on Ubuntu
----------------------
+Installing dependencies on Ubuntu
+---------------------------------
 
 You must have root privilege :
 
@@ -55,16 +50,10 @@ You must have root privilege :
 
         sudo apt-get update
         sudo apt-get install netcdf-bin libnetcdf-c++4-dev libboost-all-dev cmake
-
-        cd nextsimdg
-        mkdir -p build
-        cd build
-        cmake ..
-        make
         
 
-Compilation with dependencies installation via conda
-----------------------------------------------------
+Installing dependencies via conda
+---------------------------------
 
 Install conda via anaconda or miniconda (no root privileges required)
 
@@ -75,12 +64,19 @@ Install conda via anaconda or miniconda (no root privileges required)
         conda install netCDF4
         conda -c conda-forge boost
         conda -c anaconda cmake
-        
+
+Building the code
+-----------------
+After all dependencies have been installed, we can build the code:
+
+.. code::
+
         cd nextsimdg
         mkdir -p build
         cd build
         cmake ..
         make
+
     
 .. _NetCDF: https://www.unidata.ucar.edu/software/netcdf/
 .. _Boost: https://www.boost.org/

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -29,8 +29,7 @@ To compile neXtSIM, you need to install first some libraries :
   - `Boost`_
   - `CMake`_
 
-Installing dependencies on on MAC OS
-------------------------------------
+**Installing dependencies on on MAC OS**
 
 If your package manager is `Homebrew`_ :
 
@@ -41,8 +40,7 @@ If your package manager is `Homebrew`_ :
         brew install cmake
         
         
-Installing dependencies on Ubuntu
----------------------------------
+**Installing dependencies on Ubuntu**
 
 You must have root privilege :
 
@@ -52,8 +50,7 @@ You must have root privilege :
         sudo apt-get install netcdf-bin libnetcdf-c++4-dev libboost-all-dev cmake
         
 
-Installing dependencies via conda
----------------------------------
+**Installing dependencies via conda**
 
 Install conda via anaconda or miniconda (no root privileges required)
 
@@ -76,6 +73,31 @@ After all dependencies have been installed, we can build the code:
         cd build
         cmake ..
         make
+
+Dependencies and Build for MPI Parallelisation
+----------------------------------------------
+
+To build the code with MPI support, we need to install the respective compiler as well as parallel NetCDF support.
+
+For example, on Debian-based Linux we need to also do:
+
+.. code::
+
+        sudo apt-get install libnetcdf-mpi-dev 
+        sudo apt-get install openmpi-bin libopenmpi-dev 
+
+The cmake call has to enable MPI support:
+
+.. code::
+
+        cmake .. -DENABLE_MPI=ON 
+
+You might need to tell cmake which compiler to use, e.g.
+
+.. code::
+
+        cmake .. -DCMAKE_CXX_COMPILER=/usr/bin/mpicxx -DENABLE_MPI=ON 
+
 
     
 .. _NetCDF: https://www.unidata.ucar.edu/software/netcdf/


### PR DESCRIPTION
# Pull Request Title
## Fixes \#483

### Changes

The documentation has been updated in the following way

- [x]  Split up installation and building instructions.
- -  Previously, the dependency installation and the build command were given under the same heading. This has now been separated.
- [x] Add information for MPI builds
-- Information about dependencies and changes in the cmake command to support MPI have been added
- [x] Consider removing conda install information (and potentially do it)
-- The documentation still gives the option to install the dependencies using a conda environment. Although this might not be the first choice for a C++ code, for some users this might be the preferred way.

