### PR TITLE
Wrap XIOS API calls part 2: setters

### DIFF
--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -282,7 +282,7 @@ void Xios::updateCalendar(int stepNumber) { cxios_update_calendar(stepNumber); }
 void Xios::createAxis(std::string axisId)
 {
     xios::CAxisGroup* axisGroup = NULL;
-    std::string axisGroupId = { "default_xios_axis_group" }; // TODO: Generalise
+    std::string axisGroupId = { "axis_definition" };
     cxios_xml_tree_add_axisgroup(&axisGroup, axisGroupId.c_str(), axisGroupId.length());
     xios::CAxis* axis = NULL;
     cxios_xml_tree_add_axis(axisGroup, &axis, axisId.c_str(), axisId.length());
@@ -383,7 +383,7 @@ bool Xios::areDefinedAxisValues(std::string axisId)
 void Xios::createDomain(std::string domainId)
 {
     xios::CDomainGroup* domainGroup = NULL;
-    std::string domainGroupId = { "default_xios_domain_group" }; // TODO: Generalise
+    std::string domainGroupId = { "domain_definition" };
     cxios_xml_tree_add_domaingroup(&domainGroup, domainGroupId.c_str(), domainGroupId.length());
     xios::CDomain* domain = NULL;
     cxios_xml_tree_add_domain(domainGroup, &domain, domainId.c_str(), domainId.length());
@@ -736,7 +736,7 @@ bool Xios::areDefinedDomainLatitudeValues(std::string domainId)
 void Xios::createGrid(std::string gridId)
 {
     xios::CGridGroup* gridGroup = NULL;
-    std::string gridGroupId = { "default_xios_grid_group" }; // TODO: Generalise
+    std::string gridGroupId = { "grid_definition" };
     cxios_xml_tree_add_gridgroup(&gridGroup, gridGroupId.c_str(), gridGroupId.length());
     xios::CGrid* grid = NULL;
     cxios_xml_tree_add_grid(gridGroup, &grid, gridId.c_str(), gridId.length());
@@ -794,6 +794,30 @@ bool Xios::isDefinedGridName(std::string gridId)
 }
 
 /*!
+ * Associate an axis with a grid
+ *
+ * @param the grid ID
+ * @param the axis ID
+ */
+void Xios::gridAddAxis(std::string gridId, std::string axisId)
+{
+    xios::CAxis* axis = getAxis(axisId);
+    cxios_xml_tree_add_axistogrid(getGrid(gridId), &axis, axisId.c_str(), axisId.length());
+}
+
+/*!
+ * Associate a domain with a grid
+ *
+ * @param the grid ID
+ * @param the domain ID
+ */
+void Xios::gridAddDomain(std::string gridId, std::string domainId)
+{
+    xios::CDomain* domain = getDomain(domainId);
+    cxios_xml_tree_add_domaintogrid(getGrid(gridId), &domain, domainId.c_str(), domainId.length());
+}
+
+/*!
  * Create a field with some ID
  *
  * @param the field ID
@@ -801,7 +825,7 @@ bool Xios::isDefinedGridName(std::string gridId)
 void Xios::createField(std::string fieldId)
 {
     xios::CFieldGroup* fieldGroup = NULL;
-    std::string fieldGroupId = { "default_xios_field_group" }; // TODO: Generalise
+    std::string fieldGroupId = { "field_definition" };
     cxios_xml_tree_add_fieldgroup(&fieldGroup, fieldGroupId.c_str(), fieldGroupId.length());
     xios::CField* field = NULL;
     cxios_xml_tree_add_field(fieldGroup, &field, fieldId.c_str(), fieldId.length());
@@ -942,7 +966,7 @@ bool Xios::isDefinedFieldGridRef(std::string fieldId)
 void Xios::createFile(std::string fileId)
 {
     xios::CFileGroup* fileGroup = NULL;
-    std::string fileGroupId = { "default_xios_file_group" }; // TODO: Generalise
+    std::string fileGroupId = { "file_definition" };
     cxios_xml_tree_add_filegroup(&fileGroup, fileGroupId.c_str(), fileGroupId.length());
     xios::CFile* file = NULL;
     cxios_xml_tree_add_file(fileGroup, &file, fileId.c_str(), fileId.length());
@@ -1089,6 +1113,18 @@ bool Xios::isDefinedFileType(std::string fileId)
 bool Xios::isDefinedFileOutputFreq(std::string fileId)
 {
     return cxios_is_defined_file_output_freq(getFile(fileId));
+}
+
+/*!
+ * Associate a field with a file
+ *
+ * @param the file ID
+ * @param the field ID
+ */
+void Xios::fileAddField(std::string fileId, std::string fieldId)
+{
+    xios::CField* field = getField(fieldId);
+    cxios_xml_tree_add_fieldtofile(getFile(fileId), &field, fieldId.c_str(), fieldId.length());
 }
 
 /*!

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file    Xios.cpp
- * @author  Tom Meltzer <tdm39@cam.ac.uk>
- * @date    Fri 23 Feb 13:43:16 GMT 2024
+ * @author  Joe Wallwork <jw2423@cam.ac.uk
+ * @date    7 June 2024
  * @brief   XIOS interface implementation
  * @details
  *

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -524,6 +524,57 @@ std::vector<double> Xios::getDomainLatitudeValues(std::string domainId)
 }
 
 /*!
+ * Get the grid associated with a given ID
+ *
+ * @param the grid ID
+ * @return a pointer to the XIOS CGrid object
+ */
+xios::CGrid* Xios::getGrid(std::string gridId)
+{
+    xios::CGrid* grid = NULL;
+    cxios_grid_handle_create(&grid, gridId.c_str(), gridId.length());
+    return grid;
+}
+
+/*!
+ * Get the name of a grid with a given ID
+ *
+ * @param the grid ID
+ * @return name of the corresponding grid
+ */
+std::string Xios::getGridName(std::string gridId)
+{
+    int size = 20;
+    char cStr[size];
+    cxios_get_grid_name(getGrid(gridId), cStr, size);
+    std::string gridName(cStr, size);
+    boost::algorithm::trim_right(gridName);
+    return gridName;
+}
+
+/*!
+ * Set the name of a grid with a given ID
+ *
+ * @param the grid ID
+ * @param name to set
+ */
+void Xios::setGridName(std::string gridId, std::string gridName)
+{
+    cxios_set_grid_name(getGrid(gridId), gridName.c_str(), gridName.length());
+}
+
+/*!
+ * Verify whether a name has been defined for a given grid ID
+ *
+ * @param the grid ID
+ * @return `true` if the name has been set, otherwise `false`
+ */
+bool Xios::isDefinedGridName(std::string gridId)
+{
+    return cxios_is_defined_grid_name(getGrid(gridId));
+}
+
+/*!
  * Get the field associated with a given ID
  *
  * @param the field ID
@@ -615,35 +666,6 @@ bool Xios::isDefinedFieldOperation(std::string fieldId)
 bool Xios::isDefinedFieldGridRef(std::string fieldId)
 {
     return cxios_is_defined_field_grid_ref(getField(fieldId));
-}
-
-/*!
- * Get the grid associated with a given ID
- *
- * @param the grid ID
- * @return a pointer to the XIOS CGrid object
- */
-xios::CGrid* Xios::getGrid(std::string gridId)
-{
-    xios::CGrid* grid = NULL;
-    cxios_grid_handle_create(&grid, gridId.c_str(), gridId.length());
-    return grid;
-}
-
-/*!
- * Get the name of a grid with a given ID
- *
- * @param the grid ID
- * @return name of the corresponding grid
- */
-std::string Xios::getGridName(std::string gridId)
-{
-    int size = 20;
-    char cStr[size];
-    cxios_get_grid_name(getGrid(gridId), cStr, size);
-    std::string gridName(cStr, size);
-    boost::algorithm::trim_right(gridName);
-    return gridName;
 }
 
 /*!

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -588,6 +588,39 @@ xios::CField* Xios::getField(std::string fieldId)
 }
 
 /*!
+ * Set the name of a field with a given ID
+ *
+ * @param the field ID
+ * @param name to set
+ */
+void Xios::setFieldName(std::string fieldId, std::string fieldName)
+{
+    cxios_set_field_name(getField(fieldId), fieldName.c_str(), fieldName.length());
+}
+
+/*!
+ * Set the operation for a field with a given ID
+ *
+ * @param the field ID
+ * @param operation to set
+ */
+void Xios::setFieldOperation(std::string fieldId, std::string operation)
+{
+    cxios_set_field_operation(getField(fieldId), operation.c_str(), operation.length());
+}
+
+/*!
+ * Set the grid reference for a field with a given ID
+ *
+ * @param the field ID
+ * @param grid reference to set
+ */
+void Xios::setFieldGridRef(std::string fieldId, std::string gridRef)
+{
+    cxios_set_field_grid_ref(getField(fieldId), gridRef.c_str(), gridRef.length());
+}
+
+/*!
  * Get the name of a field with a given ID
  *
  * @param the field ID

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -275,6 +275,20 @@ void Xios::setCalendarTimestep(cxios_duration timestep)
 void Xios::updateCalendar(int stepNumber) { cxios_update_calendar(stepNumber); }
 
 /*!
+ * Create an axis with some ID
+ *
+ * @param the axis ID
+ */
+void Xios::createAxis(std::string axisId)
+{
+    xios::CAxisGroup* axisGroup = NULL;
+    std::string axisGroupId = { "default_xios_axis_group" }; // TODO: Generalise
+    cxios_xml_tree_add_axisgroup(&axisGroup, axisGroupId.c_str(), axisGroupId.length());
+    xios::CAxis* axis = NULL;
+    cxios_xml_tree_add_axis(axisGroup, &axis, axisId.c_str(), axisId.length());
+}
+
+/*!
  * Get the axis associated with a given ID
  *
  * @param the axis ID
@@ -359,6 +373,20 @@ bool Xios::isDefinedAxisSize(std::string axisId)
 bool Xios::areDefinedAxisValues(std::string axisId)
 {
     return cxios_is_defined_axis_value(getAxis(axisId));
+}
+
+/*!
+ * Create a domain with some ID
+ *
+ * @param the domain ID
+ */
+void Xios::createDomain(std::string domainId)
+{
+    xios::CDomainGroup* domainGroup = NULL;
+    std::string domainGroupId = { "default_xios_domain_group" }; // TODO: Generalise
+    cxios_xml_tree_add_domaingroup(&domainGroup, domainGroupId.c_str(), domainGroupId.length());
+    xios::CDomain* domain = NULL;
+    cxios_xml_tree_add_domain(domainGroup, &domain, domainId.c_str(), domainId.length());
 }
 
 /*!
@@ -701,6 +729,20 @@ bool Xios::areDefinedDomainLatitudeValues(std::string domainId)
 }
 
 /*!
+ * Create a grid with some ID
+ *
+ * @param the grid ID
+ */
+void Xios::createGrid(std::string gridId)
+{
+    xios::CGridGroup* gridGroup = NULL;
+    std::string gridGroupId = { "default_xios_grid_group" }; // TODO: Generalise
+    cxios_xml_tree_add_gridgroup(&gridGroup, gridGroupId.c_str(), gridGroupId.length());
+    xios::CGrid* grid = NULL;
+    cxios_xml_tree_add_grid(gridGroup, &grid, gridId.c_str(), gridId.length());
+}
+
+/*!
  * Get the grid associated with a given ID
  *
  * @param the grid ID
@@ -749,6 +791,20 @@ void Xios::setGridName(std::string gridId, std::string gridName)
 bool Xios::isDefinedGridName(std::string gridId)
 {
     return cxios_is_defined_grid_name(getGrid(gridId));
+}
+
+/*!
+ * Create a field with some ID
+ *
+ * @param the field ID
+ */
+void Xios::createField(std::string fieldId)
+{
+    xios::CFieldGroup* fieldGroup = NULL;
+    std::string fieldGroupId = { "default_xios_field_group" }; // TODO: Generalise
+    cxios_xml_tree_add_fieldgroup(&fieldGroup, fieldGroupId.c_str(), fieldGroupId.length());
+    xios::CField* field = NULL;
+    cxios_xml_tree_add_field(fieldGroup, &field, fieldId.c_str(), fieldId.length());
 }
 
 /*!
@@ -876,6 +932,20 @@ bool Xios::isDefinedFieldOperation(std::string fieldId)
 bool Xios::isDefinedFieldGridRef(std::string fieldId)
 {
     return cxios_is_defined_field_grid_ref(getField(fieldId));
+}
+
+/*!
+ * Create a file with some ID
+ *
+ * @param the file ID
+ */
+void Xios::createFile(std::string fileId)
+{
+    xios::CFileGroup* fileGroup = NULL;
+    std::string fileGroupId = { "default_xios_file_group" }; // TODO: Generalise
+    cxios_xml_tree_add_filegroup(&fileGroup, fileGroupId.c_str(), fileGroupId.length());
+    xios::CFile* file = NULL;
+    cxios_xml_tree_add_file(fileGroup, &file, fileId.c_str(), fileId.length());
 }
 
 /*!

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -660,6 +660,40 @@ xios::CFile* Xios::getFile(std::string fileId)
 }
 
 /*!
+ * Set the name of a file with a given ID
+ *
+ * @param the file ID
+ * @param file name to set
+ */
+void Xios::setFileName(std::string fileId, std::string fileName)
+{
+    cxios_set_file_name(getFile(fileId), fileName.c_str(), fileName.length());
+}
+
+/*!
+ * Set the type of a file with a given ID
+ *
+ * @param the file ID
+ * @param file type to set
+ */
+void Xios::setFileType(std::string fileId, std::string fileType)
+{
+    cxios_set_file_type(getFile(fileId), fileType.c_str(), fileType.length());
+}
+
+/*!
+ * Set the output frequency of a file with a given ID
+ *
+ * @param the file ID
+ * @param output frequency to set
+ */
+void Xios::setFileOutputFreq(std::string fileId, std::string freq)
+{
+    cxios_duration duration = cxios_duration_convert_from_string(freq.c_str(), freq.length());
+    cxios_set_file_output_freq(getFile(fileId), duration);
+}
+
+/*!
  * Get the name of a file with a given ID
  *
  * @param the file ID
@@ -704,9 +738,9 @@ std::string Xios::getFileOutputFreq(std::string fileId)
     int size = 20;
     char cStr[size];
     cxios_duration_convert_to_string(duration, cStr, size);
-    std::string outputFreq(cStr, size);
-    boost::algorithm::trim_right(outputFreq);
-    return outputFreq;
+    std::string freq(cStr, size);
+    boost::algorithm::trim_right(freq);
+    return freq;
 }
 
 /*!
@@ -720,6 +754,28 @@ bool Xios::validFileId(std::string fileId)
     bool valid;
     cxios_file_valid_id(&valid, fileId.c_str(), fileId.length());
     return valid;
+}
+
+/*!
+ * Verify whether a name has been defined for a given file ID
+ *
+ * @param the file ID
+ * @return `true` if the name has been set, otherwise `false`
+ */
+bool Xios::isDefinedFileName(std::string fileId)
+{
+    return cxios_is_defined_file_name(getFile(fileId));
+}
+
+/*!
+ * Verify whether a type has been defined for a given file ID
+ *
+ * @param the file ID
+ * @return `true` if the type has been set, otherwise `false`
+ */
+bool Xios::isDefinedFileType(std::string fileId)
+{
+    return cxios_is_defined_file_type(getFile(fileId));
 }
 
 /*!

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -288,6 +288,29 @@ xios::CAxis* Xios::getAxis(std::string axisId)
 }
 
 /*!
+ * Set the size of a given axis (the number of global points)
+ *
+ * @param the axis ID
+ * @param the size to set
+ */
+void Xios::setAxisSize(std::string axisId, int size)
+{
+    cxios_set_axis_n_glo(getAxis(axisId), size);
+}
+
+/*!
+ * Set the values associated with a given axis
+ *
+ * @param the axis ID
+ * @param the values to set
+ */
+void Xios::setAxisValues(std::string axisId, std::vector<double> values)
+{
+    int size = getAxisSize(axisId);
+    cxios_set_axis_value(getAxis(axisId), values.data(), &size);
+}
+
+/*!
  * Get the size of a given axis (the number of global points)
  *
  * @param the axis ID
@@ -314,6 +337,28 @@ std::vector<double> Xios::getAxisValues(std::string axisId)
     std::vector<double> vec(values, values + size);
     delete[] values;
     return vec;
+}
+
+/*!
+ * Verify whether a size has been defined for a given axis ID
+ *
+ * @param the axis ID
+ * @return `true` if the size has been set, otherwise `false`
+ */
+bool Xios::isDefinedAxisSize(std::string axisId)
+{
+    return cxios_is_defined_axis_n_glo(getAxis(axisId));
+}
+
+/*!
+ * Verify whether values have been defined for a given axis ID
+ *
+ * @param the axis ID
+ * @return `true` if the values have been set, otherwise `false`
+ */
+bool Xios::areDefinedAxisValues(std::string axisId)
+{
+    return cxios_is_defined_axis_value(getAxis(axisId));
 }
 
 /*!

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -398,6 +398,39 @@ xios::CDomain* Xios::getDomain(std::string domainId)
 }
 
 /*!
+ * Set the type of a given domain
+ *
+ * @param the domain ID
+ * @param domain type to set
+ */
+void Xios::setDomainType(std::string domainId, std::string domainType)
+{
+    cxios_set_domain_type(getDomain(domainId), domainType.c_str(), domainType.length());
+}
+
+/*!
+ * Set the global longitude size for a given domain
+ *
+ * @param the domain ID
+ * @param global longitude size to set
+ */
+void Xios::setDomainGlobalLongitudeSize(std::string domainId, int size)
+{
+    cxios_set_domain_ni_glo(getDomain(domainId), size);
+}
+
+/*!
+ * Set the global latitude size for a given domain
+ *
+ * @param the domain ID
+ * @param global latitude size to set
+ */
+void Xios::setDomainGlobalLatitudeSize(std::string domainId, int size)
+{
+    cxios_set_domain_nj_glo(getDomain(domainId), size);
+}
+
+/*!
  * Get the type of a given domain
  *
  * @param the domain ID
@@ -521,6 +554,105 @@ std::vector<double> Xios::getDomainLatitudeValues(std::string domainId)
     std::vector<double> vec(values, values + size);
     delete[] values;
     return vec;
+}
+
+/*!
+ * Verify whether a type has been defined for a given domain ID
+ *
+ * @param the domain ID
+ * @return `true` if the type has been set, otherwise `false`
+ */
+bool Xios::isDefinedDomainType(std::string domainId)
+{
+    return cxios_is_defined_domain_type(getDomain(domainId));
+}
+
+/*!
+ * Verify whether a global longitude size has been defined for a given domain ID
+ *
+ * @param the domain ID
+ * @return `true` if the global longitude size has been set, otherwise `false`
+ */
+bool Xios::isDefinedDomainGlobalLongitudeSize(std::string domainId)
+{
+    return cxios_is_defined_domain_ni_glo(getDomain(domainId));
+}
+
+/*!
+ * Verify whether a global latitude size has been defined for a given domain ID
+ *
+ * @param the domain ID
+ * @return `true` if the global latitude size has been set, otherwise `false`
+ */
+bool Xios::isDefinedDomainGlobalLatitudeSize(std::string domainId)
+{
+    return cxios_is_defined_domain_nj_glo(getDomain(domainId));
+}
+
+/*!
+ * Verify whether a local longitude size has been defined for a given domain ID
+ *
+ * @param the domain ID
+ * @return `true` if the local longitude size has been set, otherwise `false`
+ */
+bool Xios::isDefinedDomainLongitudeSize(std::string domainId)
+{
+    return cxios_is_defined_domain_ni(getDomain(domainId));
+}
+
+/*!
+ * Verify whether a local latitude size has been defined for a given domain ID
+ *
+ * @param the domain ID
+ * @return `true` if the local latitude size has been set, otherwise `false`
+ */
+bool Xios::isDefinedDomainLatitudeSize(std::string domainId)
+{
+    return cxios_is_defined_domain_nj(getDomain(domainId));
+}
+
+/*!
+ * Verify whether a local starting longitude has been defined for a given domain ID
+ *
+ * @param the domain ID
+ * @return `true` if the local starting longitude has been set, otherwise `false`
+ */
+bool Xios::isDefinedDomainLongitudeStart(std::string domainId)
+{
+    return cxios_is_defined_domain_ibegin(getDomain(domainId));
+}
+
+/*!
+ * Verify whether a local starting latitude has been defined for a given domain ID
+ *
+ * @param the domain ID
+ * @return `true` if the local starting latitude has been set, otherwise `false`
+ */
+bool Xios::isDefinedDomainLatitudeStart(std::string domainId)
+{
+    return cxios_is_defined_domain_jbegin(getDomain(domainId));
+}
+
+/*!
+ * Verify whether a local longitude values have been defined for a given domain ID
+ *
+ * @param the domain ID
+ * @return `true` if the local longitude values have been set, otherwise `false`
+ */
+bool Xios::areDefinedDomainLongitudeValues(std::string domainId)
+{
+    return cxios_is_defined_domain_lonvalue_1d(getDomain(domainId));
+}
+
+/*!
+ * Verify whether a local latitude values have been defined for a given domain ID
+ *
+ * @param the domain ID
+ * @return `true` if the local latitude values have been set, otherwise `false`
+ */
+bool Xios::areDefinedDomainLatitudeValues(std::string domainId)
+{
+    return cxios_is_defined_domain_latvalue_1d(getDomain(domainId));
 }
 
 /*!

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -275,17 +275,16 @@ void Xios::setCalendarTimestep(cxios_duration timestep)
 void Xios::updateCalendar(int stepNumber) { cxios_update_calendar(stepNumber); }
 
 /*!
- * Create an axis with some ID
+ * Get the axis_definition group
  *
- * @param the axis ID
+ * @return a pointer to the XIOS CAxisGroup object
  */
-void Xios::createAxis(std::string axisId)
+xios::CAxisGroup* Xios::getAxisGroup()
 {
-    xios::CAxisGroup* axisGroup = NULL;
-    std::string axisGroupId = { "axis_definition" };
-    cxios_xml_tree_add_axisgroup(&axisGroup, axisGroupId.c_str(), axisGroupId.length());
-    xios::CAxis* axis = NULL;
-    cxios_xml_tree_add_axis(axisGroup, &axis, axisId.c_str(), axisId.length());
+    std::string groupId = { "axis_definition" };
+    xios::CAxisGroup* group = NULL;
+    cxios_axisgroup_handle_create(&group, groupId.c_str(), groupId.length());
+    return group;
 }
 
 /*!
@@ -299,6 +298,17 @@ xios::CAxis* Xios::getAxis(std::string axisId)
     xios::CAxis* axis = NULL;
     cxios_axis_handle_create(&axis, axisId.c_str(), axisId.length());
     return axis;
+}
+
+/*!
+ * Create an axis with some ID
+ *
+ * @param the axis ID
+ */
+void Xios::createAxis(std::string axisId)
+{
+    xios::CAxis* axis = NULL;
+    cxios_xml_tree_add_axis(getAxisGroup(), &axis, axisId.c_str(), axisId.length());
 }
 
 /*!
@@ -376,17 +386,40 @@ bool Xios::areDefinedAxisValues(std::string axisId)
 }
 
 /*!
+ * Get the domain_definition group
+ *
+ * @return a pointer to the XIOS CDomainGroup object
+ */
+xios::CDomainGroup* Xios::getDomainGroup()
+{
+    std::string groupId = { "domain_definition" };
+    xios::CDomainGroup* group = NULL;
+    cxios_domaingroup_handle_create(&group, groupId.c_str(), groupId.length());
+    return group;
+}
+
+/*!
+ * Get the domain associated with a given ID
+ *
+ * @param the domain ID
+ * @return a pointer to the XIOS CDomain object
+ */
+xios::CDomain* Xios::getDomain(std::string domainId)
+{
+    xios::CDomain* domain = NULL;
+    cxios_domain_handle_create(&domain, domainId.c_str(), domainId.length());
+    return domain;
+}
+
+/*!
  * Create a domain with some ID
  *
  * @param the domain ID
  */
 void Xios::createDomain(std::string domainId)
 {
-    xios::CDomainGroup* domainGroup = NULL;
-    std::string domainGroupId = { "domain_definition" };
-    cxios_xml_tree_add_domaingroup(&domainGroup, domainGroupId.c_str(), domainGroupId.length());
     xios::CDomain* domain = NULL;
-    cxios_xml_tree_add_domain(domainGroup, &domain, domainId.c_str(), domainId.length());
+    cxios_xml_tree_add_domain(getDomainGroup(), &domain, domainId.c_str(), domainId.length());
 }
 
 /*!
@@ -455,19 +488,6 @@ void Xios::setDomainLatitudeValues(std::string domainId, std::vector<double> val
 {
     int size = getDomainLatitudeSize(domainId);
     cxios_set_domain_latvalue_1d(getDomain(domainId), values.data(), &size);
-}
-
-/*!
- * Get the domain associated with a given ID
- *
- * @param the domain ID
- * @return a pointer to the XIOS CDomain object
- */
-xios::CDomain* Xios::getDomain(std::string domainId)
-{
-    xios::CDomain* domain = NULL;
-    cxios_domain_handle_create(&domain, domainId.c_str(), domainId.length());
-    return domain;
 }
 
 /*!
@@ -729,17 +749,16 @@ bool Xios::areDefinedDomainLatitudeValues(std::string domainId)
 }
 
 /*!
- * Create a grid with some ID
+ * Get the grid_definition group
  *
- * @param the grid ID
+ * @return a pointer to the XIOS CGridGroup object
  */
-void Xios::createGrid(std::string gridId)
+xios::CGridGroup* Xios::getGridGroup()
 {
-    xios::CGridGroup* gridGroup = NULL;
-    std::string gridGroupId = { "grid_definition" };
-    cxios_xml_tree_add_gridgroup(&gridGroup, gridGroupId.c_str(), gridGroupId.length());
-    xios::CGrid* grid = NULL;
-    cxios_xml_tree_add_grid(gridGroup, &grid, gridId.c_str(), gridId.length());
+    std::string groupId = { "grid_definition" };
+    xios::CGridGroup* group = NULL;
+    cxios_gridgroup_handle_create(&group, groupId.c_str(), groupId.length());
+    return group;
 }
 
 /*!
@@ -753,6 +772,17 @@ xios::CGrid* Xios::getGrid(std::string gridId)
     xios::CGrid* grid = NULL;
     cxios_grid_handle_create(&grid, gridId.c_str(), gridId.length());
     return grid;
+}
+
+/*!
+ * Create a grid with some ID
+ *
+ * @param the grid ID
+ */
+void Xios::createGrid(std::string gridId)
+{
+    xios::CGrid* grid = NULL;
+    cxios_xml_tree_add_grid(getGridGroup(), &grid, gridId.c_str(), gridId.length());
 }
 
 /*!
@@ -818,17 +848,16 @@ void Xios::gridAddDomain(std::string gridId, std::string domainId)
 }
 
 /*!
- * Create a field with some ID
+ * Get the field_definition group
  *
- * @param the field ID
+ * @return a pointer to the XIOS CFieldGroup object
  */
-void Xios::createField(std::string fieldId)
+xios::CFieldGroup* Xios::getFieldGroup()
 {
-    xios::CFieldGroup* fieldGroup = NULL;
-    std::string fieldGroupId = { "field_definition" };
-    cxios_xml_tree_add_fieldgroup(&fieldGroup, fieldGroupId.c_str(), fieldGroupId.length());
-    xios::CField* field = NULL;
-    cxios_xml_tree_add_field(fieldGroup, &field, fieldId.c_str(), fieldId.length());
+    std::string groupId = { "field_definition" };
+    xios::CFieldGroup* group = NULL;
+    cxios_fieldgroup_handle_create(&group, groupId.c_str(), groupId.length());
+    return group;
 }
 
 /*!
@@ -842,6 +871,17 @@ xios::CField* Xios::getField(std::string fieldId)
     xios::CField* field = NULL;
     cxios_field_handle_create(&field, fieldId.c_str(), fieldId.length());
     return field;
+}
+
+/*!
+ * Create a field with some ID
+ *
+ * @param the field ID
+ */
+void Xios::createField(std::string fieldId)
+{
+    xios::CField* field = NULL;
+    cxios_xml_tree_add_field(getFieldGroup(), &field, fieldId.c_str(), fieldId.length());
 }
 
 /*!
@@ -959,17 +999,16 @@ bool Xios::isDefinedFieldGridRef(std::string fieldId)
 }
 
 /*!
- * Create a file with some ID
+ * Get the file_definition group
  *
- * @param the file ID
+ * @return a pointer to the XIOS CFileGroup object
  */
-void Xios::createFile(std::string fileId)
+xios::CFileGroup* Xios::getFileGroup()
 {
-    xios::CFileGroup* fileGroup = NULL;
-    std::string fileGroupId = { "file_definition" };
-    cxios_xml_tree_add_filegroup(&fileGroup, fileGroupId.c_str(), fileGroupId.length());
-    xios::CFile* file = NULL;
-    cxios_xml_tree_add_file(fileGroup, &file, fileId.c_str(), fileId.length());
+    std::string groupId = { "file_definition" };
+    xios::CFileGroup* group = NULL;
+    cxios_filegroup_handle_create(&group, groupId.c_str(), groupId.length());
+    return group;
 }
 
 /*!
@@ -983,6 +1022,17 @@ xios::CFile* Xios::getFile(std::string fileId)
     xios::CFile* file = NULL;
     cxios_file_handle_create(&file, fileId.c_str(), fileId.length());
     return file;
+}
+
+/*!
+ * Create a file with some ID
+ *
+ * @param the file ID
+ */
+void Xios::createFile(std::string fileId)
+{
+    xios::CFile* file = NULL;
+    cxios_xml_tree_add_file(getFileGroup(), &file, fileId.c_str(), fileId.length());
 }
 
 /*!

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -61,9 +61,9 @@ public:
 
     /* Domain */
     void createDomain(std::string domainId); // TODO
-    void setDomainType(std::string domainId, std::string domainType); // TODO
-    void setDomainGlobalLongitudeSize(std::string domainId, int size); // TODO
-    void setDomainGlobalLatitudeSize(std::string domainId, int size); // TODO
+    void setDomainType(std::string domainId, std::string domainType);
+    void setDomainGlobalLongitudeSize(std::string domainId, int size);
+    void setDomainGlobalLatitudeSize(std::string domainId, int size);
     void setDomainLongitudeSize(std::string domainId, int size);
     void setDomainLatitudeSize(std::string domainId, int size);
     void setDomainLongitudeStart(std::string domainId, int start);
@@ -79,6 +79,15 @@ public:
     int getDomainLatitudeStart(std::string domainId);
     std::vector<double> getDomainLongitudeValues(std::string domainId);
     std::vector<double> getDomainLatitudeValues(std::string domainId);
+    bool isDefinedDomainType(std::string domainId);
+    bool isDefinedDomainGlobalLongitudeSize(std::string domainId);
+    bool isDefinedDomainGlobalLatitudeSize(std::string domainId);
+    bool isDefinedDomainLongitudeSize(std::string domainId);
+    bool isDefinedDomainLatitudeSize(std::string domainId);
+    bool isDefinedDomainLongitudeStart(std::string domainId);
+    bool isDefinedDomainLatitudeStart(std::string domainId);
+    bool areDefinedDomainLongitudeValues(std::string domainId);
+    bool areDefinedDomainLatitudeValues(std::string domainId);
 
     /* Grid */
     void createGrid(std::string gridId); // TODO

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -1,7 +1,7 @@
 /*!
  * @file    Xios.hpp
- * @author  Tom Meltzer <tdm39@cam.ac.uk>
- * @date    Fri 23 Feb 13:43:16 GMT 2024
+ * @author  Joe Wallwork <jw2423@cam.ac.uk
+ * @date    7 June 2024
  * @brief   XIOS interface header
  * @details
  *

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -96,6 +96,8 @@ public:
     void setGridName(std::string gridId, std::string name);
     std::string getGridName(std::string gridId);
     bool isDefinedGridName(std::string GridId);
+    void gridAddAxis(std::string axisId, std::string domainId);
+    void gridAddDomain(std::string gridId, std::string domainId);
 
     /* Field */
     void createField(std::string fieldId);
@@ -121,6 +123,7 @@ public:
     bool isDefinedFileName(std::string fileId);
     bool isDefinedFileType(std::string fileId);
     bool isDefinedFileOutputFreq(std::string fileId);
+    void fileAddField(std::string fileId, std::string fieldId);
 
     /* I/O */
     void write(const std::string fieldId, double* data, const int ni, const int nj);

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -99,13 +99,15 @@ public:
 
     /* File */
     void createFile(std::string fileId); // TODO
-    void setFileName(std::string fileId, std::string fileName); // TODO
-    void setFileType(std::string fileId, std::string fileType); // TODO
-    void setFileOutputFreq(std::string fileId, cxios_duration duration); // TODO
+    void setFileName(std::string fileId, std::string fileName);
+    void setFileType(std::string fileId, std::string fileType);
+    void setFileOutputFreq(std::string fileId, std::string outputFreq);
     std::string getFileName(std::string fileId);
     std::string getFileType(std::string fileId);
     std::string getFileOutputFreq(std::string fileId);
     bool validFileId(std::string fileId);
+    bool isDefinedFileName(std::string fileId);
+    bool isDefinedFileType(std::string fileId);
     bool isDefinedFileOutputFreq(std::string fileId);
 
     /* I/O */

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -53,7 +53,7 @@ public:
     void updateCalendar(int stepNumber);
 
     /* Axis */
-    void createAxis(std::string axisId); // TODO
+    void createAxis(std::string axisId);
     void setAxisSize(std::string axisId, int size);
     void setAxisValues(std::string axisId, std::vector<double> values);
     int getAxisSize(std::string axisId);
@@ -62,7 +62,7 @@ public:
     bool areDefinedAxisValues(std::string axisId);
 
     /* Domain */
-    void createDomain(std::string domainId); // TODO
+    void createDomain(std::string domainId);
     void setDomainType(std::string domainId, std::string domainType);
     void setDomainGlobalLongitudeSize(std::string domainId, int size);
     void setDomainGlobalLatitudeSize(std::string domainId, int size);
@@ -92,13 +92,13 @@ public:
     bool areDefinedDomainLatitudeValues(std::string domainId);
 
     /* Grid */
-    void createGrid(std::string gridId); // TODO
+    void createGrid(std::string gridId);
     void setGridName(std::string gridId, std::string name);
     std::string getGridName(std::string gridId);
     bool isDefinedGridName(std::string GridId);
 
     /* Field */
-    void createField(std::string fieldId); // TODO
+    void createField(std::string fieldId);
     void setFieldName(std::string fieldId, std::string name);
     void setFieldOperation(std::string fieldId, std::string operation);
     void setFieldGridRef(std::string fieldId, std::string gridRef);
@@ -110,7 +110,7 @@ public:
     bool isDefinedFieldGridRef(std::string fieldId);
 
     /* File */
-    void createFile(std::string fileId); // TODO
+    void createFile(std::string fileId);
     void setFileName(std::string fileId, std::string fileName);
     void setFileType(std::string fileId, std::string fileType);
     void setFileOutputFreq(std::string fileId, std::string outputFreq);

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -82,8 +82,9 @@ public:
 
     /* Grid */
     void createGrid(std::string gridId); // TODO
-    void setGridName(std::string gridId, std::string name); // TODO
+    void setGridName(std::string gridId, std::string name);
     std::string getGridName(std::string gridId);
+    bool isDefinedGridName(std::string GridId);
 
     /* Field */
     void createField(std::string fieldId); // TODO

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -54,10 +54,12 @@ public:
 
     /* Axis */
     void createAxis(std::string axisId); // TODO
-    void setAxisSize(std::string axisId, int size); // TODO
-    void setAxisValues(std::string axisId, std::vector<double> values); // TODO
+    void setAxisSize(std::string axisId, int size);
+    void setAxisValues(std::string axisId, std::vector<double> values);
     int getAxisSize(std::string axisId);
     std::vector<double> getAxisValues(std::string axisId);
+    bool isDefinedAxisSize(std::string axisId);
+    bool areDefinedAxisValues(std::string axisId);
 
     /* Domain */
     void createDomain(std::string domainId); // TODO

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -88,9 +88,9 @@ public:
 
     /* Field */
     void createField(std::string fieldId); // TODO
-    void setFieldName(std::string fieldId, std::string name); // TODO
-    void setFieldOperation(std::string fieldId, std::string operation); // TODO
-    void setFieldGridRef(std::string fieldId, std::string gridRef); // TODO
+    void setFieldName(std::string fieldId, std::string name);
+    void setFieldOperation(std::string fieldId, std::string operation);
+    void setFieldGridRef(std::string fieldId, std::string gridRef);
     std::string getFieldName(std::string fieldId);
     std::string getFieldOperation(std::string fieldId);
     std::string getFieldGridRef(std::string fieldId);

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -149,6 +149,12 @@ private:
     std::string clientId;
     std::string contextId;
 
+    xios::CAxisGroup* getAxisGroup();
+    xios::CDomainGroup* getDomainGroup();
+    xios::CFieldGroup* getFieldGroup();
+    xios::CGridGroup* getGridGroup();
+    xios::CFileGroup* getFileGroup();
+
     xios::CAxis* getAxis(std::string axisId);
     xios::CDomain* getDomain(std::string domainId);
     xios::CField* getField(std::string fieldId);

--- a/core/src/include/xios_c_interface.hpp
+++ b/core/src/include/xios_c_interface.hpp
@@ -62,8 +62,12 @@ void cxios_update_calendar_timestep(xios::CCalendarWrapper* calendarWrapper_hdl)
 
 // axis methods
 void cxios_axis_handle_create(xios::CAxis** _ret, const char* _id, int _id_len);
+void cxios_set_axis_n_glo(xios::CAxis* axis_hdl, int n_glo);
+void cxios_set_axis_value(xios::CAxis* axis_hdl, double* value, int* extent);
 void cxios_get_axis_n_glo(xios::CAxis* axis_hdl, int* n_glo);
 void cxios_get_axis_value(xios::CAxis* axis_hdl, double* value, int* extent);
+bool cxios_is_defined_axis_n_glo(xios::CAxis* axis_hdl);
+bool cxios_is_defined_axis_value(xios::CAxis* axis_hdl);
 
 // domain methods
 void cxios_domain_handle_create(xios::CDomain** _ret, const char* _id, int _id_len);

--- a/core/src/include/xios_c_interface.hpp
+++ b/core/src/include/xios_c_interface.hpp
@@ -19,6 +19,8 @@
 #include <calendar_wrapper.hpp>
 #include <domain.hpp>
 #include <field.hpp>
+#include <file.hpp>
+#include <grid.hpp>
 #include <icdate.hpp>
 
 extern "C" {
@@ -61,6 +63,9 @@ void cxios_get_calendar_wrapper_timestep(
 void cxios_update_calendar_timestep(xios::CCalendarWrapper* calendarWrapper_hdl);
 
 // axis methods
+void cxios_xml_tree_add_axisgroup(xios::CAxisGroup* axis_grp, const char* _id, int _id_len); // TODO
+void cxios_xml_tree_add_axis(
+    xios::CAxisGroup* axis_grp, xios::CAxis* axis, const char* _id, int _id_len); // TODO
 void cxios_axis_handle_create(xios::CAxis** _ret, const char* _id, int _id_len);
 void cxios_set_axis_n_glo(xios::CAxis* axis_hdl, int n_glo);
 void cxios_set_axis_value(xios::CAxis* axis_hdl, double* value, int* extent);
@@ -70,6 +75,10 @@ bool cxios_is_defined_axis_n_glo(xios::CAxis* axis_hdl);
 bool cxios_is_defined_axis_value(xios::CAxis* axis_hdl);
 
 // domain methods
+void cxios_xml_tree_add_domaingroup(
+    xios::CDomainGroup* domain_grp, const char* _id, int _id_len); // TODO
+void cxios_xml_tree_add_domain(
+    xios::CDomainGroup* domain_grp, xios::CDomain* domain, const char* _id, int _id_len); // TODO
 void cxios_domain_handle_create(xios::CDomain** _ret, const char* _id, int _id_len);
 void cxios_set_domain_type(xios::CDomain* domain_hdl, const char* type, int type_size);
 void cxios_set_domain_ni_glo(xios::CDomain* domain_hdl, int ni_glo);
@@ -100,12 +109,20 @@ bool cxios_is_defined_domain_lonvalue_1d(xios::CDomain* axis_hdl);
 bool cxios_is_defined_domain_latvalue_1d(xios::CDomain* axis_hdl);
 
 // grid methods
+void cxios_xml_tree_add_gridgroup(
+    xios::CGridGroup** grid_grp, const char* _id, int _id_len); // TODO
+void cxios_xml_tree_add_grid(
+    xios::CGridGroup* grid_grp, xios::CGrid** grid, const char* _id, int _id_len); // TODO
 void cxios_grid_handle_create(xios::CGrid** _ret, const char* _id, int _id_len);
 void cxios_set_grid_name(xios::CGrid* _ret, const char* name, int name_size);
 void cxios_get_grid_name(xios::CGrid* _ret, char* name, int name_size);
 bool cxios_is_defined_grid_name(xios::CGrid* file_hdl);
 
 // field methods
+void cxios_xml_tree_add_fieldgroup(
+    xios::CFieldGroup** field_grp, const char* _id, int _id_len); // TODO
+void cxios_xml_tree_add_field(
+    xios::CFieldGroup* field_grp, xios::CField** field, const char* _id, int _id_len); // TODO
 void cxios_field_handle_create(xios::CField** _ret, const char* _id, int _id_len);
 void cxios_set_field_name(xios::CField* _ret, const char* name, int name_size);
 void cxios_set_field_operation(xios::CField* _ret, const char* operation, int operation_size);
@@ -118,6 +135,10 @@ bool cxios_is_defined_field_operation(xios::CField* _ret);
 bool cxios_is_defined_field_grid_ref(xios::CField* _ret);
 
 // file methods
+void cxios_xml_tree_add_filegroup(
+    xios::CFileGroup** file_grp, const char* _id, int _id_len); // TODO
+void cxios_xml_tree_add_file(
+    xios::CFileGroup* file_grp, xios::CFile** file, const char* _id, int _id_len); // TODO
 void cxios_file_handle_create(xios::CFile** _ret, const char* _id, int _id_len);
 void cxios_file_valid_id(bool* _ret, const char* _id, int _id_len);
 void cxios_set_file_name(xios::CFile* file_hdl, const char* name, int name_size);

--- a/core/src/include/xios_c_interface.hpp
+++ b/core/src/include/xios_c_interface.hpp
@@ -90,6 +90,7 @@ void cxios_get_domain_latvalue_1d(xios::CDomain* domain_hdl, double* latvalue_1d
 void cxios_grid_handle_create(xios::CGrid** _ret, const char* _id, int _id_len);
 void cxios_set_grid_name(xios::CGrid* _ret, const char* name, int name_size);
 void cxios_get_grid_name(xios::CGrid* _ret, char* name, int name_size);
+bool cxios_is_defined_grid_name(xios::CGrid* file_hdl);
 
 // field methods
 void cxios_field_handle_create(xios::CField** _ret, const char* _id, int _id_len);

--- a/core/src/include/xios_c_interface.hpp
+++ b/core/src/include/xios_c_interface.hpp
@@ -38,6 +38,7 @@ void cxios_context_finalize();
 void cxios_date_convert_to_string(cxios_date date_c, char* str, int str_size);
 cxios_date cxios_date_convert_from_string(const char* str, int str_size); // TODO: unused
 void cxios_duration_convert_to_string(cxios_duration dur_c, char* str, int str_size);
+cxios_duration cxios_duration_convert_from_string(const char* str, int str_size);
 
 // calendar methods
 void cxios_get_current_calendar_wrapper(xios::CCalendarWrapper** _ret);
@@ -107,13 +108,14 @@ bool cxios_is_defined_field_grid_ref(xios::CField* _ret);
 // file methods
 void cxios_file_handle_create(xios::CFile** _ret, const char* _id, int _id_len);
 void cxios_file_valid_id(bool* _ret, const char* _id, int _id_len);
-void cxios_set_file_name(xios::CFile* file_hdl, const char* name, int name_size); // TODO: unused
-void cxios_set_file_type(xios::CFile* file_hdl, const char* type, int type_size); // TODO: unused
-void cxios_set_file_output_freq(
-    xios::CFile* file_hdl, cxios_duration output_freq_c); // TODO: unused
+void cxios_set_file_name(xios::CFile* file_hdl, const char* name, int name_size);
+void cxios_set_file_type(xios::CFile* file_hdl, const char* type, int type_size);
+void cxios_set_file_output_freq(xios::CFile* file_hdl, cxios_duration output_freq_c);
 void cxios_get_file_name(xios::CFile* file_hdl, char* name, int name_size);
 void cxios_get_file_type(xios::CFile* file_hdl, char* type, int type_size);
 void cxios_get_file_output_freq(xios::CFile* file_hdl, cxios_duration* output_freq_c);
+bool cxios_is_defined_file_name(xios::CFile* file_hdl);
+bool cxios_is_defined_file_type(xios::CFile* file_hdl);
 bool cxios_is_defined_file_output_freq(xios::CFile* file_hdl);
 
 // writing methods

--- a/core/src/include/xios_c_interface.hpp
+++ b/core/src/include/xios_c_interface.hpp
@@ -34,14 +34,13 @@ void cxios_context_is_initialized(const char* context_id, int len_context_id, bo
 void cxios_context_close_definition();
 void cxios_context_finalize();
 
-void cxios_get_current_calendar_wrapper(xios::CCalendarWrapper** _ret);
-
 // conversions
 void cxios_date_convert_to_string(cxios_date date_c, char* str, int str_size);
 cxios_date cxios_date_convert_from_string(const char* str, int str_size); // TODO: unused
 void cxios_duration_convert_to_string(cxios_duration dur_c, char* str, int str_size);
 
 // calendar methods
+void cxios_get_current_calendar_wrapper(xios::CCalendarWrapper** _ret);
 void cxios_set_calendar_wrapper_date_time_origin(
     xios::CCalendarWrapper* calendarWrapper_hdl, cxios_date time_origin_c);
 void cxios_get_calendar_wrapper_date_time_origin(

--- a/core/src/include/xios_c_interface.hpp
+++ b/core/src/include/xios_c_interface.hpp
@@ -62,10 +62,12 @@ void cxios_get_calendar_wrapper_timestep(
     xios::CCalendarWrapper* calendar_wrapper_hdl, cxios_duration* timestep_c);
 void cxios_update_calendar_timestep(xios::CCalendarWrapper* calendarWrapper_hdl);
 
-// axis methods
-void cxios_xml_tree_add_axisgroup(xios::CAxisGroup** axis_grp, const char* _id, int _id_len);
+// axis group methods
+void cxios_axisgroup_handle_create(xios::CAxisGroup** _ret, const char* _id, int _id_len);
 void cxios_xml_tree_add_axis(
     xios::CAxisGroup* axis_grp, xios::CAxis** axis, const char* _id, int _id_len);
+
+// axis methods
 void cxios_axis_handle_create(xios::CAxis** _ret, const char* _id, int _id_len);
 void cxios_set_axis_n_glo(xios::CAxis* axis_hdl, int n_glo);
 void cxios_set_axis_value(xios::CAxis* axis_hdl, double* value, int* extent);
@@ -74,10 +76,12 @@ void cxios_get_axis_value(xios::CAxis* axis_hdl, double* value, int* extent);
 bool cxios_is_defined_axis_n_glo(xios::CAxis* axis_hdl);
 bool cxios_is_defined_axis_value(xios::CAxis* axis_hdl);
 
-// domain methods
-void cxios_xml_tree_add_domaingroup(xios::CDomainGroup** domain_grp, const char* _id, int _id_len);
+// domain group methods
+void cxios_domaingroup_handle_create(xios::CDomainGroup** _ret, const char* _id, int _id_len);
 void cxios_xml_tree_add_domain(
     xios::CDomainGroup* domain_grp, xios::CDomain** domain, const char* _id, int _id_len);
+
+// domain methods
 void cxios_domain_handle_create(xios::CDomain** _ret, const char* _id, int _id_len);
 void cxios_set_domain_type(xios::CDomain* domain_hdl, const char* type, int type_size);
 void cxios_set_domain_ni_glo(xios::CDomain* domain_hdl, int ni_glo);
@@ -107,10 +111,12 @@ bool cxios_is_defined_domain_jbegin(xios::CDomain* axis_hdl);
 bool cxios_is_defined_domain_lonvalue_1d(xios::CDomain* axis_hdl);
 bool cxios_is_defined_domain_latvalue_1d(xios::CDomain* axis_hdl);
 
-// grid methods
-void cxios_xml_tree_add_gridgroup(xios::CGridGroup** grid_grp, const char* _id, int _id_len);
+// grid group methods
+void cxios_gridgroup_handle_create(xios::CGridGroup** _ret, const char* _id, int _id_len);
 void cxios_xml_tree_add_grid(
     xios::CGridGroup* grid_grp, xios::CGrid** grid, const char* _id, int _id_len);
+
+// grid methods
 void cxios_grid_handle_create(xios::CGrid** _ret, const char* _id, int _id_len);
 void cxios_set_grid_name(xios::CGrid* _ret, const char* name, int name_size);
 void cxios_get_grid_name(xios::CGrid* _ret, char* name, int name_size);
@@ -120,10 +126,12 @@ void cxios_xml_tree_add_axistogrid(
 void cxios_xml_tree_add_domaintogrid(
     xios::CGrid* grid, xios::CDomain** domain, const char* _id, int _id_len);
 
-// field methods
-void cxios_xml_tree_add_fieldgroup(xios::CFieldGroup** field_grp, const char* _id, int _id_len);
+// field group methods
+void cxios_fieldgroup_handle_create(xios::CFieldGroup** _ret, const char* _id, int _id_len);
 void cxios_xml_tree_add_field(
     xios::CFieldGroup* field_grp, xios::CField** field, const char* _id, int _id_len);
+
+// field methods
 void cxios_field_handle_create(xios::CField** _ret, const char* _id, int _id_len);
 void cxios_set_field_name(xios::CField* _ret, const char* name, int name_size);
 void cxios_set_field_operation(xios::CField* _ret, const char* operation, int operation_size);
@@ -136,9 +144,11 @@ bool cxios_is_defined_field_operation(xios::CField* _ret);
 bool cxios_is_defined_field_grid_ref(xios::CField* _ret);
 
 // file methods
-void cxios_xml_tree_add_filegroup(xios::CFileGroup** file_grp, const char* _id, int _id_len);
+void cxios_filegroup_handle_create(xios::CFileGroup** _ret, const char* _id, int _id_len);
 void cxios_xml_tree_add_file(
     xios::CFileGroup* file_grp, xios::CFile** file, const char* _id, int _id_len);
+
+// file methods
 void cxios_file_handle_create(xios::CFile** _ret, const char* _id, int _id_len);
 void cxios_file_valid_id(bool* _ret, const char* _id, int _id_len);
 void cxios_set_file_name(xios::CFile* file_hdl, const char* name, int name_size);

--- a/core/src/include/xios_c_interface.hpp
+++ b/core/src/include/xios_c_interface.hpp
@@ -94,11 +94,9 @@ bool cxios_is_defined_grid_name(xios::CGrid* file_hdl);
 
 // field methods
 void cxios_field_handle_create(xios::CField** _ret, const char* _id, int _id_len);
-void cxios_set_field_name(xios::CField* _ret, const char* name, int name_size); // TODO: unused
-void cxios_set_field_operation(
-    xios::CField* _ret, const char* operation, int operation_size); // TODO: unused
-void cxios_set_field_grid_ref(
-    xios::CField* _ret, const char* grid_ref, int grid_ref_size); // TODO: unused
+void cxios_set_field_name(xios::CField* _ret, const char* name, int name_size);
+void cxios_set_field_operation(xios::CField* _ret, const char* operation, int operation_size);
+void cxios_set_field_grid_ref(xios::CField* _ret, const char* grid_ref, int grid_ref_size);
 void cxios_get_field_name(xios::CField* _ret, char* name, int name_size);
 void cxios_get_field_operation(xios::CField* _ret, char* operation, int operation_size);
 void cxios_get_field_grid_ref(xios::CField* _ret, char* grid_ref, int grid_ref_size);

--- a/core/src/include/xios_c_interface.hpp
+++ b/core/src/include/xios_c_interface.hpp
@@ -67,9 +67,9 @@ void cxios_get_axis_value(xios::CAxis* axis_hdl, double* value, int* extent);
 
 // domain methods
 void cxios_domain_handle_create(xios::CDomain** _ret, const char* _id, int _id_len);
-void cxios_set_domain_type(xios::CDomain* domain_hdl, char* type, int type_size); // TODO: unused
-void cxios_set_domain_ni_glo(xios::CDomain* domain_hdl, int ni_glo); // TODO: unused
-void cxios_set_domain_nj_glo(xios::CDomain* domain_hdl, int nj_glo); // TODO: unused
+void cxios_set_domain_type(xios::CDomain* domain_hdl, const char* type, int type_size);
+void cxios_set_domain_ni_glo(xios::CDomain* domain_hdl, int ni_glo);
+void cxios_set_domain_nj_glo(xios::CDomain* domain_hdl, int nj_glo);
 void cxios_set_domain_ni(xios::CDomain* domain_hdl, int ni);
 void cxios_set_domain_nj(xios::CDomain* domain_hdl, int nj);
 void cxios_set_domain_ibegin(xios::CDomain* domain_hdl, int ibegin);
@@ -85,6 +85,15 @@ void cxios_get_domain_ibegin(xios::CDomain* domain_hdl, int* ibegin);
 void cxios_get_domain_jbegin(xios::CDomain* domain_hdl, int* jbegin);
 void cxios_get_domain_lonvalue_1d(xios::CDomain* domain_hdl, double* lonvalue_1d, int* extent);
 void cxios_get_domain_latvalue_1d(xios::CDomain* domain_hdl, double* latvalue_1d, int* extent);
+bool cxios_is_defined_domain_type(xios::CDomain* axis_hdl);
+bool cxios_is_defined_domain_ni_glo(xios::CDomain* axis_hdl);
+bool cxios_is_defined_domain_nj_glo(xios::CDomain* axis_hdl);
+bool cxios_is_defined_domain_ni(xios::CDomain* axis_hdl);
+bool cxios_is_defined_domain_nj(xios::CDomain* axis_hdl);
+bool cxios_is_defined_domain_ibegin(xios::CDomain* axis_hdl);
+bool cxios_is_defined_domain_jbegin(xios::CDomain* axis_hdl);
+bool cxios_is_defined_domain_lonvalue_1d(xios::CDomain* axis_hdl);
+bool cxios_is_defined_domain_latvalue_1d(xios::CDomain* axis_hdl);
 
 // grid methods
 void cxios_grid_handle_create(xios::CGrid** _ret, const char* _id, int _id_len);

--- a/core/src/include/xios_c_interface.hpp
+++ b/core/src/include/xios_c_interface.hpp
@@ -143,7 +143,7 @@ bool cxios_is_defined_field_name(xios::CField* _ret);
 bool cxios_is_defined_field_operation(xios::CField* _ret);
 bool cxios_is_defined_field_grid_ref(xios::CField* _ret);
 
-// file methods
+// file group methods
 void cxios_filegroup_handle_create(xios::CFileGroup** _ret, const char* _id, int _id_len);
 void cxios_xml_tree_add_file(
     xios::CFileGroup* file_grp, xios::CFile** file, const char* _id, int _id_len);

--- a/core/src/include/xios_c_interface.hpp
+++ b/core/src/include/xios_c_interface.hpp
@@ -63,9 +63,9 @@ void cxios_get_calendar_wrapper_timestep(
 void cxios_update_calendar_timestep(xios::CCalendarWrapper* calendarWrapper_hdl);
 
 // axis methods
-void cxios_xml_tree_add_axisgroup(xios::CAxisGroup* axis_grp, const char* _id, int _id_len); // TODO
+void cxios_xml_tree_add_axisgroup(xios::CAxisGroup** axis_grp, const char* _id, int _id_len);
 void cxios_xml_tree_add_axis(
-    xios::CAxisGroup* axis_grp, xios::CAxis* axis, const char* _id, int _id_len); // TODO
+    xios::CAxisGroup* axis_grp, xios::CAxis** axis, const char* _id, int _id_len);
 void cxios_axis_handle_create(xios::CAxis** _ret, const char* _id, int _id_len);
 void cxios_set_axis_n_glo(xios::CAxis* axis_hdl, int n_glo);
 void cxios_set_axis_value(xios::CAxis* axis_hdl, double* value, int* extent);
@@ -75,10 +75,9 @@ bool cxios_is_defined_axis_n_glo(xios::CAxis* axis_hdl);
 bool cxios_is_defined_axis_value(xios::CAxis* axis_hdl);
 
 // domain methods
-void cxios_xml_tree_add_domaingroup(
-    xios::CDomainGroup* domain_grp, const char* _id, int _id_len); // TODO
+void cxios_xml_tree_add_domaingroup(xios::CDomainGroup** domain_grp, const char* _id, int _id_len);
 void cxios_xml_tree_add_domain(
-    xios::CDomainGroup* domain_grp, xios::CDomain* domain, const char* _id, int _id_len); // TODO
+    xios::CDomainGroup* domain_grp, xios::CDomain** domain, const char* _id, int _id_len);
 void cxios_domain_handle_create(xios::CDomain** _ret, const char* _id, int _id_len);
 void cxios_set_domain_type(xios::CDomain* domain_hdl, const char* type, int type_size);
 void cxios_set_domain_ni_glo(xios::CDomain* domain_hdl, int ni_glo);
@@ -109,20 +108,18 @@ bool cxios_is_defined_domain_lonvalue_1d(xios::CDomain* axis_hdl);
 bool cxios_is_defined_domain_latvalue_1d(xios::CDomain* axis_hdl);
 
 // grid methods
-void cxios_xml_tree_add_gridgroup(
-    xios::CGridGroup** grid_grp, const char* _id, int _id_len); // TODO
+void cxios_xml_tree_add_gridgroup(xios::CGridGroup** grid_grp, const char* _id, int _id_len);
 void cxios_xml_tree_add_grid(
-    xios::CGridGroup* grid_grp, xios::CGrid** grid, const char* _id, int _id_len); // TODO
+    xios::CGridGroup* grid_grp, xios::CGrid** grid, const char* _id, int _id_len);
 void cxios_grid_handle_create(xios::CGrid** _ret, const char* _id, int _id_len);
 void cxios_set_grid_name(xios::CGrid* _ret, const char* name, int name_size);
 void cxios_get_grid_name(xios::CGrid* _ret, char* name, int name_size);
 bool cxios_is_defined_grid_name(xios::CGrid* file_hdl);
 
 // field methods
-void cxios_xml_tree_add_fieldgroup(
-    xios::CFieldGroup** field_grp, const char* _id, int _id_len); // TODO
+void cxios_xml_tree_add_fieldgroup(xios::CFieldGroup** field_grp, const char* _id, int _id_len);
 void cxios_xml_tree_add_field(
-    xios::CFieldGroup* field_grp, xios::CField** field, const char* _id, int _id_len); // TODO
+    xios::CFieldGroup* field_grp, xios::CField** field, const char* _id, int _id_len);
 void cxios_field_handle_create(xios::CField** _ret, const char* _id, int _id_len);
 void cxios_set_field_name(xios::CField* _ret, const char* name, int name_size);
 void cxios_set_field_operation(xios::CField* _ret, const char* operation, int operation_size);
@@ -135,10 +132,9 @@ bool cxios_is_defined_field_operation(xios::CField* _ret);
 bool cxios_is_defined_field_grid_ref(xios::CField* _ret);
 
 // file methods
-void cxios_xml_tree_add_filegroup(
-    xios::CFileGroup** file_grp, const char* _id, int _id_len); // TODO
+void cxios_xml_tree_add_filegroup(xios::CFileGroup** file_grp, const char* _id, int _id_len);
 void cxios_xml_tree_add_file(
-    xios::CFileGroup* file_grp, xios::CFile** file, const char* _id, int _id_len); // TODO
+    xios::CFileGroup* file_grp, xios::CFile** file, const char* _id, int _id_len);
 void cxios_file_handle_create(xios::CFile** _ret, const char* _id, int _id_len);
 void cxios_file_valid_id(bool* _ret, const char* _id, int _id_len);
 void cxios_set_file_name(xios::CFile* file_hdl, const char* name, int name_size);

--- a/core/src/include/xios_c_interface.hpp
+++ b/core/src/include/xios_c_interface.hpp
@@ -115,6 +115,10 @@ void cxios_grid_handle_create(xios::CGrid** _ret, const char* _id, int _id_len);
 void cxios_set_grid_name(xios::CGrid* _ret, const char* name, int name_size);
 void cxios_get_grid_name(xios::CGrid* _ret, char* name, int name_size);
 bool cxios_is_defined_grid_name(xios::CGrid* file_hdl);
+void cxios_xml_tree_add_axistogrid(
+    xios::CGrid* grid, xios::CAxis** axis, const char* _id, int _id_len);
+void cxios_xml_tree_add_domaintogrid(
+    xios::CGrid* grid, xios::CDomain** domain, const char* _id, int _id_len);
 
 // field methods
 void cxios_xml_tree_add_fieldgroup(xios::CFieldGroup** field_grp, const char* _id, int _id_len);
@@ -146,6 +150,8 @@ void cxios_get_file_output_freq(xios::CFile* file_hdl, cxios_duration* output_fr
 bool cxios_is_defined_file_name(xios::CFile* file_hdl);
 bool cxios_is_defined_file_type(xios::CFile* file_hdl);
 bool cxios_is_defined_file_output_freq(xios::CFile* file_hdl);
+void cxios_xml_tree_add_fieldtofile(
+    xios::CFile* file, xios::CField** field, const char* _id, int _id_len);
 
 // writing methods
 void cxios_write_data_k82(const char* fieldid, int fieldid_size, double* data_k8, int data_Xsize,

--- a/core/src/include/xios_c_interface.hpp
+++ b/core/src/include/xios_c_interface.hpp
@@ -1,7 +1,7 @@
 /*!
  * @file    xios_c_interface.hpp
- * @author  Tom Meltzer <tdm39@cam.ac.uk>
- * @date    Fri 23 Feb 13:43:16 GMT 2024
+ * @author  Joe Wallwork <jw2423@cam.ac.uk
+ * @date    7 June 2024
  * @brief   C interface for xios library
  * @details
  * This interface is based on an earlier version provided by Laurent as part of

--- a/core/test/XiosInit_test.cpp
+++ b/core/test/XiosInit_test.cpp
@@ -222,6 +222,8 @@ MPI_TEST_CASE("TestXiosInitialization", 2)
     xios_handler.setFieldGridRef(fieldId, gridRef);
     REQUIRE(xios_handler.isDefinedFieldGridRef(fieldId));
     REQUIRE(xios_handler.getFieldGridRef(fieldId) == gridRef);
+    // xios_handler.gridAddDomain(gridId, domainId); // FIXME and test
+    // xios_handler.gridAddAxis(gridId, axisId); // FIXME and test
 
     // --- Tests for file API
     REQUIRE_FALSE(xios_handler.validFileId("invalid"));
@@ -247,6 +249,7 @@ MPI_TEST_CASE("TestXiosInitialization", 2)
     xios_handler.setFileOutputFreq(fileId, freq);
     REQUIRE(xios_handler.isDefinedFileOutputFreq(fileId));
     REQUIRE(xios_handler.getFileOutputFreq(fileId) == freq);
+    // xios_handler.fileAddField(fieldId, fieldId); // FIXME and test
 
     xios_handler.close_context_definition();
 

--- a/core/test/XiosInit_test.cpp
+++ b/core/test/XiosInit_test.cpp
@@ -222,14 +222,13 @@ MPI_TEST_CASE("TestXiosInitialization", 2)
     xios_handler.setFieldGridRef(fieldId, gridRef);
     REQUIRE(xios_handler.isDefinedFieldGridRef(fieldId));
     REQUIRE(xios_handler.getFieldGridRef(fieldId) == gridRef);
-    // xios_handler.gridAddDomain(gridId, domainId); // FIXME and test
-    // xios_handler.gridAddAxis(gridId, axisId); // FIXME and test
+    xios_handler.gridAddDomain(gridId, domainId);
+    xios_handler.gridAddAxis(gridId, axisId);
 
-    // --- Tests for file API
-    REQUIRE_FALSE(xios_handler.validFileId("invalid"));
+    // // --- Tests for file API
     std::string fileId { "output" };
-    // REQUIRE_FALSE(xios_handler.validFileId("fileId")); // TODO
-    // xios_handler.createFile(fileId); // FIXME
+    // REQUIRE_FALSE(xios_handler.validFileId(fileId)); // TODO: Needs fix for following line
+    // xios_handler.createFile(fileId); // FIXME: throws unknown exception
     REQUIRE(xios_handler.validFileId(fileId));
     // File name
     REQUIRE_FALSE(xios_handler.isDefinedFileName(fileId));
@@ -249,7 +248,7 @@ MPI_TEST_CASE("TestXiosInitialization", 2)
     xios_handler.setFileOutputFreq(fileId, freq);
     REQUIRE(xios_handler.isDefinedFileOutputFreq(fileId));
     REQUIRE(xios_handler.getFileOutputFreq(fileId) == freq);
-    // xios_handler.fileAddField(fieldId, fieldId); // FIXME and test
+    // xios_handler.fileAddField(fieldId, fieldId); // FIXME: throws unknown exception
 
     xios_handler.close_context_definition();
 

--- a/core/test/XiosInit_test.cpp
+++ b/core/test/XiosInit_test.cpp
@@ -248,7 +248,7 @@ MPI_TEST_CASE("TestXiosInitialization", 2)
     xios_handler.setFileOutputFreq(fileId, freq);
     REQUIRE(xios_handler.isDefinedFileOutputFreq(fileId));
     REQUIRE(xios_handler.getFileOutputFreq(fileId) == freq);
-    // xios_handler.fileAddField(fieldId, fieldId); // FIXME: throws unknown exception
+    xios_handler.fileAddField(fileId, fieldId);
 
     xios_handler.close_context_definition();
 

--- a/core/test/XiosInit_test.cpp
+++ b/core/test/XiosInit_test.cpp
@@ -100,6 +100,7 @@ MPI_TEST_CASE("TestXiosInitialization", 2)
 
     // --- Tests for axis API
     std::string axisId = { "axis_A" };
+    // xios_handler.createAxis(axisId); // FIXME
     // Axis size
     int axis_size = 30;
     REQUIRE_FALSE(xios_handler.isDefinedAxisSize(axisId));
@@ -121,6 +122,7 @@ MPI_TEST_CASE("TestXiosInitialization", 2)
 
     // --- Tests for domain API
     std::string domainId = { "domain_A" };
+    // xios_handler.createDomain(domainId); // FIXME
     // Domain type
     REQUIRE_FALSE(xios_handler.isDefinedDomainType(domainId));
     std::string domainType = { "rectilinear" };
@@ -191,6 +193,7 @@ MPI_TEST_CASE("TestXiosInitialization", 2)
 
     // --- Tests for grid API
     std::string gridId = { "grid_2D" };
+    // xios_handler.createGrid(gridId); // FIXME
     // Grid name
     REQUIRE_FALSE(xios_handler.isDefinedGridName(gridId));
     std::string gridName = { "test_grid" };
@@ -200,6 +203,7 @@ MPI_TEST_CASE("TestXiosInitialization", 2)
 
     // --- Tests for field API
     std::string fieldId = { "field_A" };
+    // xios_handler.createField(fieldId); // FIXME
     // Field name
     std::string fieldName = { "test_field" };
     REQUIRE_FALSE(xios_handler.isDefinedFieldName(fieldId));
@@ -222,6 +226,8 @@ MPI_TEST_CASE("TestXiosInitialization", 2)
     // --- Tests for file API
     REQUIRE_FALSE(xios_handler.validFileId("invalid"));
     std::string fileId { "output" };
+    // REQUIRE_FALSE(xios_handler.validFileId("fileId")); // TODO
+    // xios_handler.createFile(fileId); // FIXME
     REQUIRE(xios_handler.validFileId(fileId));
     // File name
     REQUIRE_FALSE(xios_handler.isDefinedFileName(fileId));

--- a/core/test/XiosInit_test.cpp
+++ b/core/test/XiosInit_test.cpp
@@ -193,7 +193,7 @@ MPI_TEST_CASE("TestXiosInitialization", 2)
 
     // --- Tests for grid API
     std::string gridId = { "grid_2D" };
-    // xios_handler.createGrid(gridId); // FIXME
+    xios_handler.createGrid(gridId);
     // Grid name
     REQUIRE_FALSE(xios_handler.isDefinedGridName(gridId));
     std::string gridName = { "test_grid" };

--- a/core/test/XiosInit_test.cpp
+++ b/core/test/XiosInit_test.cpp
@@ -147,6 +147,15 @@ MPI_TEST_CASE("TestXiosInitialization", 2)
         REQUIRE(vecLatOut[j] == doctest::Approx(vecLat[j]));
     }
 
+    // --- Tests for grid API
+    std::string gridId = { "grid_2D" };
+    // Grid name
+    REQUIRE_FALSE(xios_handler.isDefinedGridName(gridId));
+    std::string gridName = { "test_grid" };
+    xios_handler.setGridName(gridId, gridName);
+    REQUIRE(xios_handler.isDefinedGridName(gridId));
+    REQUIRE(xios_handler.getGridName(gridId) == gridName);
+
     // check field getters
     std::string fieldId = { "field_A" };
     REQUIRE(xios_handler.isDefinedFieldName(fieldId));
@@ -155,10 +164,6 @@ MPI_TEST_CASE("TestXiosInitialization", 2)
     REQUIRE(xios_handler.getFieldName(fieldId) == "test_field");
     REQUIRE(xios_handler.getFieldOperation(fieldId) == "instant");
     REQUIRE(xios_handler.getFieldGridRef(fieldId) == "grid_2D");
-
-    // check grid getters
-    std::string gridId = { "grid_2D" };
-    REQUIRE(xios_handler.getGridName(gridId) == "test_grid");
 
     // --- Tests for file API
     REQUIRE_FALSE(xios_handler.validFileId("invalid"));

--- a/core/test/XiosInit_test.cpp
+++ b/core/test/XiosInit_test.cpp
@@ -156,14 +156,26 @@ MPI_TEST_CASE("TestXiosInitialization", 2)
     REQUIRE(xios_handler.isDefinedGridName(gridId));
     REQUIRE(xios_handler.getGridName(gridId) == gridName);
 
-    // check field getters
+    // --- Tests for field API
     std::string fieldId = { "field_A" };
+    // Field name
+    std::string fieldName = { "test_field" };
+    REQUIRE_FALSE(xios_handler.isDefinedFieldName(fieldId));
+    xios_handler.setFieldName(fieldId, fieldName);
+    REQUIRE(xios_handler.getFieldName(fieldId) == fieldName);
     REQUIRE(xios_handler.isDefinedFieldName(fieldId));
+    // Operation
+    std::string operation = { "instant" };
+    REQUIRE_FALSE(xios_handler.isDefinedFieldOperation(fieldId));
+    xios_handler.setFieldOperation(fieldId, operation);
     REQUIRE(xios_handler.isDefinedFieldOperation(fieldId));
+    REQUIRE(xios_handler.getFieldOperation(fieldId) == operation);
+    // Grid reference
+    std::string gridRef = { "grid_2D" };
+    REQUIRE_FALSE(xios_handler.isDefinedFieldGridRef(fieldId));
+    xios_handler.setFieldGridRef(fieldId, gridRef);
     REQUIRE(xios_handler.isDefinedFieldGridRef(fieldId));
-    REQUIRE(xios_handler.getFieldName(fieldId) == "test_field");
-    REQUIRE(xios_handler.getFieldOperation(fieldId) == "instant");
-    REQUIRE(xios_handler.getFieldGridRef(fieldId) == "grid_2D");
+    REQUIRE(xios_handler.getFieldGridRef(fieldId) == gridRef);
 
     // --- Tests for file API
     REQUIRE_FALSE(xios_handler.validFileId("invalid"));

--- a/core/test/XiosInit_test.cpp
+++ b/core/test/XiosInit_test.cpp
@@ -225,10 +225,10 @@ MPI_TEST_CASE("TestXiosInitialization", 2)
     xios_handler.gridAddDomain(gridId, domainId);
     xios_handler.gridAddAxis(gridId, axisId);
 
-    // // --- Tests for file API
+    // --- Tests for file API
     std::string fileId { "output" };
-    // REQUIRE_FALSE(xios_handler.validFileId(fileId)); // TODO: Needs fix for following line
-    // xios_handler.createFile(fileId); // FIXME: throws unknown exception
+    REQUIRE_FALSE(xios_handler.validFileId(fileId));
+    xios_handler.createFile(fileId);
     REQUIRE(xios_handler.validFileId(fileId));
     // File name
     REQUIRE_FALSE(xios_handler.isDefinedFileName(fileId));

--- a/core/test/XiosInit_test.cpp
+++ b/core/test/XiosInit_test.cpp
@@ -100,7 +100,7 @@ MPI_TEST_CASE("TestXiosInitialization", 2)
 
     // --- Tests for axis API
     std::string axisId = { "axis_A" };
-    // xios_handler.createAxis(axisId); // FIXME
+    xios_handler.createAxis(axisId);
     // Axis size
     int axis_size = 30;
     REQUIRE_FALSE(xios_handler.isDefinedAxisSize(axisId));
@@ -122,7 +122,7 @@ MPI_TEST_CASE("TestXiosInitialization", 2)
 
     // --- Tests for domain API
     std::string domainId = { "domain_A" };
-    // xios_handler.createDomain(domainId); // FIXME
+    xios_handler.createDomain(domainId);
     // Domain type
     REQUIRE_FALSE(xios_handler.isDefinedDomainType(domainId));
     std::string domainType = { "rectilinear" };
@@ -203,7 +203,7 @@ MPI_TEST_CASE("TestXiosInitialization", 2)
 
     // --- Tests for field API
     std::string fieldId = { "field_A" };
-    // xios_handler.createField(fieldId); // FIXME
+    xios_handler.createField(fieldId);
     // Field name
     std::string fieldName = { "test_field" };
     REQUIRE_FALSE(xios_handler.isDefinedFieldName(fieldId));

--- a/core/test/XiosInit_test.cpp
+++ b/core/test/XiosInit_test.cpp
@@ -106,43 +106,72 @@ MPI_TEST_CASE("TestXiosInitialization", 2)
         REQUIRE(axis_A[i] == doctest::Approx(i));
     }
 
-    // check global domain getters
-    std::string domainId { "domain_A" };
-    REQUIRE(xios_handler.getDomainType(domainId) == "rectilinear");
-    int ni_glo = xios_handler.getDomainGlobalLongitudeSize(domainId);
-    int nj_glo = xios_handler.getDomainGlobalLatitudeSize(domainId);
-    REQUIRE(ni_glo == 60);
-    REQUIRE(nj_glo == 20);
-
-    // check local domain setters and getters
-    int rank = xios_handler.rank;
+    // --- Tests for domain API
+    std::string domainId = { "domain_A" };
+    // Domain type
+    REQUIRE_FALSE(xios_handler.isDefinedDomainType(domainId));
+    std::string domainType = { "rectilinear" };
+    xios_handler.setDomainType(domainId, domainType);
+    REQUIRE(xios_handler.isDefinedDomainType(domainId));
+    REQUIRE(xios_handler.getDomainType(domainId) == domainType);
+    // Global longitude size
+    REQUIRE_FALSE(xios_handler.isDefinedDomainGlobalLongitudeSize(domainId));
+    int ni_glo = 60;
+    xios_handler.setDomainGlobalLongitudeSize(domainId, ni_glo);
+    REQUIRE(xios_handler.isDefinedDomainGlobalLongitudeSize(domainId));
+    REQUIRE(xios_handler.getDomainGlobalLongitudeSize(domainId) == ni_glo);
+    // Global latitude size
+    REQUIRE_FALSE(xios_handler.isDefinedDomainGlobalLatitudeSize(domainId));
+    int nj_glo = 20;
+    xios_handler.setDomainGlobalLatitudeSize(domainId, nj_glo);
+    REQUIRE(xios_handler.isDefinedDomainGlobalLatitudeSize(domainId));
+    REQUIRE(xios_handler.getDomainGlobalLatitudeSize(domainId) == nj_glo);
+    // Local longitude size
+    REQUIRE_FALSE(xios_handler.isDefinedDomainLongitudeSize(domainId));
     int ni = ni_glo / xios_handler.size;
-    int nj = nj_glo;
     xios_handler.setDomainLongitudeSize(domainId, ni);
-    xios_handler.setDomainLatitudeSize(domainId, nj);
+    REQUIRE_FALSE(xios_handler.isDefinedDomainLatitudeSize(domainId));
     REQUIRE(xios_handler.getDomainLongitudeSize(domainId) == ni);
+    // Local latitude size
+    REQUIRE_FALSE(xios_handler.isDefinedDomainLatitudeSize(domainId));
+    int nj = nj_glo;
+    xios_handler.setDomainLatitudeSize(domainId, nj);
+    REQUIRE(xios_handler.isDefinedDomainLatitudeSize(domainId));
     REQUIRE(xios_handler.getDomainLatitudeSize(domainId) == nj);
+    // Local longitude start
+    REQUIRE_FALSE(xios_handler.isDefinedDomainLongitudeStart(domainId));
+    int rank = xios_handler.rank;
     int startLon = ni * rank;
-    int startLat = 0;
     xios_handler.setDomainLongitudeStart(domainId, startLon);
-    xios_handler.setDomainLatitudeStart(domainId, startLat);
+    REQUIRE(xios_handler.isDefinedDomainLongitudeStart(domainId));
     REQUIRE(xios_handler.getDomainLongitudeStart(domainId) == startLon);
+    // Local latitude start
+    REQUIRE_FALSE(xios_handler.isDefinedDomainLatitudeStart(domainId));
+    int startLat = 0;
+    xios_handler.setDomainLatitudeStart(domainId, startLat);
+    REQUIRE(xios_handler.isDefinedDomainLatitudeStart(domainId));
     REQUIRE(xios_handler.getDomainLatitudeStart(domainId) == startLat);
+    // Local longitude values
+    REQUIRE_FALSE(xios_handler.areDefinedDomainLongitudeValues(domainId));
     std::vector<double> vecLon {};
-    std::vector<double> vecLat {};
     for (int i = 0; i < ni; i++) {
         vecLon.push_back(-180 + (rank * ni * i) * 360 / ni_glo);
     }
-    for (int j = 0; j < nj; j++) {
-        vecLat.push_back(-90 + j * 180 / nj_glo);
-    }
     xios_handler.setDomainLongitudeValues(domainId, vecLon);
-    xios_handler.setDomainLatitudeValues(domainId, vecLat);
+    REQUIRE(xios_handler.areDefinedDomainLongitudeValues(domainId));
     std::vector<double> vecLonOut = xios_handler.getDomainLongitudeValues(domainId);
-    std::vector<double> vecLatOut = xios_handler.getDomainLatitudeValues(domainId);
     for (int i = 0; i < ni; i++) {
         REQUIRE(vecLonOut[i] == doctest::Approx(vecLon[i]));
     }
+    // Local latitude values
+    REQUIRE_FALSE(xios_handler.areDefinedDomainLatitudeValues(domainId));
+    std::vector<double> vecLat {};
+    for (int j = 0; j < nj; j++) {
+        vecLat.push_back(-90 + j * 180 / nj_glo);
+    }
+    xios_handler.setDomainLatitudeValues(domainId, vecLat);
+    REQUIRE(xios_handler.areDefinedDomainLatitudeValues(domainId));
+    std::vector<double> vecLatOut = xios_handler.getDomainLatitudeValues(domainId);
     for (int j = 0; j < nj; j++) {
         REQUIRE(vecLatOut[j] == doctest::Approx(vecLat[j]));
     }

--- a/core/test/XiosInit_test.cpp
+++ b/core/test/XiosInit_test.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file    XiosInit_test.cpp
- * @author  Tom Meltzer <tdm39@cam.ac.uk>
- * @date    Fri 23 Feb 13:43:16 GMT 2024
+ * @author  Joe Wallwork <jw2423@cam.ac.uk
+ * @date    7 June 2024
  * @brief   Tests for XIOS C++ interface
  * @details
  * This test is designed to test all core functionality of the C++ interface

--- a/core/test/XiosInit_test.cpp
+++ b/core/test/XiosInit_test.cpp
@@ -160,14 +160,28 @@ MPI_TEST_CASE("TestXiosInitialization", 2)
     std::string gridId = { "grid_2D" };
     REQUIRE(xios_handler.getGridName(gridId) == "test_grid");
 
-    // check file getters
+    // --- Tests for file API
     REQUIRE_FALSE(xios_handler.validFileId("invalid"));
     std::string fileId { "output" };
     REQUIRE(xios_handler.validFileId(fileId));
-    REQUIRE(xios_handler.getFileName(fileId) == "diagnostic");
-    REQUIRE(xios_handler.getFileType(fileId) == "one_file");
+    // File name
+    REQUIRE_FALSE(xios_handler.isDefinedFileName(fileId));
+    std::string fileName { "diagnostic" };
+    xios_handler.setFileName(fileId, fileName);
+    REQUIRE(xios_handler.isDefinedFileName(fileId));
+    REQUIRE(xios_handler.getFileName(fileId) == fileName);
+    // File type
+    std::string fileType { "one_file" };
+    REQUIRE_FALSE(xios_handler.isDefinedFileType(fileId));
+    xios_handler.setFileType(fileId, fileType);
+    REQUIRE(xios_handler.isDefinedFileType(fileId));
+    REQUIRE(xios_handler.getFileType(fileId) == fileType);
+    // Output frequency
+    REQUIRE_FALSE(xios_handler.isDefinedFileOutputFreq(fileId));
+    std::string freq { "1ts" };
+    xios_handler.setFileOutputFreq(fileId, freq);
     REQUIRE(xios_handler.isDefinedFileOutputFreq(fileId));
-    REQUIRE(xios_handler.getFileOutputFreq(fileId) == "1ts");
+    REQUIRE(xios_handler.getFileOutputFreq(fileId) == freq);
 
     xios_handler.close_context_definition();
 

--- a/core/test/XiosInit_test.cpp
+++ b/core/test/XiosInit_test.cpp
@@ -98,12 +98,25 @@ MPI_TEST_CASE("TestXiosInitialization", 2)
     REQUIRE(duration.second == doctest::Approx(0.0));
     REQUIRE(duration.timestep == doctest::Approx(0.0));
 
-    // check axis getters
-    int axis_size = xios_handler.getAxisSize("axis_A");
-    REQUIRE(axis_size == 30);
-    std::vector<double> axis_A = xios_handler.getAxisValues("axis_A");
+    // --- Tests for axis API
+    std::string axisId = { "axis_A" };
+    // Axis size
+    int axis_size = 30;
+    REQUIRE_FALSE(xios_handler.isDefinedAxisSize(axisId));
+    xios_handler.setAxisSize(axisId, axis_size);
+    REQUIRE(xios_handler.isDefinedAxisSize(axisId));
+    REQUIRE(xios_handler.getAxisSize(axisId) == axis_size);
+    // Axis values
+    std::vector<double> axisValues;
     for (int i = 0; i < axis_size; i++) {
-        REQUIRE(axis_A[i] == doctest::Approx(i));
+        axisValues.push_back(i);
+    }
+    REQUIRE_FALSE(xios_handler.areDefinedAxisValues(axisId));
+    xios_handler.setAxisValues(axisId, axisValues);
+    REQUIRE(xios_handler.areDefinedAxisValues(axisId));
+    std::vector<double> axis_A = xios_handler.getAxisValues(axisId);
+    for (int i = 0; i < axis_size; i++) {
+        REQUIRE(axis_A[i] == doctest::Approx(axisValues[i]));
     }
 
     // --- Tests for domain API

--- a/core/test/iodef.xml
+++ b/core/test/iodef.xml
@@ -25,7 +25,7 @@
     </field_definition>
 
     <file_definition>
-      <file id="output" name="diagnostic" output_freq="1ts" type="one_file">
+      <file id="output">
         <field id="field_A"/>
       </file>
     </file_definition>

--- a/core/test/iodef.xml
+++ b/core/test/iodef.xml
@@ -3,16 +3,6 @@
   <context id="nextsim">
     <calendar type="Gregorian" time_origin="2020-01-23 00:08:15" start_date="2023-03-17 17:11:00" timestep="1.5 h"/>
 
-    <!-- TODO: Drop axis def -->
-    <axis_definition>
-      <axis id="axis_A"/>
-    </axis_definition>
-
-    <!-- TODO: Drop domain def -->
-    <domain_definition>
-      <domain id="domain_A"/>
-    </domain_definition>
-
     <!-- TODO: Drop grid def -->
     <grid_definition>
       <grid id="grid_2D">
@@ -20,11 +10,6 @@
         <axis axis_ref="axis_A"/>
       </grid>
     </grid_definition>
-
-    <!-- TODO: Drop field def -->
-    <field_definition>
-      <field id="field_A"/>
-    </field_definition>
 
     <!-- TODO: Drop file def -->
     <file_definition>

--- a/core/test/iodef.xml
+++ b/core/test/iodef.xml
@@ -9,8 +9,7 @@
     </axis_definition>
 
     <domain_definition>
-      <domain id="domain_A" type="rectilinear" ni_glo="60" nj_glo="20">
-      </domain>
+      <domain id="domain_A"/>
     </domain_definition>
 
     <grid_definition>

--- a/core/test/iodef.xml
+++ b/core/test/iodef.xml
@@ -3,11 +3,6 @@
   <context id="nextsim">
     <calendar type="Gregorian" time_origin="2020-01-23 00:08:15" start_date="2023-03-17 17:11:00" timestep="1.5 h"/>
 
-    <!-- TODO: Drop grid def -->
-    <grid_definition>
-      <grid id="grid_2D"/>
-    </grid_definition>
-
     <!-- TODO: Drop file def -->
     <file_definition>
       <file id="output">

--- a/core/test/iodef.xml
+++ b/core/test/iodef.xml
@@ -5,10 +5,7 @@
 
     <!-- TODO: Drop grid def -->
     <grid_definition>
-      <grid id="grid_2D">
-        <domain domain_ref="domain_A"/>
-        <axis axis_ref="axis_A"/>
-      </grid>
+      <grid id="grid_2D"/>
     </grid_definition>
 
     <!-- TODO: Drop file def -->

--- a/core/test/iodef.xml
+++ b/core/test/iodef.xml
@@ -2,12 +2,6 @@
 <simulation>
   <context id="nextsim">
     <calendar type="Gregorian" time_origin="2020-01-23 00:08:15" start_date="2023-03-17 17:11:00" timestep="1.5 h"/>
-
-    <!-- TODO: Drop file def -->
-    <file_definition>
-      <file id="output"/>
-    </file_definition>
-
   </context>
   <context id="xios">
     <variable_definition>

--- a/core/test/iodef.xml
+++ b/core/test/iodef.xml
@@ -3,14 +3,17 @@
   <context id="nextsim">
     <calendar type="Gregorian" time_origin="2020-01-23 00:08:15" start_date="2023-03-17 17:11:00" timestep="1.5 h"/>
 
+    <!-- TODO: Drop axis def -->
     <axis_definition>
       <axis id="axis_A"/>
     </axis_definition>
 
+    <!-- TODO: Drop domain def -->
     <domain_definition>
       <domain id="domain_A"/>
     </domain_definition>
 
+    <!-- TODO: Drop grid def -->
     <grid_definition>
       <grid id="grid_2D">
         <domain domain_ref="domain_A"/>
@@ -18,10 +21,12 @@
       </grid>
     </grid_definition>
 
+    <!-- TODO: Drop field def -->
     <field_definition>
       <field id="field_A"/>
     </field_definition>
 
+    <!-- TODO: Drop file def -->
     <file_definition>
       <file id="output">
         <field id="field_A"/>

--- a/core/test/iodef.xml
+++ b/core/test/iodef.xml
@@ -21,7 +21,7 @@
     </grid_definition>
 
     <field_definition>
-      <field id="field_A" name="test_field" operation="instant" grid_ref="grid_2D"/>
+      <field id="field_A"/>
     </field_definition>
 
     <file_definition>

--- a/core/test/iodef.xml
+++ b/core/test/iodef.xml
@@ -5,9 +5,7 @@
 
     <!-- TODO: Drop file def -->
     <file_definition>
-      <file id="output">
-        <field id="field_A"/>
-      </file>
+      <file id="output"/>
     </file_definition>
 
   </context>

--- a/core/test/iodef.xml
+++ b/core/test/iodef.xml
@@ -4,8 +4,7 @@
     <calendar type="Gregorian" time_origin="2020-01-23 00:08:15" start_date="2023-03-17 17:11:00" timestep="1.5 h"/>
 
     <axis_definition>
-      <axis id="axis_A" n_glo="30" value="(0,29)[0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29]">
-      </axis>
+      <axis id="axis_A"/>
     </axis_definition>
 
     <domain_definition>

--- a/core/test/iodef.xml
+++ b/core/test/iodef.xml
@@ -14,7 +14,7 @@
     </domain_definition>
 
     <grid_definition>
-      <grid id="grid_2D" name="test_grid">
+      <grid id="grid_2D">
         <domain domain_ref="domain_A"/>
         <axis axis_ref="axis_A"/>
       </grid>


### PR DESCRIPTION
# Wrap XIOS API calls part 2: setters
## Fixes #558

### Task List
- [x] Defined the tests that specify a complete and functioning change (*It may help to create a [design specification & test specification](../../../wiki/Specification-Template)*)
- [x] Implemented the source code change that satisfies the tests
- [x] Documented the feature by providing worked example
- [x] Updated the README or other documentation
- [x] Completed the pre-Request checklist below

---
# Change Description

Note that #555 will need to be merged first. This PR wraps more of the XIOS API for use in neXtSIM-DG. In particular, it allows neXtSIM-DG to create XIOS objects itself rather than relying on XML input files.

- [x] Wrap axis setters from XIOS API.
- [x] Wrap domain setters from XIOS API.
- [x] Wrap grid setters from XIOS API.
- [x] Wrap field setters from XIOS API.
- [x] Wrap file setters from XIOS API.
- [x] Method for creating an axis.
- [x] Method for creating a domain.
- [x] Method for creating a grid.
- [x] Method for creating a field.
- [x] Method for creating a file.
- [x] Method for associating a domain with a grid.
- [x] Method for associating an axis with a grid.
- [x] Method for associating a field with a file.

---
# Test Description

Update `TestXiosInit_MPI2.cpp`...
- [x] To test setter methods.
- [x] To test creation methods (checking valid IDs).
- [x] To test association methods.

---
### Pre-Request Checklist

- [x] The requirements of this pull request are fully captured in an issue or design specification and are linked and summarised in the description of this PR
- [x] No new warnings are generated
- [x] The documentation has been updated (or an issue has been created to track the corresponding change)
- [x] Methods and Tests are commented such that they can be understood without having to obtain additional context
- [x] This PR/Issue is labelled as a bug/feature/enhancement/breaking change
- [x] File dates have been updated to reflect modification date
- [x] This change conforms to the conventions described in the README
