### PR TITLE
Pass `ModelArray` to `Xios.write`, rather than array of `double`s

### DIFF
--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -68,10 +68,7 @@ void Xios::finalize()
  * Configure the XIOS server if XIOS is enabled in the settings.
  *
  */
-void Xios::configure()
-{
-    configureServer();
-}
+void Xios::configure() { configureServer(); }
 
 //! Configure calendar settings
 void Xios::configureServer()
@@ -214,8 +211,8 @@ void Xios::updateCalendar(int stepNumber) { cxios_update_calendar(stepNumber); }
 void Xios::write(const std::string fieldstr, const ModelArray& modelarray)
 {
     auto dim2 = modelarray.dimensions();
-    cxios_write_data_k82(fieldstr.c_str(), fieldstr.length(), modelarray.getData(),
-                         dim2[0], dim2[1], -1);
+    cxios_write_data_k82(
+        fieldstr.c_str(), fieldstr.length(), modelarray.getData(), dim2[0], dim2[1], -1);
 }
 
 /*!

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -201,18 +201,30 @@ void Xios::setCalendarTimestep(cxios_duration timestep)
 void Xios::updateCalendar(int stepNumber) { cxios_update_calendar(stepNumber); }
 
 /*!
- * send 2D field to xios server to be written to file.
+ * send 2D, 3D, or 4D field to xios server to be written to file.
  *
  * @param field name
- * @param data to be written
- * @param size of 1st dimension
- * @param size of 2nd dimension
+ * @param ModelArray containing data to be written
  */
 void Xios::write(const std::string fieldstr, const ModelArray& modelarray)
 {
-    auto dim2 = modelarray.dimensions();
-    cxios_write_data_k82(
-        fieldstr.c_str(), fieldstr.length(), modelarray.getData(), dim2[0], dim2[1], -1);
+    auto ndim = modelarray.nDimensions();
+    auto dims = modelarray.dimensions();
+
+    if (ndim == 2) {
+        cxios_write_data_k82(
+            fieldstr.c_str(), fieldstr.length(), modelarray.getData(), dims[0], dims[1], -1);
+    } else if (ndim == 3) {
+        cxios_write_data_k83(
+            fieldstr.c_str(), fieldstr.length(), modelarray.getData(), dims[0], dims[1], dims[2], -1);
+
+    } else if (ndim == 4) {
+        cxios_write_data_k84(
+            fieldstr.c_str(), fieldstr.length(), modelarray.getData(), dims[0], dims[1], dims[2], dims[3], -1);
+
+    } else {
+        throw std::invalid_argument("Only ModelArrays of dimension 2, 3, or 4 are supported");
+    }
 }
 
 /*!

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -220,9 +220,11 @@ void Xios::updateCalendar(int stepNumber) { cxios_update_calendar(stepNumber); }
  * @param size of 1st dimension
  * @param size of 2nd dimension
  */
-void Xios::write(const std::string fieldstr, double* data, const int ni, const int nj)
+void Xios::write(const std::string fieldstr, const ModelArray& modelarray)
 {
-    cxios_write_data_k82(fieldstr.c_str(), fieldstr.length(), data, ni, nj, -1);
+    auto dim2 = modelarray.dimensions();
+    cxios_write_data_k82(fieldstr.c_str(), fieldstr.length(), modelarray.getData(),
+                         dim2[0], dim2[1], -1);
 }
 
 /*!

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -34,10 +34,6 @@
 
 namespace Nextsim {
 
-template <>
-const std::map<int, std::string> Configured<Xios>::keyMap
-    = { { Xios::ENABLED_KEY, "xios.enable" } };
-
 /*!
  * Constructor
  *
@@ -74,12 +70,7 @@ void Xios::finalize()
  */
 void Xios::configure()
 {
-    // check if xios is enabled in the nextsim configuration
-    istringstream(Configured::getConfiguration(keyMap.at(ENABLED_KEY), std::string()))
-        >> std::boolalpha >> isEnabled;
-    if (isEnabled) {
-        configureServer();
-    }
+    configureServer();
 }
 
 //! Configure calendar settings

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -215,12 +215,12 @@ void Xios::write(const std::string fieldstr, const ModelArray& modelarray)
         cxios_write_data_k82(
             fieldstr.c_str(), fieldstr.length(), modelarray.getData(), dims[0], dims[1], -1);
     } else if (ndim == 3) {
-        cxios_write_data_k83(
-            fieldstr.c_str(), fieldstr.length(), modelarray.getData(), dims[0], dims[1], dims[2], -1);
+        cxios_write_data_k83(fieldstr.c_str(), fieldstr.length(), modelarray.getData(), dims[0],
+            dims[1], dims[2], -1);
 
     } else if (ndim == 4) {
-        cxios_write_data_k84(
-            fieldstr.c_str(), fieldstr.length(), modelarray.getData(), dims[0], dims[1], dims[2], dims[3], -1);
+        cxios_write_data_k84(fieldstr.c_str(), fieldstr.length(), modelarray.getData(), dims[0],
+            dims[1], dims[2], dims[3], -1);
 
     } else {
         throw std::invalid_argument("Only ModelArrays of dimension 2, 3, or 4 are supported");

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -18,6 +18,7 @@
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/format.hpp>
 #include <boost/format/group.hpp>
+#include <include/ModelArray.hpp>
 #include <include/xios_c_interface.hpp>
 #include <mpi.h>
 
@@ -50,7 +51,8 @@ public:
     int getCalendarStep();
 
     void updateCalendar(int stepNumber);
-    void write(const std::string fieldstr, double* data, const int ni, const int nj);
+
+    void write(const std::string fieldstr, const ModelArray& modelarray);
 
     std::string convertXiosDatetimeToString(cxios_date datetime, bool isoFormat = true);
 

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -14,7 +14,6 @@
 #include "date.hpp"
 #if USE_XIOS
 
-#include "Configured.hpp"
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/format.hpp>
 #include <boost/format/group.hpp>
@@ -24,7 +23,7 @@
 
 namespace Nextsim {
 
-class Xios : public Configured<Xios> {
+class Xios {
 public:
     Xios();
     ~Xios();
@@ -33,7 +32,7 @@ public:
     void context_finalize();
     bool isInitialized();
 
-    void configure() override;
+    void configure();
     void configureServer();
     void configureCalendar();
 
@@ -58,10 +57,6 @@ public:
 
     void printCXiosDate(cxios_date date);
     void printCXiosDuration(cxios_duration duration);
-
-    enum {
-        ENABLED_KEY,
-    };
 
     int rank { 0 };
     int size { 0 };

--- a/core/src/include/xios_c_interface.hpp
+++ b/core/src/include/xios_c_interface.hpp
@@ -80,10 +80,10 @@ void cxios_set_domain_lonvalue_1d(xios::CDomain* domain_hdl, double* lonvalue_1d
 void cxios_set_domain_latvalue_1d(xios::CDomain* domain_hdl, double* latvalue_1d, int* extent);
 
 // writing methods
-void cxios_write_data_k82(const char* fieldid, int fieldid_size, const double* data_k8, int data_Xsize,
-    int data_Ysize, int tileid);
-void cxios_write_data_k83(const char* fieldid, int fieldid_size, const double* data_k8, int data_Xsize,
-    int data_Ysize, int data_Zsize, int tileid);
+void cxios_write_data_k82(const char* fieldid, int fieldid_size, const double* data_k8,
+    int data_Xsize, int data_Ysize, int tileid);
+void cxios_write_data_k83(const char* fieldid, int fieldid_size, const double* data_k8,
+    int data_Xsize, int data_Ysize, int data_Zsize, int tileid);
 };
 
 #endif

--- a/core/src/include/xios_c_interface.hpp
+++ b/core/src/include/xios_c_interface.hpp
@@ -80,9 +80,9 @@ void cxios_set_domain_lonvalue_1d(xios::CDomain* domain_hdl, double* lonvalue_1d
 void cxios_set_domain_latvalue_1d(xios::CDomain* domain_hdl, double* latvalue_1d, int* extent);
 
 // writing methods
-void cxios_write_data_k82(const char* fieldid, int fieldid_size, double* data_k8, int data_Xsize,
+void cxios_write_data_k82(const char* fieldid, int fieldid_size, const double* data_k8, int data_Xsize,
     int data_Ysize, int tileid);
-void cxios_write_data_k83(const char* fieldid, int fieldid_size, double* data_k8, int data_Xsize,
+void cxios_write_data_k83(const char* fieldid, int fieldid_size, const double* data_k8, int data_Xsize,
     int data_Ysize, int data_Zsize, int tileid);
 };
 

--- a/core/src/include/xios_c_interface.hpp
+++ b/core/src/include/xios_c_interface.hpp
@@ -81,9 +81,11 @@ void cxios_set_domain_latvalue_1d(xios::CDomain* domain_hdl, double* latvalue_1d
 
 // writing methods
 void cxios_write_data_k82(const char* fieldid, int fieldid_size, const double* data_k8,
-    int data_Xsize, int data_Ysize, int tileid);
+    int data_size1, int data_size2, int tileid);
 void cxios_write_data_k83(const char* fieldid, int fieldid_size, const double* data_k8,
-    int data_Xsize, int data_Ysize, int data_Zsize, int tileid);
+    int data_size1, int data_size2, int data_size3, int tileid);
+void cxios_write_data_k84(const char* fieldid, int fieldid_size, const double* data_k8,
+    int data_size1, int data_size2, int data_size3, int data_size4, int tileid);
 };
 
 #endif

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -43,6 +43,9 @@ target_link_libraries(testModelArray PRIVATE doctest::doctest Eigen3::Eigen)
 
 if(ENABLE_MPI)
   if(ENABLE_XIOS)
+    set(CMAKE_EXE_LINKER_FLAGS
+      "${CMAKE_EXE_LINKER_FLAGS} -Wl,--copy-dt-needed-entries" # TODO: Avoid this hack!
+    )
     FILE(CREATE_LINK
       "${CMAKE_SOURCE_DIR}/core/test/iodef.xml"
       "${CMAKE_CURRENT_BINARY_DIR}/iodef.xml"

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -41,6 +41,34 @@ add_executable(testModelArray "ModelArray_test.cpp" "../src/ModelArray.cpp" "${M
 target_include_directories(testModelArray PRIVATE "../src" "${MODEL_INCLUDE_DIR}")
 target_link_libraries(testModelArray PRIVATE doctest::doctest Eigen3::Eigen)
 
+if(ENABLE_MPI)
+  if(ENABLE_XIOS)
+    FILE(CREATE_LINK
+      "${CMAKE_SOURCE_DIR}/core/test/iodef.xml"
+      "${CMAKE_CURRENT_BINARY_DIR}/iodef.xml"
+      SYMBOLIC
+    )
+    set(XIOS_INCLUDE_LIST
+      "${xios_INCLUDES}"
+      "${xios_EXTERNS}/blitz/"
+      "${xios_EXTERNS}/rapidxml/include"
+      )
+    add_executable(testXiosInit_MPI2
+      "XiosInit_test.cpp" "../src/ModelArray.cpp" "${MODEL_INCLUDE_DIR}/ModelArrayDetails.cpp"
+      "../src/Xios.cpp" "MainMPI.cpp"
+    )
+    target_compile_definitions(testXiosInit_MPI2 PRIVATE USE_XIOS USE_MPI)
+    target_include_directories(testXiosInit_MPI2
+      PRIVATE "../src" "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}"
+      PUBLIC "${netCDF_INCLUDE_DIR}"
+    )
+    target_link_directories(testXiosInit_MPI2 PUBLIC "${netCDF_LIB_DIR}" "${xios_LIBRARIES}")
+    target_link_libraries(testXiosInit_MPI2
+      PUBLIC doctest::doctest xios Boost::program_options "${NSDG_NetCDF_Library}" Eigen3::Eigen "${FORTRAN_RUNTIME_LIB}"
+    )
+  endif()
+endif()
+
 set(MODEL_INCLUDE_DIR "../../core/src/discontinuousgalerkin")
 
 if(ENABLE_MPI)
@@ -54,18 +82,6 @@ if(ENABLE_MPI)
       DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/partition_metadata_3.nc.dump
   )
   add_custom_target(generate_partition_file ALL DEPENDS partition_metadata_3.nc)
-  if(ENABLE_XIOS)
-    FILE(CREATE_LINK "${CMAKE_SOURCE_DIR}/core/test/iodef.xml" "${CMAKE_CURRENT_BINARY_DIR}/iodef.xml" SYMBOLIC)
-    set(XIOS_INCLUDE_LIST
-      "${xios_INCLUDES}"
-      "${xios_EXTERNS}/blitz/"
-      "${xios_EXTERNS}/rapidxml/include"
-      )
-    add_executable(testXiosInit_MPI2 "XiosInit_test.cpp" "MainMPI.cpp")
-    target_compile_definitions(testXiosInit_MPI2 PRIVATE USE_XIOS USE_MPI)
-    target_include_directories(testXiosInit_MPI2 PRIVATE "${XIOS_INCLUDE_LIST}")
-    target_link_libraries(testXiosInit_MPI2 PRIVATE nextsimlib doctest::doctest)
-  endif()
 else()
   add_executable(testRectGrid "RectGrid_test.cpp")
   target_compile_definitions(testRectGrid PRIVATE TEST_FILES_DIR=\"${CMAKE_CURRENT_BINARY_DIR}\")

--- a/core/test/XiosInit_test.cpp
+++ b/core/test/XiosInit_test.cpp
@@ -12,10 +12,12 @@
  * boilerplate, so they have all been group in this test.
  *
  */
+// clang-format off
 #include <cstdio>
 #include <doctest/extensions/doctest_mpi.h>
 #include "include/ModelArray.hpp"
 #include "include/Xios.hpp"
+// clang-format on
 
 using namespace Nextsim;
 
@@ -102,7 +104,7 @@ MPI_TEST_CASE("TestXiosInitialization", 2)
     // create some fake data to test writing methods
     size_t ni = 30;
     size_t nj = 30;
-    ModelArray::MultiDim dims2 = {ni, nj};
+    ModelArray::MultiDim dims2 = { ni, nj };
     ModelArray::setDimensions(ModelArray::Type::TWOD, dims2);
     ModelArray field_A = ModelArray::TwoDField();
     for (int idx = 0; idx < field_A.size(); idx++) {

--- a/core/test/XiosInit_test.cpp
+++ b/core/test/XiosInit_test.cpp
@@ -106,13 +106,13 @@ MPI_TEST_CASE("TestXiosInitialization", 2)
     size_t nj = 30;
     ModelArray::MultiDim dims2 = { ni, nj };
     ModelArray::setDimensions(ModelArray::Type::TWOD, dims2);
-    ModelArray field_A = ModelArray::TwoDField();
-    for (int idx = 0; idx < field_A.size(); idx++) {
-        field_A[idx] = 1.0 * idx;
+    ModelArray field_2D = ModelArray::TwoDField();
+    for (int idx = 0; idx < field_2D.size(); idx++) {
+        field_2D[idx] = 1.0 * idx;
     }
 
     // create field
-    std::string fieldId = { "field_A" };
+    std::string fieldId = { "field_2D" };
 
     // verify calendar step is starting from zero
     int step = xios_handler.getCalendarStep();
@@ -123,7 +123,7 @@ MPI_TEST_CASE("TestXiosInitialization", 2)
         // update the current timestep
         xios_handler.updateCalendar(ts);
         // send data to XIOS to be written to disk
-        xios_handler.write(fieldId, field_A);
+        xios_handler.write(fieldId, field_2D);
         // verify timestep
         step = xios_handler.getCalendarStep();
         REQUIRE(step == ts);

--- a/core/test/XiosInit_test.cpp
+++ b/core/test/XiosInit_test.cpp
@@ -15,6 +15,7 @@
 // clang-format off
 #include <cstdio>
 #include <doctest/extensions/doctest_mpi.h>
+#include <filesystem>
 #include "include/ModelArray.hpp"
 #include "include/Xios.hpp"
 // clang-format on
@@ -146,4 +147,9 @@ MPI_TEST_CASE("TestXiosInitialization", 2)
         step = xios_handler.getCalendarStep();
         REQUIRE(step == ts);
     }
+
+    // verify output files exist
+    REQUIRE(std::filesystem::exists("diagnostic_2D.nc"));
+    REQUIRE(std::filesystem::exists("diagnostic_3D.nc"));
+    REQUIRE(std::filesystem::exists("diagnostic_4D.nc"));
 }

--- a/core/test/XiosInit_test.cpp
+++ b/core/test/XiosInit_test.cpp
@@ -104,15 +104,31 @@ MPI_TEST_CASE("TestXiosInitialization", 2)
     // create some fake data to test writing methods
     size_t ni = 30;
     size_t nj = 30;
+    size_t nk = 30;
+    size_t nl = 30;
     ModelArray::MultiDim dims2 = { ni, nj };
+    ModelArray::MultiDim dims3 = { ni, nj, nk };
+    ModelArray::MultiDim dims4 = { ni, nj, nk, nl };
     ModelArray::setDimensions(ModelArray::Type::TWOD, dims2);
+    ModelArray::setDimensions(ModelArray::Type::THREED, dims3);
+    ModelArray::setDimensions(ModelArray::Type::FOURD, dims4);
     ModelArray field_2D = ModelArray::TwoDField();
+    ModelArray field_3D = ModelArray::ThreeDField();
+    ModelArray field_4D = ModelArray::FourDField();
     for (int idx = 0; idx < field_2D.size(); idx++) {
         field_2D[idx] = 1.0 * idx;
     }
+    for (int idx = 0; idx < field_3D.size(); idx++) {
+        field_3D[idx] = 1.0 * idx;
+    }
+    for (int idx = 0; idx < field_4D.size(); idx++) {
+        field_4D[idx] = 1.0 * idx;
+    }
 
     // create field
-    std::string fieldId = { "field_2D" };
+    std::string fieldId2D = { "field_2D" };
+    std::string fieldId3D = { "field_3D" };
+    std::string fieldId4D = { "field_4D" };
 
     // verify calendar step is starting from zero
     int step = xios_handler.getCalendarStep();
@@ -123,7 +139,9 @@ MPI_TEST_CASE("TestXiosInitialization", 2)
         // update the current timestep
         xios_handler.updateCalendar(ts);
         // send data to XIOS to be written to disk
-        xios_handler.write(fieldId, field_2D);
+        xios_handler.write(fieldId2D, field_2D);
+        xios_handler.write(fieldId3D, field_3D);
+        xios_handler.write(fieldId4D, field_4D);
         // verify timestep
         step = xios_handler.getCalendarStep();
         REQUIRE(step == ts);

--- a/core/test/iodef.xml
+++ b/core/test/iodef.xml
@@ -4,16 +4,31 @@
     <calendar type="Gregorian" time_origin="2020-01-23 00:08:15" start_date="2023-03-17 17:11:00" timestep="1.5 h"/>
 
     <axis_definition>
-      <axis id="axis_x" n_glo="30" value="(0,29)[0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29]">
+      <axis id="axis_1" n_glo="30" value="(0,29)[0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29]">
       </axis>
-      <axis id="axis_y" n_glo="30" value="(0,29)[0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29]">
+      <axis id="axis_2" n_glo="30" value="(0,29)[0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29]">
+      </axis>
+      <axis id="axis_3" n_glo="30" value="(0,29)[0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29]">
+      </axis>
+      <axis id="axis_4" n_glo="30" value="(0,29)[0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29]">
       </axis>
     </axis_definition>
 
     <grid_definition>
       <grid id="grid_2D">
-        <axis axis_ref="axis_x"/>
-        <axis axis_ref="axis_y"/>
+        <axis axis_ref="axis_1"/>
+        <axis axis_ref="axis_2"/>
+      </grid>
+      <grid id="grid_3D">
+        <axis axis_ref="axis_1"/>
+        <axis axis_ref="axis_2"/>
+        <axis axis_ref="axis_3"/>
+      </grid>
+      <grid id="grid_4D">
+        <axis axis_ref="axis_1"/>
+        <axis axis_ref="axis_2"/>
+        <axis axis_ref="axis_3"/>
+        <axis axis_ref="axis_4"/>
       </grid>
     </grid_definition>
 

--- a/core/test/iodef.xml
+++ b/core/test/iodef.xml
@@ -39,8 +39,14 @@
     </field_definition>
 
     <file_definition>
-      <file id="output" name="diagnostic" output_freq="1ts" type="one_file">
+      <file id="output_2D" name="diagnostic_2D" output_freq="1ts" type="one_file">
         <field id="field_2D"/>
+      </file>
+      <file id="output_3D" name="diagnostic_3D" output_freq="1ts" type="one_file">
+        <field id="field_3D"/>
+      </file>
+      <file id="output_4D" name="diagnostic_4D" output_freq="1ts" type="one_file">
+        <field id="field_4D"/>
       </file>
     </file_definition>
 

--- a/core/test/iodef.xml
+++ b/core/test/iodef.xml
@@ -33,12 +33,14 @@
     </grid_definition>
 
     <field_definition>
-      <field id="field_A" name="test_field" operation="instant" grid_ref="grid_2D"/>
+      <field id="field_2D" name="test_field_2D" operation="instant" grid_ref="grid_2D"/>
+      <field id="field_3D" name="test_field_3D" operation="instant" grid_ref="grid_3D"/>
+      <field id="field_4D" name="test_field_4D" operation="instant" grid_ref="grid_4D"/>
     </field_definition>
 
     <file_definition>
       <file id="output" name="diagnostic" output_freq="1ts" type="one_file">
-        <field id="field_A"/>
+        <field id="field_2D"/>
       </file>
     </file_definition>
 


### PR DESCRIPTION
# Pass `ModelArray` to `Xios.write`, rather than array of `double`s
## Fixes #544

### Task List
- [x] Defined the tests that specify a complete and functioning change (*It may help to create a [design specification & test specification](../../../wiki/Specification-Template)*)
- [x] Implemented the source code change that satisfies the tests
- [ ] Documented the feature by providing worked example
- [ ] Updated the README or other documentation
- [ ] Completed the pre-Request checklist below

---
# Change Description

In the existing implementation of the `Xios` class, its `write` method accepts a C-style array of `double`s, along with its dimensions in each direction. The approach adopted here - better in line with Nextsim's approach - is to instead pass a `ModelArray`, which knows about both the data and dimensions. I think this change is fairly uncontroversial.

While working on this last week, @timspainNERSC said it would be preferable if runtime configuration of Nextsim-DG would not required when using Xios functionality. To address this, the changes here also make the `Xios` class independent of Nextsim-DG. Is this acceptable @TomMelt, or are there other reasons that we should keep the configuration code in that we aren't aware of?

# Test Description

@timspainNERSC also said it would be preferable if the Xios tests are built without linking to `nextsimlib`, to keep them separate. As such, the Xios test build has been reworked. In the current setup, the tests build and all pass. However, the latest commit (2e83114b1fd9efda9a0b99ca7900ce0ff8d0d8a1) is a temporary hack to get the Xios test to build correctly. @TomMelt do you have any insight on how to avoid this?

### Pre-Request Checklist

- [x] The requirements of this pull request are fully captured in an issue or design specification and are linked and summarised in the description of this PR
- [x] No new warnings are generated
- [ ] The documentation has been updated (or an issue has been created to track the corresponding change)
- [ ] Methods and Tests are commented such that they can be understood without having to obtain additional context
- [ ] This PR/Issue is labelled as a bug/feature/enhancement/breaking change
- [ ] File dates have been updated to reflect modification date
- [ ] This change conforms to the conventions described in the README