### PR TITLE
Install numpy from pip3.

### DIFF
--- a/.github/workflows/clang-compile-tests.yml
+++ b/.github/workflows/clang-compile-tests.yml
@@ -67,6 +67,7 @@ jobs:
         brew install boost
         brew install eigen
         brew install cmake
+        pip3 install numpy
         pip3 install netCDF4
     - name: make
       run: |


### PR DESCRIPTION
# Install numpy from pip3
## Fixes \#517

# Change Description

Presumably due to a change in the configuration of the CI MacOS image, there is an incompatibility between the supplied version of numpy and that that was used to compile the python netCDF4 library that is required to process the various python scripts that are included in the build process. This results in a failure when building the model for the MacOS CI workflow.

This can be fixed by using the version of numpy provided by `pip3`, which should match that used to build the netCDF4 python library, which is also installed using `pip3`.

---
# Test Description

The MacOS CI workflow now builds successfully.
