### PR TITLE
Initialize the u,v arrays in DummyDynamics

### DIFF
--- a/core/src/modules/DynamicsModule/include/DummyDynamics.hpp
+++ b/core/src/modules/DynamicsModule/include/DummyDynamics.hpp
@@ -21,7 +21,6 @@ public:
     std::string getName() const override { return "DummyDynamics"; }
     void update(const TimestepTime& tst) override { };
 
-    void setData(const ModelState::DataMap&) override { };
 };
 }
 


### PR DESCRIPTION
# Initialize the u,v arrays in DummyDynamics
## Fixes \#530

---
# Change Description

The u & v `ModelArrays` need to be initialized. This is done in `IDynamics::setData()`. However, `DummyDynamics` overrides this with its own empty implementation of `setData()`. By deleting this empty function, the base class implementation of setData() is called instead and initializes u and v arrays correctly.

---
# Test Description

Any model run using `DummyDynamics` as its implementation of `IDynamics` now works correctly.
