### PR TITLE
Dynamics references

### DIFF
--- a/dynamics/src/include/BrittleCGDynamicsKernel.hpp
+++ b/dynamics/src/include/BrittleCGDynamicsKernel.hpp
@@ -20,8 +20,7 @@ namespace Nextsim {
 static const double radians = 0x1.1df46a2529d39p-6;
 
 // The brittle momentum solver for CG velocity fields
-template <int DGadvection>
-class BrittleCGDynamicsKernel : public CGDynamicsKernel<DGadvection> {
+template <int DGadvection> class BrittleCGDynamicsKernel : public CGDynamicsKernel<DGadvection> {
 protected:
     using DynamicsKernel<DGadvection, DGstressDegree>::nSteps;
     using DynamicsKernel<DGadvection, DGstressDegree>::s11;
@@ -53,14 +52,16 @@ protected:
     using CGDynamicsKernel<DGadvection>::dStressX;
     using CGDynamicsKernel<DGadvection>::dStressY;
     using CGDynamicsKernel<DGadvection>::pmap;
+
 public:
-    BrittleCGDynamicsKernel(StressUpdateStep<DGadvection, DGstressDegree>& stressStepIn, const DynamicsParameters& paramsIn)
+    BrittleCGDynamicsKernel(StressUpdateStep<DGadvection, DGstressDegree>& stressStepIn,
+        const DynamicsParameters& paramsIn)
         : CGDynamicsKernel<DGadvection>()
         , stressStep(stressStepIn)
         , params(reinterpret_cast<const MEBParameters&>(paramsIn))
         , stresstransport(nullptr)
-      {
-      }
+    {
+    }
     virtual ~BrittleCGDynamicsKernel() = default;
 
     void initialise(const ModelArray& coords, bool isSpherical, const ModelArray& mask) override
@@ -74,7 +75,8 @@ public:
         damage.resize_by_mesh(*smesh);
     }
 
-    void update(const TimestepTime& tst) override {
+    void update(const TimestepTime& tst) override
+    {
 
         // Let DynamicsKernel handle the advection step
         advectionAndLimits(tst);
@@ -96,20 +98,16 @@ public:
         deltaT = tst.step.seconds() / nSteps;
 
         for (size_t subStep = 0; subStep < nSteps; ++subStep) {
-   
+
             projectVelocityToStrain();
 
-            std::array<DGVector<DGstressDegree>, 3> stress = { s11, s12, s22 };
+            std::array<std::reference_wrapper<DGVector<DGstressDegree>>, N_TENSOR_ELEMENTS> stress
+                = { s11, s12, s22 }; // Call the step function on the StressUpdateStep class
             // Call the step function on the StressUpdateStep class
-            stressStep.stressUpdateHighOrder(params,
-                    *smesh,
-                    stress, { e11, e12, e22 },
-                    hice, cice,
-                    deltaT);
+            stressStep.stressUpdateHighOrder(
+                params, *smesh, stress, { e11, e12, e22 }, hice, cice, deltaT);
 
-            s11 = stress[I11];
-            s12 = stress[I12];
-            s22 = stress[I22];
+            stressDivergence(); // Compute divergence of stress tensor
 
             dStressX.zero();
             dStressY.zero();
@@ -124,7 +122,6 @@ public:
         }
         // Finally, do the base class update
         DynamicsKernel<DGadvection, DGstressDegree>::update(tst);
-
     }
 
     void setData(const std::string& name, const ModelArray& data) override
@@ -145,6 +142,7 @@ public:
             return CGDynamicsKernel<DGadvection>::getDG0Data(name);
         }
     }
+
 protected:
     CGVector<CGdegree> avgX;
     CGVector<CGdegree> avgY;
@@ -170,7 +168,8 @@ protected:
             const double uIce = u(i);
             const double vIce = v(i);
 
-            const double cPrime = cgA(i) * params.F_ocean * std::hypot(uOcean(i) - uIce, vOcean(i) - vIce);
+            const double cPrime
+                = cgA(i) * params.F_ocean * std::hypot(uOcean(i) - uIce, vOcean(i) - vIce);
 
             // FIXME grounding term tauB = cBu[i] / std::hypot(uIce, vIce) + u0
             const double tauB = 0.;
@@ -184,21 +183,21 @@ protected:
 
             // Atmospheric drag
             const double dragAtm = cgA(i) * params.F_atm * std::hypot(uAtmos(i), vAtmos(i));
-            const double tauX = dragAtm * uAtmos(i) +
-                    cPrime * (uOcean(i) * cosOceanAngle - vOcean(i) * sinOceanAngle);
-            const double tauY = dragAtm * vAtmos(i) +
-                    cPrime * (vOcean(i) * cosOceanAngle + uOcean(i) * sinOceanAngle);
+            const double tauX = dragAtm * uAtmos(i)
+                + cPrime * (uOcean(i) * cosOceanAngle - vOcean(i) * sinOceanAngle);
+            const double tauY = dragAtm * vAtmos(i)
+                + cPrime * (vOcean(i) * cosOceanAngle + uOcean(i) * sinOceanAngle);
 
             // Stress gradient
             const double gradX = dStressX(i) / pmap->lumpedcgmass(i);
             const double gradY = dStressY(i) / pmap->lumpedcgmass(i);
 
             u(i) = alpha * uIce + beta * vIce
-                    + dteOverMass * (alpha * (gradX + tauX) + beta * (gradY + tauY));
+                + dteOverMass * (alpha * (gradX + tauX) + beta * (gradY + tauY));
             u(i) *= rDenom;
 
-            v(i) = alpha * vIce - beta *uIce
-                    + dteOverMass * (alpha * (gradY + tauY) + beta * (gradX + tauX));
+            v(i) = alpha * vIce - beta * uIce
+                + dteOverMass * (alpha * (gradY + tauY) + beta * (gradX + tauX));
             v(i) *= rDenom;
         }
         dirichletZero(u);
@@ -213,7 +212,7 @@ protected:
                 const size_t ey = eid / smesh->nx;
                 // Loop over CG elements for this finite volume grid cell
                 for (size_t jy = 0; jy <= CGdegree; ++jy) {
-                    for (size_t jx = 0; jx <= CGdegree; ++ jx) {
+                    for (size_t jx = 0; jx <= CGdegree; ++jx) {
                         const size_t cgi = cgRowLength * (CGdegree * ey + jy) + CGdegree * ex + jx;
                         u(cgi) = 0.;
                         v(cgi) = 0.;
@@ -226,7 +225,6 @@ protected:
         avgX += u / nSteps;
         avgY += v / nSteps;
     }
-
 };
 }
 

--- a/dynamics/src/include/MEVPStressUpdateStep.hpp
+++ b/dynamics/src/include/MEVPStressUpdateStep.hpp
@@ -10,32 +10,40 @@
 
 #include "include/StressUpdateStep.hpp"
 
-#include "include/codeGenerationDGinGauss.hpp"
 #include "include/ParametricMap.hpp"
 #include "include/VPParameters.hpp"
+#include "include/codeGenerationDGinGauss.hpp"
 
 namespace Nextsim {
 
 template <int DGadvection, int DGstress, int CG>
 class MEVPStressUpdateStep : public StressUpdateStep<DGadvection, DGstress> {
-//using StressUpdateStep<DGadvection, DGstress>::SymmetricTensorVector;
 
 public:
-    typedef std::array<DGVector<DGstress>, N_TENSOR_ELEMENTS> SymmetricTensorVector;
+    typedef std::array<std::reference_wrapper<DGVector<DGstress>>, N_TENSOR_ELEMENTS>
+        SymmetricTensorVector;
     MEVPStressUpdateStep()
-        : pmap (nullptr)
+        : pmap(nullptr)
     {
     }
     ~MEVPStressUpdateStep() = default;
-    void stressUpdateHighOrder(const DynamicsParameters& params,
-            const ParametricMesh& smesh,
-            SymmetricTensorVector& stress, const SymmetricTensorVector& strain,
-            const DGVector<DGadvection>& h, const DGVector<DGadvection>& a,
-            const double deltaT) override
+    void stressUpdateHighOrder(const DynamicsParameters& params, const ParametricMesh& smesh,
+        SymmetricTensorVector& stress, const SymmetricTensorVector& strain,
+        const DGVector<DGadvection>& h, const DGVector<DGadvection>& a,
+        const double deltaT) override
     {
+        // Unwrap references
+        DGVector<DGstress>& s11 = stress[I11];
+        DGVector<DGstress>& s12 = stress[I12];
+        DGVector<DGstress>& s22 = stress[I22];
+
+        DGVector<DGstress>& e11 = strain[I11];
+        DGVector<DGstress>& e12 = strain[I12];
+        DGVector<DGstress>& e22 = strain[I22];
+
         const VPParameters& vpParams = reinterpret_cast<const VPParameters&>(params);
         // Number of Gauss points
-        const size_t nGauss = ( ((DGstress == 8) || (DGstress == 6) ) ? 3 : (DGstress == 3 ? 2 : -1));
+        const size_t nGauss = (((DGstress == 8) || (DGstress == 6)) ? 3 : (DGstress == 3 ? 2 : -1));
         //! Stress Update
 #pragma omp parallel for
         for (size_t i = 0; i < smesh.nelements; ++i) {
@@ -43,76 +51,81 @@ public:
             // Here, one should check if it is enough to use a 2-point Gauss rule.
             // We're dealing with dG2, 3-point Gauss should be required.
 
-            const LocalEdgeVector<nGauss * nGauss> h_gauss = (h.row(i) * PSI<DGadvection, nGauss>).array().max(0.0).matrix();
-            const LocalEdgeVector<nGauss * nGauss> a_gauss = (a.row(i) * PSI<DGadvection, nGauss>).array().max(0.0).min(1.0).matrix();
+            const LocalEdgeVector<nGauss* nGauss> h_gauss
+                = (h.row(i) * PSI<DGadvection, nGauss>).array().max(0.0).matrix();
+            const LocalEdgeVector<nGauss* nGauss> a_gauss
+                = (a.row(i) * PSI<DGadvection, nGauss>).array().max(0.0).min(1.0).matrix();
 
-            const LocalEdgeVector<nGauss * nGauss> e11_gauss = strain[I11].row(i) * PSI<DGstress, nGauss>;
-            const LocalEdgeVector<nGauss * nGauss> e12_gauss = strain[I12].row(i) * PSI<DGstress, nGauss>;
-            const LocalEdgeVector<nGauss * nGauss> e22_gauss = strain[I22].row(i) * PSI<DGstress, nGauss>;
+            const LocalEdgeVector<nGauss* nGauss> e11_gauss = e11.row(i) * PSI<DGstress, nGauss>;
+            const LocalEdgeVector<nGauss* nGauss> e12_gauss = e12.row(i) * PSI<DGstress, nGauss>;
+            const LocalEdgeVector<nGauss* nGauss> e22_gauss = e22.row(i) * PSI<DGstress, nGauss>;
 
-            const LocalEdgeVector<nGauss * nGauss> DELTA = (SQR(vpParams.DeltaMin)
+            const LocalEdgeVector<nGauss* nGauss> DELTA = (SQR(vpParams.DeltaMin)
                 + 1.25 * (e11_gauss.array().square() + e22_gauss.array().square())
-                + 1.50 * e11_gauss.array() * e22_gauss.array()
-                + e12_gauss.array().square())
-                                                        .sqrt()
-                                                        .matrix();
-            // double DELTA = sqrt(SQR(vpparameters.DeltaMin) + 1.25 * (SQR(E11(i, 0)) + SQR(E22(i, 0)))
+                + 1.50 * e11_gauss.array() * e22_gauss.array() + e12_gauss.array().square())
+                                                              .sqrt()
+                                                              .matrix();
+            // double DELTA = sqrt(SQR(vpparameters.DeltaMin) + 1.25 * (SQR(E11(i, 0)) + SQR(E22(i,
+            // 0)))
             //       + 1.50 * E11(i, 0) * E22(i, 0) + SQR(E12(i, 0)));
             //   assert(DELTA > 0);
 
             //   //! Ice strength
             //   double P = vpparameters.Pstar * H(i, 0) * exp(-20.0 * (1.0 - A(i, 0)));
-            const LocalEdgeVector<nGauss * nGauss> P = (vpParams.Pstar * h_gauss.array() * (-20.0 * (1.0 - a_gauss.array())).exp()).matrix();
+            const LocalEdgeVector<nGauss* nGauss> P
+                = (vpParams.Pstar * h_gauss.array() * (-20.0 * (1.0 - a_gauss.array())).exp())
+                      .matrix();
 
-            // //   double zeta = P / 2.0 / DELTA;
-            // //   double eta = zeta / 4;
-
-            // //   // replacement pressure
-            // //   P = P * DELTA / (vpparameters.DeltaMin + DELTA);
-
-            // std::cout << P << std::endl << DELTA << std::endl;
-            // abort();
 
             //   // S = S_old + 1/alpha (S(u)-S_old) = (1-1/alpha) S_old + 1/alpha S(u)
-            stress[I11].row(i) *= (1.0 - 1.0 / alpha);
-            stress[I12].row(i) *= (1.0 - 1.0 / alpha);
-            stress[I22].row(i) *= (1.0 - 1.0 / alpha);
-
-            //  zeta = P / 2.0 / DELTA;
-            //  eta = zeta / 4;
-            //  (zeta-eta) = zeta - 1/4 zeta = 3/4 zeta
-
-            //   S11.row(i)
-            //       += 1.0 / alpha * (2. * eta * E11.row(i) + (zeta - eta) * (E11.row(i) + E22.row(i)));
-            //   S11(i, 0) -= 1.0 / alpha * 0.5 * P;
+            s11.row(i) *= (1.0 - 1.0 / alpha);
+            s12.row(i) *= (1.0 - 1.0 / alpha);
+            s22.row(i) *= (1.0 - 1.0 / alpha);
 
             // const Eigen::Matrix<Nextsim::FloatType, 1, 9> J = ParametricTools::J<3>(smesh, i);
-            // // get the inverse of the mass matrix scaled with the test-functions in the gauss points,
+            // // get the inverse of the mass matrix scaled with the test-functions in the gauss
+            // points,
             // // with the gauss weights and with J. This is a 8 x 9 matrix
-            // const Eigen::Matrix<Nextsim::FloatType, 8, 9> imass_psi = ParametricTools::massMatrix<8>(smesh, i).inverse()
+            // const Eigen::Matrix<Nextsim::FloatType, 8, 9> imass_psi =
+            // ParametricTools::massMatrix<8>(smesh, i).inverse()
             //     * (PSI<8,3>.array().rowwise() * (GAUSSWEIGHTS<3>.array() * J.array())).matrix();
 
-            stress[I11].row(i) += pmap->iMJwPSI[i] * (1.0 / alpha * (P.array() / 8.0 / DELTA.array() * (5.0 * e11_gauss.array() + 3.0 * e22_gauss.array()) - 0.5 * P.array()).matrix().transpose());
+            s11.row(i) += pmap->iMJwPSI[i]
+                * (1.0 / alpha
+                    * (P.array() / 8.0 / DELTA.array()
+                            * (5.0 * e11_gauss.array() + 3.0 * e22_gauss.array())
+                        - 0.5 * P.array())
+                          .matrix()
+                          .transpose());
 
             //   S12.row(i) += 1.0 / alpha * (2. * eta * E12.row(i));
             // 2 eta = 2/4 * P / (2 Delta) = P / (4 Delta)
-            stress[I12].row(i) += pmap->iMJwPSI[i] * (1.0 / alpha * (P.array() / 4.0 / DELTA.array() * e12_gauss.array()).matrix().transpose());
+            s12.row(i) += pmap->iMJwPSI[i]
+                * (1.0 / alpha
+                    * (P.array() / 4.0 / DELTA.array() * e12_gauss.array()).matrix().transpose());
 
             //   S22.row(i)
-            //       += 1.0 / alpha * (2. * eta * E22.row(i) + (zeta - eta) * (E11.row(i) + E22.row(i)));
+            //       += 1.0 / alpha * (2. * eta * E22.row(i) + (zeta - eta) * (E11.row(i) +
+            //       E22.row(i)));
             //   S22(i, 0) -= 1.0 / alpha * 0.5 * P;
-            stress[I22].row(i) += pmap->iMJwPSI[i] * (1.0 / alpha * (P.array() / 8.0 / DELTA.array() * (5.0 * e22_gauss.array() + 3.0 * e11_gauss.array()) - 0.5 * P.array()).matrix().transpose());
+            s22.row(i) += pmap->iMJwPSI[i]
+                * (1.0 / alpha
+                    * (P.array() / 8.0 / DELTA.array()
+                            * (5.0 * e22_gauss.array() + 3.0 * e11_gauss.array())
+                        - 0.5 * P.array())
+                          .matrix()
+                          .transpose());
         }
-
     }
     void setPMap(ParametricMomentumMap<CG>* pmapIn) { pmap = pmapIn; }
+
 protected:
     ParametricMomentumMap<CG>* pmap;
+
 private:
     //! MEVP parameters
     double alpha = 1500.0;
     double beta = 1500.0;
-
 };
 
 } /* namespace Nextsim */

--- a/dynamics/src/include/StressUpdateStep.hpp
+++ b/dynamics/src/include/StressUpdateStep.hpp
@@ -20,7 +20,7 @@ namespace Nextsim {
 template <int DGadvection, int DGstress>
 class StressUpdateStep {
 public:
-    typedef std::array<DGVector<DGstress>, N_TENSOR_ELEMENTS> SymmetricTensorVector;
+    typedef std::array<std::reference_wrapper<DGVector<DGstress>>, N_TENSOR_ELEMENTS> SymmetricTensorVector;
 
     static const int nGauss = ( ((DGstress == 8) || (DGstress == 6) ) ? 3 : (DGstress == 3 ? 2 : -1));
     StressUpdateStep() = default;

--- a/dynamics/src/include/VPCGDynamicsKernel.hpp
+++ b/dynamics/src/include/VPCGDynamicsKernel.hpp
@@ -74,16 +74,11 @@ public:
 
             projectVelocityToStrain();
 
-            // FIXME Why can I not use the typedef from StressUpdateStep?
-            /*StressUpdateStep<DGadvection, DGstressDegree>::SymmetricTensorVector*/
-            std::array<DGVector<DGstressDegree>, 3> stress = { s11, s12, s22 };
+            std::array<std::reference_wrapper<DGVector<DGstressDegree>>, N_TENSOR_ELEMENTS> stress
+                = { s11, s12, s22 }; // Call the step function on the StressUpdateStep class
             // Call the step function on the StressUpdateStep class
             stressStep.stressUpdateHighOrder(
                 params, *smesh, stress, { e11, e12, e22 }, hice, cice, deltaT);
-
-            s11 = stress[I11];
-            s12 = stress[I12];
-            s22 = stress[I22];
 
             stressDivergence(); // Compute divergence of stress tensor
 


### PR DESCRIPTION
# Dynamics references
## Fixes \#527

Avoid doing big copies in tight loops by passing references, rather than copying the data when calling the stress update functions.

The edited files have also been `clang-format`ted.