### PR TITLE
Dimension names redux

### DIFF
--- a/core/src/RectGridIO.cpp
+++ b/core/src/RectGridIO.cpp
@@ -86,9 +86,9 @@ ModelState RectGridIO::getModelState(const std::string& filePath)
     // Get the sizes of the four types of field
     // HField from hice
     dimensionSetter(dataGroup, hiceName, ModelArray::Type::H, metadata);
-    // UField from hice        TODO replace with u velocity once it is present
+    // UField from hice
     dimensionSetter(dataGroup, hiceName, ModelArray::Type::U, metadata);
-    // VField from hice        TODO replace with v velocity once it is present
+    // VField from hice
     dimensionSetter(dataGroup, hiceName, ModelArray::Type::V, metadata);
     // ZField from tice
     dimensionSetter(dataGroup, ticeName, ModelArray::Type::Z, metadata);
@@ -96,9 +96,9 @@ ModelState RectGridIO::getModelState(const std::string& filePath)
     // Get the sizes of the four types of field
     // HField from hice
     dimensionSetter(dataGroup, hiceName, ModelArray::Type::H);
-    // UField from hice        TODO replace with u velocity once it is present
+    // UField from hice
     dimensionSetter(dataGroup, hiceName, ModelArray::Type::U);
-    // VField from hice        TODO replace with v velocity once it is present
+    // VField from hice
     dimensionSetter(dataGroup, hiceName, ModelArray::Type::V);
     // ZField from tice
     dimensionSetter(dataGroup, ticeName, ModelArray::Type::Z);

--- a/core/src/discontinuousgalerkin/ModelArrayDetails.cpp
+++ b/core/src/discontinuousgalerkin/ModelArrayDetails.cpp
@@ -16,18 +16,18 @@
 namespace Nextsim {
 // clang-format off
 std::map<ModelArray::Dimension, ModelArray::DimensionSpec> ModelArray::definedDimensions = {
-    { ModelArray::Dimension::X, { "xdim", 0 } },
-    { ModelArray::Dimension::Y, { "ydim", 0 } },
-    { ModelArray::Dimension::Z, { "zdim", 1 } },
-    { ModelArray::Dimension::XVERTEX, { "xvertex", 1 } }, // defined as x + 1
-    { ModelArray::Dimension::YVERTEX, { "yvertex", 1 } }, // defined as y + 1
-    { ModelArray::Dimension::XCG, { "x_cg", 1 } },
-    { ModelArray::Dimension::YCG, { "y_cg", 1 } },
+    { ModelArray::Dimension::X, { "xdim", "x", 0 } },
+    { ModelArray::Dimension::Y, { "ydim", "y", 0 } },
+    { ModelArray::Dimension::Z, { "zdim", "z", 1 } },
+    { ModelArray::Dimension::XVERTEX, { "xvertex", "xvertex", 1 } }, // defined as x + 1
+    { ModelArray::Dimension::YVERTEX, { "yvertex", "yvertex", 1 } }, // defined as y + 1
+    { ModelArray::Dimension::XCG, { "x_cg", "x_cg", 1 } },
+    { ModelArray::Dimension::YCG, { "y_cg", "y_cg", 1 } },
     // The DG components are also included here to store the names
-    { ModelArray::Dimension::DG, { "dg_comp", 1 } },
-    { ModelArray::Dimension::DGSTRESS, { "dgstress_comp", 1 } },
-    { ModelArray::Dimension::NCOORDS, { "ncoords", 2 } }, // It's a two dimensional model
-// clang-format on
+    { ModelArray::Dimension::DG, { "dg_comp", "dg_comp", 1 } },
+    { ModelArray::Dimension::DGSTRESS, { "dgstress_comp", "dgstress_comp", 1 } },
+    { ModelArray::Dimension::NCOORDS, { "ncoords", "ncoords", 2 } }, // It's a two dimensional model
+    // clang-format on
 };
 
 ModelArray::TypeDimensions ModelArray::typeDimensions = {

--- a/core/src/finitevolume/ModelArrayDetails.cpp
+++ b/core/src/finitevolume/ModelArrayDetails.cpp
@@ -15,11 +15,11 @@
 
 namespace Nextsim {
 std::map<ModelArray::Dimension, ModelArray::DimensionSpec> ModelArray::definedDimensions = {
-    { ModelArray::Dimension::X, { "xdim", 0 } },
-    { ModelArray::Dimension::Y, { "ydim", 0 } },
-    { ModelArray::Dimension::Z, { "zdim", 1 } },
-    { ModelArray::Dimension::XVERTEX, { "xvertex", 1 } }, // defined as x + 1
-    { ModelArray::Dimension::YVERTEX, { "yvertex", 1 } }, // defined as y + 1
+    { ModelArray::Dimension::X, { "xdim", "x", 0 } },
+    { ModelArray::Dimension::Y, { "ydim", "y", 0 } },
+    { ModelArray::Dimension::Z, { "zdim", "z", 1 } },
+    { ModelArray::Dimension::XVERTEX, { "xvertex", "xvertex", 1 } }, // defined as x + 1
+    { ModelArray::Dimension::YVERTEX, { "yvertex", "yvertex", 1 } }, // defined as y + 1
 };
 
 ModelArray::TypeDimensions ModelArray::typeDimensions = {

--- a/core/src/include/ModelArray.hpp
+++ b/core/src/include/ModelArray.hpp
@@ -56,6 +56,7 @@ public:
 
     struct DimensionSpec {
         std::string name;
+        std::string altName;
         size_t length;
     };
     typedef std::map<Type, std::vector<Dimension>> TypeDimensions;

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -83,6 +83,8 @@ else()
   target_compile_definitions(testParaGrid PRIVATE TEST_FILE_SOURCE=${CMAKE_CURRENT_SOURCE_DIR})
   target_include_directories(testParaGrid PRIVATE ${MODEL_INCLUDE_DIR} "${ModulesRoot}/StructureModule")
   target_link_libraries(testParaGrid PRIVATE nextsimlib doctest::doctest)
+  file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/old_names.nc"
+     DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
 endif()
 
 add_executable(testModelComponent "ModelComponent_test.cpp")

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -12,6 +12,9 @@ set(PHYSICS_INCLUDE_DIRS
 
 set(ModulesRoot "../src/modules")
 
+# Generate netCDF files for tests
+execute_process(COMMAND "${Python_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/old_names.py" WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
+
 include_directories(${COMMON_INCLUDE_DIRS})
 
 add_executable(testIterator "Iterator_test.cpp")

--- a/core/test/ParaGrid_test.cpp
+++ b/core/test/ParaGrid_test.cpp
@@ -482,7 +482,7 @@ TEST_CASE("Check if a file with the old dimension names can be read")
     REQUIRE(ModelArray::nComponents(ModelArray::Type::DG) == DG);
     REQUIRE(ModelArray::nComponents(ModelArray::Type::VERTEX) == ModelArray::nCoords);
 
-    ModelState ms = gridIn.getModelState(filename);
+    ModelState ms = gridIn.getModelState(inputFilename);
 
     REQUIRE(ModelArray::dimensions(ModelArray::Type::Z)[0] == nx);
     REQUIRE(ModelArray::dimensions(ModelArray::Type::Z)[1] == ny);

--- a/core/test/ParaGrid_test.cpp
+++ b/core/test/ParaGrid_test.cpp
@@ -452,8 +452,44 @@ TEST_CASE("Check an exception is thrown for an invalid file name")
     // MD5 hash of the current output of $ date
     std::string longRandomFilename("a44f5cc1f7934a8ae8dd03a95308745d.nc");
     REQUIRE_THROWS(state = gridIn.getModelState(longRandomFilename));
+}
+
+TEST_CASE("Check if a file with the old dimension names can be read")
+{
+    std::string inputFilename = "old_names.nc";
+
+    Module::setImplementation<IStructure>("Nextsim::ParametricGrid");
+
+    REQUIRE(Module::getImplementation<IStructure>().structureType() == "parametric_rectangular");
+
+    size_t nx = 1;
+    size_t ny = 1;
+    NZLevels::set(1);
+
+    ParametricGrid gridIn;
+    ParaGridIO* readIO = new ParaGridIO(gridIn);
+    gridIn.setIO(readIO);
+
+    // Reset the array dimensions to make sure that the read function gets them correct
+    ModelArray::setDimension(ModelArray::Dimension::X, 2);
+    ModelArray::setDimension(ModelArray::Dimension::Y, 2);
+    ModelArray::setDimension(ModelArray::Dimension::Z, 2);
+    ModelArray::setDimension(ModelArray::Dimension::XVERTEX, 3);
+    ModelArray::setDimension(ModelArray::Dimension::YVERTEX, 3);
+    ModelArray::setDimension(ModelArray::Dimension::XCG, 2);
+    ModelArray::setDimension(ModelArray::Dimension::YCG, 2);
+    // In the full model numbers of DG components are set at compile time, so they are not reset
+    REQUIRE(ModelArray::nComponents(ModelArray::Type::DG) == DG);
+    REQUIRE(ModelArray::nComponents(ModelArray::Type::VERTEX) == ModelArray::nCoords);
+
+    ModelState ms = gridIn.getModelState(filename);
+
+    REQUIRE(ModelArray::dimensions(ModelArray::Type::Z)[0] == nx);
+    REQUIRE(ModelArray::dimensions(ModelArray::Type::Z)[1] == ny);
+    REQUIRE(ModelArray::dimensions(ModelArray::Type::Z)[2] == NZLevels::get());
 
 }
+
 TEST_SUITE_END();
 
 }

--- a/core/test/old_names.py
+++ b/core/test/old_names.py
@@ -1,8 +1,6 @@
 import netCDF4
 import numpy as np
-import numpy.ma as ma
 import time
-import math
 
 # Create a restart file that specifically uses the old dimension names
 if __name__ == "__main__":
@@ -53,9 +51,7 @@ if __name__ == "__main__":
 
     # Array coordinates
     space = 25000. # 25 km in metres
-    node_x = np.zeros((nfirst + 1, nsecond + 1))
-    node_y = np.zeros((nfirst + 1, nsecond + 1))
-    
+
     x_vertex1d = np.arange(0, space * (nsecond + 1), space)
     y_vertex1d = np.arange(0, space * (nfirst +1), space)
     

--- a/core/test/old_names.py
+++ b/core/test/old_names.py
@@ -1,0 +1,121 @@
+import netCDF4
+import numpy as np
+import numpy.ma as ma
+import time
+import math
+
+# Create a restart file that specifically uses the old dimension names
+if __name__ == "__main__":
+
+    # Grid dimensions. x varies fastest
+    nfirst = 1
+    nsecond = 1
+    nLayers = 1
+    ncg = 1
+    n_dg = 1
+    n_dgstress = 1
+    n_coords = 2
+    
+    
+    root = netCDF4.Dataset("old_names.nc", "w", format="NETCDF4")
+    
+    structure_name = "parametric_rectangular"
+    structgrp = root.createGroup("structure")
+    structgrp.type = structure_name
+    
+    metagrp = root.createGroup("metadata")
+    metagrp.type = structure_name
+    confgrp = metagrp.createGroup("configuration") # But add nothing to it
+    timegrp = metagrp.createGroup("time")
+    time_var = timegrp.createVariable("time", "i8")
+    data_time = 1263204000
+    time_var[:] = data_time
+    time.units = "seconds since 1970-01-01T00:00:00Z"
+    formatted = timegrp.createVariable("formatted", str)
+    formatted.format = "%Y-%m-%dT%H:%M:%SZ"
+    formatted[0] = "2010-01-01T00:00:00Z"
+    datagrp = root.createGroup("data")
+
+    nLay = datagrp.createDimension("z", nLayers)
+    yDim = datagrp.createDimension("y", nfirst)
+    xDim = datagrp.createDimension("x", nsecond)
+    yVertexDim = datagrp.createDimension("yvertex", nfirst + 1)
+    xVertexDim = datagrp.createDimension("xvertex", nsecond+ 1)
+    ycg_dim = datagrp.createDimension("y_cg", nfirst * ncg + 1)
+    xcg_dim = datagrp.createDimension("x_cg", nsecond * ncg + 1)
+    dg_comp = datagrp.createDimension("dg_comp", n_dg)
+    dgs_comp = datagrp.createDimension("dgstress_comp", n_dgstress)
+    n_coords_comp = datagrp.createDimension("ncoords", n_coords)
+    
+    field_dims = ("y", "x")
+    coord_dims = ("yvertex", "xvertex", "ncoords")
+    zfield_dims = ("z", "y", "x")
+
+    # Array coordinates
+    space = 25000. # 25 km in metres
+    node_x = np.zeros((nfirst + 1, nsecond + 1))
+    node_y = np.zeros((nfirst + 1, nsecond + 1))
+    
+    x_vertex1d = np.arange(0, space * (nsecond + 1), space)
+    y_vertex1d = np.arange(0, space * (nfirst +1), space)
+    
+    x_vertex = np.resize(x_vertex1d, (nfirst + 1, nsecond + 1))
+    y_vertex = np.resize(y_vertex1d, (nsecond + 1, nfirst + 1)).transpose()
+    
+    coords = datagrp.createVariable("coords", "f8", coord_dims)
+    coords[:,:,0] = x_vertex
+    coords[:,:,1] = y_vertex
+    
+    x_cell1d = np.arange(space * 0.5, space * (nsecond + 0.5), space)
+    y_cell1d = np.arange(space * 0.5, space * (nfirst + 0.5), space)
+    
+    x_cell = np.resize(x_cell1d, (nfirst, nsecond))
+    y_cell = np.resize(y_cell1d, (nsecond, nfirst)).transpose()
+    
+    elem_x = datagrp.createVariable("x", "f8", field_dims)
+    elem_x[:, :] = x_cell
+    elem_y = datagrp.createVariable("y", "f8", field_dims)
+    elem_y[:, :] = y_cell
+    
+    grid_azimuth = datagrp.createVariable("grid_azimuth", "f8", field_dims)
+    # Return the grid azimuth to the range -180˚ to 180˚
+    grid_azimuth[:, :] = 0.
+    
+    # All sea, everywhere
+    mask = datagrp.createVariable("mask", "f8", field_dims)
+    mask[:, :] = 1
+    
+    # Ice concentration and thickness
+    cice = datagrp.createVariable("cice", "f8", field_dims)
+    hice = datagrp.createVariable("hice", "f8", field_dims)
+    cice[:, :] = 0.96875 # 31/32
+    hice[:, :] = 1.5
+    
+    # Snow thickness
+    hsnow = datagrp.createVariable("hsnow", "f8", field_dims)
+    hsnow[:, :] = 0.125
+
+    # SSS
+    sss = datagrp.createVariable("sss", "f8", field_dims)
+    sss[:, :] = 32.
+
+    mu = -0.055
+
+    # SST
+    sst = datagrp.createVariable("sst", "f8", field_dims)
+    sst[:, :] = mu * sss[:, :]
+
+    # Ice temperature
+    tice = datagrp.createVariable("tice", "f8", zfield_dims)
+    ice_melt = mu * 5 # Melting point of sea ice (salinity = 5) in ˚C
+    # Tice outside the ice pack is the melting point of pure water ice, which is conveniently 0˚C
+    tice[0, :, :] = ice_melt
+    
+    # Ice starts at rest
+    u = datagrp.createVariable("u", "f8", field_dims)
+    u[:, :] = 0
+
+    v = datagrp.createVariable("v", "f8", field_dims)
+    v[:, :] = 0
+    
+    root.close()

--- a/core/test/testmodelarraydetails/ModelArrayDetails.cpp
+++ b/core/test/testmodelarraydetails/ModelArrayDetails.cpp
@@ -9,10 +9,10 @@
 
 namespace Nextsim {
 std::map<ModelArray::Dimension, ModelArray::DimensionSpec> ModelArray::definedDimensions = {
-    { ModelArray::Dimension::X, { "x", 1 } },
-    { ModelArray::Dimension::Y, { "y", 1 } },
-    { ModelArray::Dimension::Z, { "z", 1 } },
-    { ModelArray::Dimension::U, { "u", 1 } },
+    { ModelArray::Dimension::X, { "x", "x", 1 } },
+    { ModelArray::Dimension::Y, { "y", "y", 1 } },
+    { ModelArray::Dimension::Z, { "z", "z", 1 } },
+    { ModelArray::Dimension::U, { "u", "u", 1 } },
 };
 
 ModelArray::TypeDimensions ModelArray::typeDimensions = {

--- a/run/era5_topaz4_maker.py
+++ b/run/era5_topaz4_maker.py
@@ -249,12 +249,12 @@ if __name__ == "__main__":
     time_attr.units = "seconds since 1970-01-01T00:00:00Z"
     
     datagrp = era_root.createGroup("data")
-    xDim = datagrp.createDimension("x", nx)
-    yDim = datagrp.createDimension("y", ny)
+    xDim = datagrp.createDimension("xdim", nx)
+    yDim = datagrp.createDimension("ydim", ny)
     tDim = datagrp.createDimension("time", None)
     
-    hfield_dims = ("y", "x")
-    timefield_dims = ("time", "y", "x")
+    hfield_dims = ("ydim", "xdim")
+    timefield_dims = ("time", "ydim", "xdim")
     
     # Position and time variables
     nc_lons = datagrp.createVariable("longitude", "f8", hfield_dims)
@@ -355,8 +355,8 @@ if __name__ == "__main__":
     time_attr.units = "seconds since 1970-01-01T00:00:00Z"
     
     datagrp = topaz_root.createGroup("data")
-    xDim = datagrp.createDimension("x", nx)
-    yDim = datagrp.createDimension("y", ny)
+    xDim = datagrp.createDimension("xdim", nx)
+    yDim = datagrp.createDimension("ydim", ny)
     tDim = datagrp.createDimension("time", None)
     
     (unix_times_t, topaz4_times) = create_topaz_times(start_time, stop_time)


### PR DESCRIPTION
# Dimension names redux
## Fixes \#550 (again)

---
# Change Description

Accept both the new (`xdim`, `ydim`, `zdim`) and old (`x`, `y`, `z`) dimension names to increase compatibility.

---
# Test Description

Added a test that reads in a file with the old dimension names are ensures the dimensions are still set correctly.

---
# Documentation Impact

No impact. This is a convenience detail and no users should be writing new restart files using the old dimension names.

---
# Other Details

The generated `old_names.nc` file will suffer the same deficiencies as the restart files used to but will never be updated.
