### PR TITLE
Add spack support

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -62,6 +62,47 @@ Install conda via anaconda or miniconda (no root privileges required)
         conda -c conda-forge boost
         conda -c anaconda cmake
 
+**Installing dependencies via spack**
+
+``spack`` is a package manager which was designed for HPC software. It is language agnostic and
+compiles binaries from source. See quote from ``spack``'s `documentation
+<https://spack.readthedocs.io/en/latest/>`_ below:
+
+   Spack is a package management tool designed to support multiple versions and configurations of
+   software on a wide variety of platforms and environments. It was designed for large supercomputing
+   centers, where many users and application teams share common installations of software on clusters
+   with exotic architectures, using libraries that do not have a standard ABI. Spack is
+   non-destructive: installing a new version does not break existing installations, so many
+   configurations can coexist on the same system.
+
+To install ``spack`` please follow instruction from their documentation (see `install instructions
+<https://spack.readthedocs.io/en/latest/getting_started.html#installation>`_).
+
+In the root directory of the repository there is a ``spack.yaml`` file which can be used to install
+all required dependencies. The following command will create a ``spack`` environment (called
+``nextsim`` in this example) and install the dependencies automatically:
+
+.. code::
+
+   spack env create nextsim spack.yaml
+
+.. note::
+
+   This will install by building from source. This can take a significant amount of time, depending
+   on packages available on your machine and how your spack install is configured. If you use a
+   clean install of ``spack`` this could take 15-50 minutes on a modern CPU with 4-8 cores. It is
+   hard to give an accurate measurement but the idea is to be patient. This only needs to be done
+   once however, and then it can be loaded in seconds whenever you need it.
+
+To use the installed dependencies, you will need to load them first. This can be done using:
+
+.. code::
+
+   spack env activate nextsim
+
+For more information on using ``spack`` environments please see `using environments
+<https://spack.readthedocs.io/en/latest/environments.html#using-environments>`_.
+
 Building the code
 -----------------
 After all dependencies have been installed, we can build the code:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -65,26 +65,19 @@ Install conda via anaconda or miniconda (no root privileges required)
 **Installing dependencies via spack**
 
 ``spack`` is a package manager which was designed for HPC software. It is language agnostic and
-compiles binaries from source. See quote from ``spack``'s `documentation
-<https://spack.readthedocs.io/en/latest/>`_ below:
-
-   Spack is a package management tool designed to support multiple versions and configurations of
-   software on a wide variety of platforms and environments. It was designed for large supercomputing
-   centers, where many users and application teams share common installations of software on clusters
-   with exotic architectures, using libraries that do not have a standard ABI. Spack is
-   non-destructive: installing a new version does not break existing installations, so many
-   configurations can coexist on the same system.
-
-To install ``spack`` please follow instruction from their documentation (see `install instructions
+compiles binaries from source. To install ``spack`` please follow instruction from their
+documentation (see `install instructions
 <https://spack.readthedocs.io/en/latest/getting_started.html#installation>`_).
 
 In the root directory of the repository there is a ``spack.yaml`` file which can be used to install
 all required dependencies. The following command will create a ``spack`` environment (called
-``nextsim`` in this example) and install the dependencies automatically:
+``nextsim`` in this example), load the ``spack`` environment and install the dependencies:
 
 .. code::
 
    spack env create nextsim spack.yaml
+   spack env activate nextsim
+   spack install
 
 .. note::
 
@@ -94,13 +87,16 @@ all required dependencies. The following command will create a ``spack`` environ
    hard to give an accurate measurement but the idea is to be patient. This only needs to be done
    once however, and then it can be loaded in seconds whenever you need it.
 
-To use the installed dependencies, you will need to load them first. This can be done using:
+To use the installed dependencies, you will need to load them first. If you are in the same bash
+session as the install they will be already loaded, but in future you can use the following command
+to activate the environment.
 
 .. code::
 
    spack env activate nextsim
 
-For more information on using ``spack`` environments please see `using environments
+To unload an environment you can use the handy (and very fun) alias of ``despacktivate``. For more
+information on using ``spack`` environments please see `using environments
 <https://spack.readthedocs.io/en/latest/environments.html#using-environments>`_.
 
 Building the code

--- a/spack.yaml
+++ b/spack.yaml
@@ -1,0 +1,8 @@
+spack:
+  specs:
+    - boost@1.80.0+log+program_options
+    - cmake@3.26.3
+    - eigen@3.4.0
+    - netcdf-c@4.9.2+mpi+parallel-netcdf
+    - netcdf-cxx4@4.3.1
+    - openmpi@4.1.2


### PR DESCRIPTION
Add `spack.yaml` to project. This will allow `spack` users to easily install dependencies.

I have also added documentation to explain how to:
* install `spack`
* install the dependencies into a `spack` environment
* use `spack` environments