### PR TITLE
Melt/issue378 dynamicsswitcher2

### DIFF
--- a/dynamics/src/CGDynamicsKernel.cpp
+++ b/dynamics/src/CGDynamicsKernel.cpp
@@ -110,7 +110,7 @@ void CGDynamicsKernel<DGadvection>::prepareIteration(const DataMap& data)
 template <int CG>
 Eigen::Matrix<double, CGDOFS(CG), 1> cgLocal(const CGVector<CG>& globalVelocity, int cgi, int cgShift);
 
-Eigen::Matrix<double, CGDOFS(1), 1> cgLocal(const CGVector<1>& vGlobal, int cgi, int cgShift)
+template<> Eigen::Matrix<double, CGDOFS(1), 1> cgLocal(const CGVector<1>& vGlobal, int cgi, int cgShift)
 {
     Eigen::Matrix<double, CGDOFS(1), 1> vLocal;
     vLocal << vGlobal(cgi), vGlobal(cgi + 1),
@@ -118,7 +118,7 @@ Eigen::Matrix<double, CGDOFS(1), 1> cgLocal(const CGVector<1>& vGlobal, int cgi,
     return vLocal;
 }
 
-Eigen::Matrix<double, CGDOFS(2), 1> cgLocal(const CGVector<2>& vGlobal, int cgi, int cgShift)
+template<> Eigen::Matrix<double, CGDOFS(2), 1> cgLocal(const CGVector<2>& vGlobal, int cgi, int cgShift)
 {
     Eigen::Matrix<double, CGDOFS(2), 1> vLocal;
     vLocal << vGlobal(cgi), vGlobal(cgi + 1), vGlobal(cgi + 2),

--- a/dynamics/src/include/CGDynamicsKernel.hpp
+++ b/dynamics/src/include/CGDynamicsKernel.hpp
@@ -20,6 +20,7 @@ namespace Nextsim {
 
 template <int DGadvection>
 class CGDynamicsKernel : public DynamicsKernel<DGadvection, DGstressDegree> {
+public:
     using DynamicsKernel<DGadvection, DGstressDegree>::s11;
     using DynamicsKernel<DGadvection, DGstressDegree>::s12;
     using DynamicsKernel<DGadvection, DGstressDegree>::s22;
@@ -32,7 +33,6 @@ class CGDynamicsKernel : public DynamicsKernel<DGadvection, DGstressDegree> {
     using typename DynamicsKernel<DGadvection, DGstressDegree>::DataMap;
 
 
-public:
     CGDynamicsKernel()
         : pmap(nullptr)
     {

--- a/dynamics/src/include/MEVPDynamicsKernel.hpp
+++ b/dynamics/src/include/MEVPDynamicsKernel.hpp
@@ -17,8 +17,8 @@ namespace Nextsim {
 
 template <int DGadvection>
 class MEVPDynamicsKernel : public VPCGDynamicsKernel<DGadvection> {
-using CGDynamicsKernel<DGadvection>::pmap;
 public:
+    using CGDynamicsKernel<DGadvection>::pmap;
     MEVPDynamicsKernel(const DynamicsParameters& paramsIn)
         : VPCGDynamicsKernel<DGadvection>(MEVPStressStep, paramsIn)
     {

--- a/dynamics/src/include/VPCGDynamicsKernel.hpp
+++ b/dynamics/src/include/VPCGDynamicsKernel.hpp
@@ -19,6 +19,7 @@ namespace Nextsim {
 // The VP pseudo-timestepping momentum equation solver for CG velocities
 template <int DGadvection>
 class VPCGDynamicsKernel : public CGDynamicsKernel<DGadvection> {
+public:
     using DynamicsKernel<DGadvection, DGstressDegree>::NT_evp;
     using DynamicsKernel<DGadvection, DGstressDegree>::s11;
     using DynamicsKernel<DGadvection, DGstressDegree>::s12;
@@ -45,7 +46,6 @@ class VPCGDynamicsKernel : public CGDynamicsKernel<DGadvection> {
     using CGDynamicsKernel<DGadvection>::dStressX;
     using CGDynamicsKernel<DGadvection>::dStressY;
     using CGDynamicsKernel<DGadvection>::pmap;
-public:
     VPCGDynamicsKernel(StressUpdateStep<DGadvection, DGstressDegree>& stressStepIn, const DynamicsParameters& paramsIn)
         : CGDynamicsKernel<DGadvection>(),
           stressStep(stressStepIn),


### PR DESCRIPTION
@timspainNERSC was getting an error when trying to compile branch relating to `undefined references`:

```
/usr/bin/ld: ../../libnextsimlib.so: undefined reference to `Eigen::Matrix<double, ((2)==(1))?(4) : (9), 1, ((Eigen::StorageOptions)0)|((((((2)==(1))?(4) : (9))==(1))&&((1)!=(1)))?((Eigen::StorageOptions)1) : ((((1)==(1))&&((((2)==(1))?(4) : (9))!=(1)))?((Eigen::StorageOptions)0) :
 ((Eigen::StorageOptions)0))), ((2)==(1))?(4) : (9), 1> Nextsim::cgLocal<2>(Nextsim::CGVector<2> const&, int, int)'                          
collect2: error: ld returned 1 exit status
```

This PR fixes the issue.

The key was missing `template<>` specifier.

https://github.com/nextsimhub/nextsimdg/blob/281915017acc8e659a688d78bc9e7c3a2a2d4697/dynamics/src/CGDynamicsKernel.cpp#L113

I'll be honest I am not super familiar with template specialization. I believe what you were trying to do is called [Explicit specializations of function templates](https://en.cppreference.com/w/cpp/language/template_specialization) (but don't quote me on it).

When compiling with `g++` I also had to make the `using` statements `public` in the kernel headers. I am not sure that this is necessary. I didn't try all combinations to see if I could just expose some and not all. So you might want to check this yourself.

 * `dynamics/src/include/CGDynamicsKernel.hpp`  
 * `dynamics/src/include/MEVPDynamicsKernel.hpp` 
 * `dynamics/src/include/VPCGDynamicsKernel.hpp` 

FYI I used the following mwe to figure it out. Compile and run with `g++ test.cpp && ./a.out `

<details>
<summary> test.cpp </summary>

```cpp

#include <cstddef>
#include <iostream>
using std::cout;

template<size_t S>
  struct Vector {
    int array[S];
  };

template<> struct Vector<1>{
    int array[1];
  };

template<> struct Vector<2>{
    float darry[2];
  };

template< size_t n > Vector<n> foo( )
{
  Vector<n> x;
  for (size_t i = 0; i < n; ++i) {
    x.array[i] = (i+1)*(i+1);
  }
  return x;
}

template<> Vector<1> foo( )
{
  Vector<1> x;
  for (size_t i = 0; i < 1; ++i) {
    x.array[i] = (i+1)*(i+1);
  }
  return x;
}

template<> Vector<2> foo( )
{
  Vector<2> x;
  for (size_t i = 0; i < 2; ++i) {
    x.darry[i] = (i+1)*(i+1) + 0.5;
  }
  return x;
}

int main()
{
  cout << "1=" << foo<1>().array[0] << ", 2=" << foo<2>().darry[0] << ", "<< foo<2>().darry[1] << "\n";
}
```
</details>