### PR TITLE
Free drift dynamics: now with dynamics switcher!

### DIFF
--- a/core/src/modules/DynamicsModule/include/FreeDriftDynamics.hpp
+++ b/core/src/modules/DynamicsModule/include/FreeDriftDynamics.hpp
@@ -21,7 +21,7 @@ class FreeDriftDynamics : public IDynamics {
 public:
     FreeDriftDynamics()
         : IDynamics()
-        , kernel()
+        , kernel(params)
     {
         getStore().registerArray(Protected::ICE_U, &uice, RO);
         getStore().registerArray(Protected::ICE_V, &vice, RO);
@@ -85,6 +85,7 @@ public:
 private:
     // TODO: How to get the template parameters here?
     FreeDriftDynamicsKernel<6> kernel;
+    DynamicsParameters params;
 };
 }
 

--- a/core/src/modules/DynamicsModule/include/FreeDriftDynamics.hpp
+++ b/core/src/modules/DynamicsModule/include/FreeDriftDynamics.hpp
@@ -18,8 +18,6 @@
 namespace Nextsim {
 static const std::vector<std::string> namedFields = { hiceName, ciceName, uName, vName };
 
-// Degrees to radians as a hex float
-static const double radians = 0x1.1df46a2529d39p-6;
 
 class FreeDriftDynamics : public IDynamics {
 public:
@@ -55,6 +53,9 @@ public:
 
     void setData(const ModelState::DataMap& ms) override
     {
+        // Degrees to radians as a hex float
+        static const double radians = 0x1.1df46a2529d39p-6;
+
         IDynamics::setData(ms);
 
         bool isSpherical = checkSpherical(ms);

--- a/core/src/modules/DynamicsModule/include/FreeDriftDynamics.hpp
+++ b/core/src/modules/DynamicsModule/include/FreeDriftDynamics.hpp
@@ -1,0 +1,91 @@
+/*!
+ * @file FreeDriftDynamics.hpp
+ *
+ * @date 27 Mar 2023
+ * @author Tim Spain <timothy.spain@nersc.no>
+ */
+
+#ifndef FREEDRIFTDYNAMICS_HPP
+#define FREEDRIFTDYNAMICS_HPP
+
+#include "include/FreeDriftDynamicsKernel.hpp"
+#include "include/IDynamics.hpp"
+
+#include "include/ModelArray.hpp"
+#include "include/ModelComponent.hpp"
+#include "include/gridNames.hpp"
+
+namespace Nextsim {
+static const std::vector<std::string> namedFields = { hiceName, ciceName, uName, vName };
+class FreeDriftDynamics : public IDynamics {
+public:
+    FreeDriftDynamics()
+        : IDynamics()
+        , kernel()
+    {
+        getStore().registerArray(Protected::ICE_U, &uice, RO);
+        getStore().registerArray(Protected::ICE_V, &vice, RO);
+    }
+
+    std::string getName() const override { return "FreeDriftDynamics"; }
+    void update(const TimestepTime& tst) override
+    {
+        std::cout << tst.start << std::endl;
+
+        // set the updated ice thickness and concentration
+        kernel.setData(hiceName, hice.data());
+        kernel.setData(ciceName, cice.data());
+
+        // set the forcing velocities
+        kernel.setData(uOceanName, uocean.data());
+        kernel.setData(vOceanName, vocean.data());
+
+        kernel.update(tst);
+
+        hice.data() = kernel.getDG0Data(hiceName);
+        cice.data() = kernel.getDG0Data(ciceName);
+
+        uice = kernel.getDG0Data(uName);
+        vice = kernel.getDG0Data(vName);
+    }
+
+    void setData(const ModelState::DataMap& ms) override
+    {
+        IDynamics::setData(ms);
+
+        bool isSpherical = checkSpherical(ms);
+
+        // TODO: Remove this when spherical coordinates are fully implemented
+        ModelArray coords;
+        if (isSpherical) {
+            std::cout << "Spherical coordinates are not yet implemented. Reverting to Cartesian." << std::endl;
+            isSpherical = false;
+            ModelArray fake25kmCoords(ModelArray::Type::VERTEX);
+            double d = 25000; // 25 km in metres
+            // Fill the fake coordinate array
+            for (size_t j = 0; j < ModelArray::size(ModelArray::Dimension::YVERTEX); ++j) {
+                for (size_t i = 0; i < ModelArray::size(ModelArray::Dimension::XVERTEX); ++i) {
+                    fake25kmCoords.components({i, j})[0] = d * i;
+                    fake25kmCoords.components({i, j})[1] = d * j;
+                }
+            }
+            coords = fake25kmCoords;
+            // End of code to be removed
+        } else {
+            coords = ms.at(coordsName);
+        }
+        kernel.initialise(coords, false, ms.at(maskName));
+
+        // Set the data in the kernel arrays.
+        for (const auto& fieldName : namedFields) {
+            kernel.setData(fieldName, ms.at(fieldName));
+        }
+    }
+
+private:
+    // TODO: How to get the template parameters here?
+    FreeDriftDynamicsKernel<6> kernel;
+};
+}
+
+#endif /* FREEDRIFTDYNAMICS_HPP */

--- a/core/src/modules/DynamicsModule/include/FreeDriftDynamics.hpp
+++ b/core/src/modules/DynamicsModule/include/FreeDriftDynamics.hpp
@@ -17,6 +17,10 @@
 
 namespace Nextsim {
 static const std::vector<std::string> namedFields = { hiceName, ciceName, uName, vName };
+
+// Degrees to radians as a hex float
+static const double radians = 0x1.1df46a2529d39p-6;
+
 class FreeDriftDynamics : public IDynamics {
 public:
     FreeDriftDynamics()
@@ -55,25 +59,11 @@ public:
 
         bool isSpherical = checkSpherical(ms);
 
-        // TODO: Remove this when spherical coordinates are fully implemented
-        ModelArray coords;
+        ModelArray coords = ms.at(coordsName);
         if (isSpherical) {
-            std::cout << "Spherical coordinates are not yet implemented. Reverting to Cartesian." << std::endl;
-            isSpherical = false;
-            ModelArray fake25kmCoords(ModelArray::Type::VERTEX);
-            double d = 25000; // 25 km in metres
-            // Fill the fake coordinate array
-            for (size_t j = 0; j < ModelArray::size(ModelArray::Dimension::YVERTEX); ++j) {
-                for (size_t i = 0; i < ModelArray::size(ModelArray::Dimension::XVERTEX); ++i) {
-                    fake25kmCoords.components({i, j})[0] = d * i;
-                    fake25kmCoords.components({i, j})[1] = d * j;
-                }
-            }
-            coords = fake25kmCoords;
-            // End of code to be removed
-        } else {
-            coords = ms.at(coordsName);
+            coords *= radians;
         }
+        // TODO: Some encoding of the periodic edge boundary conditions
         kernel.initialise(coords, false, ms.at(maskName));
 
         // Set the data in the kernel arrays.

--- a/core/src/modules/DynamicsModule/module.cfg
+++ b/core/src/modules/DynamicsModule/module.cfg
@@ -21,3 +21,8 @@ has_help = false
 file_prefix = BBMDynamics
 description = Discontinuous Galerkin dynamics with BBM rheology.
 has_help = false
+
+[Nextsim::FreeDriftDynamics]
+file_prefix = FreeDriftDynamics
+description = Free drift dynamics.
+has_help = false

--- a/dynamics/src/include/FreeDriftDynamicsKernel.hpp
+++ b/dynamics/src/include/FreeDriftDynamicsKernel.hpp
@@ -1,0 +1,59 @@
+/*!
+ * @file FreeDriftDynamicsKernel.hpp
+ *
+ * @date 17 Feb 2023
+ * @author Tim Spain <timothy.spain@nersc.no>
+ */
+
+#ifndef FREEDRIFTDYNAMICSKERNEL_HPP
+#define FREEDRIFTDYNAMICSKERNEL_HPP
+
+#include "CGDynamicsKernel.hpp"
+
+namespace Nextsim {
+
+template <int DGadvection> class FreeDriftDynamicsKernel : public CGDynamicsKernel<DGadvection> {
+    using DynamicsKernel<DGadvection, DGstressDegree>::nSteps;
+    using DynamicsKernel<DGadvection, DGstressDegree>::hice;
+    using DynamicsKernel<DGadvection, DGstressDegree>::cice;
+    using DynamicsKernel<DGadvection, DGstressDegree>::advectionAndLimits;
+    using DynamicsKernel<DGadvection, DGstressDegree>::dgtransport;
+
+    using CGDynamicsKernel<DGadvection>::u;
+    using CGDynamicsKernel<DGadvection>::v;
+    using CGDynamicsKernel<DGadvection>::uOcean;
+    using CGDynamicsKernel<DGadvection>::vOcean;
+    using CGDynamicsKernel<DGadvection>::applyBoundaries;
+
+public:
+    FreeDriftDynamicsKernel()
+        : CGDynamicsKernel<DGadvection>()
+    {
+    }
+
+    virtual ~FreeDriftDynamicsKernel() = default;
+
+    void update(const TimestepTime& tst) override
+    {
+        updateMomentum(tst);
+        applyBoundaries();
+
+        // Let DynamicsKernel handle the advection step
+        advectionAndLimits(tst);
+    };
+
+protected:
+    void updateMomentum(const TimestepTime& tst) override
+    {
+        // Set the ice velocity to the ocean velocity
+#pragma omp parallel for
+        for (int i = 0; i < u.rows(); ++i) {
+            // Ice velocity is equal to ocean velocity
+            u(i) = uOcean(i);
+            v(i) = vOcean(i);
+        }
+    }
+};
+} /* namespace Nextsim */
+
+#endif /* FREEDRIFTDYNAMICSKERNEL_HPP */

--- a/dynamics/src/include/FreeDriftDynamicsKernel.hpp
+++ b/dynamics/src/include/FreeDriftDynamicsKernel.hpp
@@ -60,7 +60,7 @@ protected:
     {
 #pragma omp parallel for
         for (int i = 0; i < u.rows(); ++i) {
-            // Ice velocity is equal to ocean velocity
+            // Free drift ice velocity
             u(i) = uOcean(i) + NansenNumber * (uAtmos(i) * cosOceanAngle - vAtmos(i) * sinOceanAngle);
             v(i) = vOcean(i) + NansenNumber * (-uAtmos(i) * sinOceanAngle + vAtmos(i) * cosOceanAngle);
         }


### PR DESCRIPTION
# Free drift dynamics
## Fixes \#453

---

# Change Description

Add a free drift equivalent to MEVPStep and BBMStep. Running this depends on implementing the dynamics switcher (closing #378).

---

# Test Description

Not yet. Should be tested once this form of dynamics can be tested.

---

# Documentation Impact

The free drift dynamics step needs to be documented along with the other available dynamics steps.
