### PR TITLE
Dimension names

### DIFF
--- a/core/src/ParaGridIO.cpp
+++ b/core/src/ParaGridIO.cpp
@@ -28,8 +28,8 @@
 namespace Nextsim {
 
 const std::map<std::string, ModelArray::Type> ParaGridIO::dimensionKeys = {
-    { "yx", ModelArray::Type::H },
-    { "zyx", ModelArray::Type::Z },
+    { "ydixdim", ModelArray::Type::H },
+    { "zdimydimxdim", ModelArray::Type::Z },
     { "yxdg_comp", ModelArray::Type::DG },
     { "yxdgstress_comp", ModelArray::Type::DGSTRESS },
     { "ycgxcg", ModelArray::Type::CG },

--- a/core/src/ParaGridIO.cpp
+++ b/core/src/ParaGridIO.cpp
@@ -30,8 +30,8 @@ namespace Nextsim {
 const std::map<std::string, ModelArray::Type> ParaGridIO::dimensionKeys = {
     { "ydixdim", ModelArray::Type::H },
     { "zdimydimxdim", ModelArray::Type::Z },
-    { "yxdg_comp", ModelArray::Type::DG },
-    { "yxdgstress_comp", ModelArray::Type::DGSTRESS },
+    { "ydimxdimdg_comp", ModelArray::Type::DG },
+    { "ydimxdimdgstress_comp", ModelArray::Type::DGSTRESS },
     { "ycgxcg", ModelArray::Type::CG },
     { "yvertexxvertexncoords", ModelArray::Type::VERTEX },
 };

--- a/core/src/ParaGridIO.cpp
+++ b/core/src/ParaGridIO.cpp
@@ -28,7 +28,7 @@
 namespace Nextsim {
 
 const std::map<std::string, ModelArray::Type> ParaGridIO::dimensionKeys = {
-    { "ydixdim", ModelArray::Type::H },
+    { "ydimxdim", ModelArray::Type::H },
     { "zdimydimxdim", ModelArray::Type::Z },
     { "ydimxdimdg_comp", ModelArray::Type::DG },
     { "ydimxdimdgstress_comp", ModelArray::Type::DGSTRESS },

--- a/core/src/RectGridIO.cpp
+++ b/core/src/RectGridIO.cpp
@@ -173,7 +173,7 @@ void RectGridIO::dumpModelState(const ModelState& state, const ModelMetadata& me
     int ny = ModelArray::dimensions(Type::H)[1];
     int nz = ModelArray::dimensions(Type::Z)[2];
 
-    std::vector<std::string> dimensionNames = { "x", "y", "z", "t", "component", "u", "v", "w" };
+    std::vector<std::string> dimensionNames = { "xdim", "ydim", "zdim", "t", "component", "u", "v", "w" };
 
     // Create the dimension data, since it has to be in the same group as the
     // data or the parent group

--- a/core/src/RectGridIO.cpp
+++ b/core/src/RectGridIO.cpp
@@ -173,7 +173,8 @@ void RectGridIO::dumpModelState(const ModelState& state, const ModelMetadata& me
     int ny = ModelArray::dimensions(Type::H)[1];
     int nz = ModelArray::dimensions(Type::Z)[2];
 
-    std::vector<std::string> dimensionNames = { "xdim", "ydim", "zdim", "t", "component", "u", "v", "w" };
+    std::vector<std::string> dimensionNames
+        = { "xdim", "ydim", "zdim", "t", "component", "u", "v", "w" };
 
     // Create the dimension data, since it has to be in the same group as the
     // data or the parent group

--- a/core/src/discontinuousgalerkin/ModelArrayDetails.cpp
+++ b/core/src/discontinuousgalerkin/ModelArrayDetails.cpp
@@ -16,9 +16,9 @@
 namespace Nextsim {
 // clang-format off
 std::map<ModelArray::Dimension, ModelArray::DimensionSpec> ModelArray::definedDimensions = {
-    { ModelArray::Dimension::X, { "x", 0 } },
-    { ModelArray::Dimension::Y, { "y", 0 } },
-    { ModelArray::Dimension::Z, { "z", 1 } },
+    { ModelArray::Dimension::X, { "xdim", 0 } },
+    { ModelArray::Dimension::Y, { "ydim", 0 } },
+    { ModelArray::Dimension::Z, { "zdim", 1 } },
     { ModelArray::Dimension::XVERTEX, { "xvertex", 1 } }, // defined as x + 1
     { ModelArray::Dimension::YVERTEX, { "yvertex", 1 } }, // defined as y + 1
     { ModelArray::Dimension::XCG, { "x_cg", 1 } },

--- a/core/src/finitevolume/ModelArrayDetails.cpp
+++ b/core/src/finitevolume/ModelArrayDetails.cpp
@@ -15,9 +15,9 @@
 
 namespace Nextsim {
 std::map<ModelArray::Dimension, ModelArray::DimensionSpec> ModelArray::definedDimensions = {
-    { ModelArray::Dimension::X, { "x", 0 } },
-    { ModelArray::Dimension::Y, { "y", 0 } },
-    { ModelArray::Dimension::Z, { "z", 1 } },
+    { ModelArray::Dimension::X, { "xdim", 0 } },
+    { ModelArray::Dimension::Y, { "ydim", 0 } },
+    { ModelArray::Dimension::Z, { "zdim", 1 } },
     { ModelArray::Dimension::XVERTEX, { "xvertex", 1 } }, // defined as x + 1
     { ModelArray::Dimension::YVERTEX, { "yvertex", 1 } }, // defined as y + 1
 };

--- a/run/make_init.py
+++ b/run/make_init.py
@@ -27,14 +27,14 @@ formatted[0] = "2000-01-01T00:00:00Z"
 
 datagrp = root.createGroup("data")
 
-x_dim = datagrp.createDimension("x", nx)
-y_dim = datagrp.createDimension("y", ny)
-z_dim = datagrp.createDimension("z", nLayers)
+x_dim = datagrp.createDimension("xdim", nx)
+y_dim = datagrp.createDimension("ydim", ny)
+z_dim = datagrp.createDimension("zdim", nLayers)
 xvertex_dim = datagrp.createDimension("xvertex", nx + 1)
 yvertex_dim = datagrp.createDimension("yvertex", ny + 1)
 coords_dim = datagrp.createDimension("ncoords", n_coords)
 
-hfield_dims = ("y", "x")
+hfield_dims = ("ydim", "xdim")
 
 mask = datagrp.createVariable("mask", "f8", hfield_dims)
 mask[:,::-1] = [[0,0,0,0,0,0,0,0,0,0,1,1,1,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
@@ -104,7 +104,7 @@ hice = datagrp.createVariable("hice", "f8", hfield_dims)
 hice[:,:] = cice[:,:] * 2
 hsnow = datagrp.createVariable("hsnow", "f8", hfield_dims)
 hsnow[:,:] = cice[:,:] / 2
-tice = datagrp.createVariable("tice", "f8", ("z", "y", "x"))
+tice = datagrp.createVariable("tice", "f8", ("zdim", "ydim", "xdim"))
 tice[0,:,:] = -0.5 - cice[:,:]
 
 mdi = -3.40282347e38 # Minus float max

--- a/run/make_init25kmNH.py
+++ b/run/make_init25kmNH.py
@@ -99,9 +99,9 @@ if __name__ == "__main__":
     formatted[0] = "2010-01-01T00:00:00Z"
     datagrp = root.createGroup("data")
 
-    nLay = datagrp.createDimension("z", nLayers)
-    yDim = datagrp.createDimension("y", nfirst)
-    xDim = datagrp.createDimension("x", nsecond)
+    nLay = datagrp.createDimension("zdim", nLayers)
+    yDim = datagrp.createDimension("ydim", nfirst)
+    xDim = datagrp.createDimension("xdim", nsecond)
     yVertexDim = datagrp.createDimension("yvertex", nfirst + 1)
     xVertexDim = datagrp.createDimension("xvertex", nsecond+ 1)
     ycg_dim = datagrp.createDimension("y_cg", nfirst * ncg + 1)
@@ -110,9 +110,9 @@ if __name__ == "__main__":
     dgs_comp = datagrp.createDimension("dgstress_comp", n_dgstress)
     n_coords_comp = datagrp.createDimension("ncoords", n_coords)
     
-    field_dims = ("y", "x")
+    field_dims = ("ydim", "xdim")
     coord_dims = ("yvertex", "xvertex", "ncoords")
-    zfield_dims = ("z", "y", "x")
+    zfield_dims = ("zdim", "ydim", "xdim")
 
     # Array coordinates
     node_lon = np.zeros((nfirst + 1, nsecond + 1))

--- a/run/make_init25kmNH_test.py
+++ b/run/make_init25kmNH_test.py
@@ -32,9 +32,9 @@ formatted[0] = "2000-01-01T00:00:00Z"
 
 datagrp = root.createGroup("data")
 
-xDim = datagrp.createDimension("x", nx)
-yDim = datagrp.createDimension("y", ny)
-nLay = datagrp.createDimension("z", nLayers)
+xDim = datagrp.createDimension("xdim", nx)
+yDim = datagrp.createDimension("ydim", ny)
+nLay = datagrp.createDimension("zdim", nLayers)
 xVertexDim = datagrp.createDimension("xvertex", nx + 1)
 yVertexDim = datagrp.createDimension("yvertex", ny + 1)
 xcg_dim = datagrp.createDimension("x_cg", nx * ncg + 1)
@@ -45,7 +45,7 @@ n_coords_comp = datagrp.createDimension("ncoords", n_coords)
 
 grid_mask = grid["mask"]
 
-mask = datagrp.createVariable("mask", "f8", ("x", "y"))
+mask = datagrp.createVariable("mask", "f8", ("xdim", "ydim"))
 mask[:,:] = grid_mask[:,:]
 antimask = 1 - mask[:,:]
 
@@ -66,27 +66,27 @@ coords = datagrp.createVariable("coords", "f8", ("xvertex", "yvertex", "ncoords"
 coords[:,:,0] = node_lon
 coords[:,:,1] = node_lat
 
-elem_lon = datagrp.createVariable("longitude", "f8", ("x", "y",))
+elem_lon = datagrp.createVariable("longitude", "f8", ("xdim", "ydim",))
 elem_lon[:, :] = grid["plon"][:, :]
-elem_lat = datagrp.createVariable("latitude", "f8", ("x", "y",))
+elem_lat = datagrp.createVariable("latitude", "f8", ("xdim", "ydim",))
 elem_lat[:, :] = grid["plat"][:, :]
 
 
-cice = datagrp.createVariable("cice", "f8", ("x", "y",))
+cice = datagrp.createVariable("cice", "f8", ("xdim", "ydim",))
 cice[:,:] = mask[:, :] * 0.95
-hice = datagrp.createVariable("hice", "f8", ("x", "y",))
+hice = datagrp.createVariable("hice", "f8", ("xdim", "ydim",))
 hice[:,:] = cice[:,:] * 2
-hsnow = datagrp.createVariable("hsnow", "f8", ("x", "y",))
+hsnow = datagrp.createVariable("hsnow", "f8", ("xdim", "ydim",))
 hsnow[:,:] = cice[:,:] / 2
 tice = datagrp.createVariable("tice", "f8", ("x", "y", "z"))
 tice[:,:,0] = -0.5 - cice[:,:]
-sst = datagrp.createVariable("sst", "f8", ("x", "y",))
+sst = datagrp.createVariable("sst", "f8", ("xdim", "ydim",))
 sst[:,:] = -cice[:,:]
-sss = datagrp.createVariable("sss", "f8", ("x", "y",))
+sss = datagrp.createVariable("sss", "f8", ("xdim", "ydim",))
 sss[:,:] = cice[:,:] * 33.68
-u = datagrp.createVariable("u", "f8", ("x", "y",))
+u = datagrp.createVariable("u", "f8", ("xdim", "ydim",))
 u[:,:] = 0.
-v = datagrp.createVariable("v", "f8", ("x", "y",))
+v = datagrp.createVariable("v", "f8", ("xdim", "ydim",))
 v[:,:] = 0.
 
 #velocity in the middle of the domain

--- a/run/make_init_base.py
+++ b/run/make_init_base.py
@@ -108,9 +108,9 @@ class initMaker:
         metagrp.createGroup("configuration")  # But add nothing to it
         datagrp = root.createGroup("data")
 
-        datagrp.createDimension("z", self.__nLayers)
-        datagrp.createDimension("y", self.__nFirst)
-        datagrp.createDimension("x", self.__nSecond)
+        datagrp.createDimension("zdim", self.__nLayers)
+        datagrp.createDimension("ydim", self.__nFirst)
+        datagrp.createDimension("xdim", self.__nSecond)
         datagrp.createDimension("yvertex", self.__nFirst + 1)
         datagrp.createDimension("xvertex", self.__nSecond + 1)
         datagrp.createDimension("y_cg", self.__nFirst * self.__nCg + 1)
@@ -119,7 +119,7 @@ class initMaker:
         datagrp.createDimension("dgstress_comp", self.__nDgStress)
         datagrp.createDimension("ncoords", self.__nCoords)
 
-        field_dims = ("y", "x")
+        field_dims = ("ydim", "xdim")
         coord_dims = ("yvertex", "xvertex", "ncoords")
 
         # Array coordinates

--- a/run/make_init_base.py
+++ b/run/make_init_base.py
@@ -5,7 +5,7 @@ class initMaker:
     """
     A "plug-and-play" initialisation class for neXtSIM. The user needs to supply
     at minimum the grid dimensions and resolution. They may also supply any
-    initialisation fields they need, as well as a land maks.
+    initialisation fields they need, as well as a land mask.
     Usage:
      0. Import make_init_base
       >>> from make_init_base import initMaker
@@ -167,7 +167,7 @@ class initMaker:
         hsnow[:, :] = self.hsnow
 
         # Set ice temperatures
-        tice = datagrp.createVariable("tice", "f8", ("z", "y", "x"))
+        tice = datagrp.createVariable("tice", "f8", ("zdim", "ydim", "xdim"))
         tice[:, :, :] = self.tice
 
         # Set ice velocity

--- a/run/make_init_para24x30.py
+++ b/run/make_init_para24x30.py
@@ -36,9 +36,9 @@ if __name__ == "__main__":
     formatted[0] = "2010-01-01T00:00:00Z"
     datagrp = root.createGroup("data")
 
-    nLay = datagrp.createDimension("z", nLayers)
-    yDim = datagrp.createDimension("y", nfirst)
-    xDim = datagrp.createDimension("x", nsecond)
+    nLay = datagrp.createDimension("zdim", nLayers)
+    yDim = datagrp.createDimension("ydim", nfirst)
+    xDim = datagrp.createDimension("xdim", nsecond)
     yVertexDim = datagrp.createDimension("yvertex", nfirst + 1)
     xVertexDim = datagrp.createDimension("xvertex", nsecond+ 1)
     ycg_dim = datagrp.createDimension("y_cg", nfirst * ncg + 1)
@@ -47,9 +47,9 @@ if __name__ == "__main__":
     dgs_comp = datagrp.createDimension("dgstress_comp", n_dgstress)
     n_coords_comp = datagrp.createDimension("ncoords", n_coords)
     
-    field_dims = ("y", "x")
+    field_dims = ("ydim", "xdim")
     coord_dims = ("yvertex", "xvertex", "ncoords")
-    zfield_dims = ("z", "y", "x")
+    zfield_dims = ("zdim", "ydim", "xdim")
 
     # Array coordinates
     space = 25000. # 25 km in metres

--- a/run/make_init_rect20x30.py
+++ b/run/make_init_rect20x30.py
@@ -16,11 +16,11 @@ metagrp.type = "simple_rectangular"
 
 datagrp = root.createGroup("data")
 
-xDim = datagrp.createDimension("x", nx)
-yDim = datagrp.createDimension("y", ny)
+xDim = datagrp.createDimension("xdim", nx)
+yDim = datagrp.createDimension("ydim", ny)
 nLay = datagrp.createDimension("nLayers", nLayers)
 
-hfield_dims = ("y", "x")
+hfield_dims = ("ydim", "xdim")
 
 mask = datagrp.createVariable("mask", "f8", hfield_dims)
 mask[:,::-1] = [[0,0,0,0,0,1,1,1,1,0,0,0,0,0,0,0,0,0,0,0],

--- a/run/make_init_rect20x30.py
+++ b/run/make_init_rect20x30.py
@@ -90,7 +90,7 @@ hice = datagrp.createVariable("hice", "f8", hfield_dims)
 hice[:,:] = cice[:,:] * 2
 hsnow = datagrp.createVariable("hsnow", "f8", hfield_dims)
 hsnow[:,:] = cice[:,:] / 2
-tice = datagrp.createVariable("tice", "f8", ("nLayers", "y", "x"))
+tice = datagrp.createVariable("tice", "f8", ("nLayers", "ydim", "xdim"))
 tice[0,:,:] = -0.5 - cice[:,:]
 
 mdi = -2.**300

--- a/test/ThermoIntegration_test.py
+++ b/test/ThermoIntegration_test.py
@@ -108,9 +108,9 @@ ks = 0.31
         n_dgstress = 1
         n_coords = 2
 
-        nLay = datagrp.createDimension("z", nLayers)
-        yDim = datagrp.createDimension("y", nfirst)
-        xDim = datagrp.createDimension("x", nsecond)
+        nLay = datagrp.createDimension("zdim", nLayers)
+        yDim = datagrp.createDimension("ydim", nfirst)
+        xDim = datagrp.createDimension("xdim", nsecond)
         yVertexDim = datagrp.createDimension("yvertex", nfirst + 1)
         xVertexDim = datagrp.createDimension("xvertex", nsecond + 1)
         ycg_dim = datagrp.createDimension("y_cg", nfirst * ncg + 1)
@@ -119,9 +119,9 @@ ks = 0.31
         dgs_comp = datagrp.createDimension("dgstress_comp", n_dgstress)
         n_coords_comp = datagrp.createDimension("ncoords", n_coords)
 
-        field_dims = ("y", "x")
+        field_dims = ("ydim", "xdim")
         coord_dims = ("yvertex", "xvertex", "ncoords")
-        zfield_dims = ("z", "y", "x")
+        zfield_dims = ("zdim", "ydim", "xdim")
 
         # Array coordinates
         node_lon = np.zeros((nfirst + 1, nsecond + 1))


### PR DESCRIPTION
# Dimension names
## Fixes \#550

---
# Change Description

For Cartesian restart files, both the dimensions of the fields and the coordinate positions share the names x and y. This is confusing to humans reading these files, but causes Panoply to refuse to plot the fields at all.

Rename the dimensions to x_dim and y_dim.

---
# Test Description

The `ParaGrid` and `RectGrid` tests should still run

---
# Documentation Impact

No impact: these names are held within the creation scripts.
