### PR TITLE
Hotfix for issue where initial files using the missing_value attribute don't work

### DIFF
--- a/run/make_init_base.py
+++ b/run/make_init_base.py
@@ -183,6 +183,7 @@ class initMaker:
         sss[:, :] = self.sss
 
         # mask data
+        """ TODO: Figure out why this masking doesn't work
         mdi = -3.282346e38  # Minus float max
         cice[:, :] = cice[:, :] * mask[:, :] + antimask * mdi
         cice.missing_value = mdi
@@ -202,5 +203,6 @@ class initMaker:
         sss.missing_value = mdi
         sst[:, :] = sst[:, :] * mask[:, :] + antimask * mdi
         sst.missing_value = mdi
+        """
 
         root.close()

--- a/run/make_init_base.py
+++ b/run/make_init_base.py
@@ -199,8 +199,8 @@ class initMaker:
         grid_azimuth[:, :] = grid_azimuth[:, :] * mask[:, :] + antimask * mdi
         grid_azimuth.missing_value = mdi
         sss[:, :] = sss[:, :] * mask[:, :] + antimask * mdi
-        sss.missing_sssalue = mdi
+        sss.missing_value = mdi
         sst[:, :] = sst[:, :] * mask[:, :] + antimask * mdi
-        sst.missing_sstalue = mdi
+        sst.missing_value = mdi
 
         root.close()


### PR DESCRIPTION
# Hotfix for issue where initial files using the missing_value attribute don't work
## Fixes \#547

### Task List
- [x] Defined the tests that specify a complete and functioning change (*It may help to create a [design specification & test specification](../../../wiki/Specification-Template)*)
- [x] Implemented the source code change that satisfies the tests
- [ ] Documented the feature by providing worked example
- [ ] Updated the README or other documentation
- [x] Completed the pre-Request checklist below

---
# Change Description

Init/restart files using the missing_value attribute don't work with the new dynamics switcher. We haven't found the cause for this yet, but an easy workaround is to not use the missing_value attribute. This is implemented here for the initMaker class.

This PR does not close issue #547.

---
# Test Description

The benchmark test case runs again and produces reasonable results.

---
# Documentation Impact

N/A

---
# Other Details

N/A

---
### Pre-Request Checklist

- [x] The requirements of this pull request are fully captured in an issue or design specification and are linked and summarised in the description of this PR
- [x] No new warnings are generated
- [x] The documentation has been updated (or an issue has been created to track the corresponding change)
- [x] Methods and Tests are commented such that they can be understood without having to obtain additional context
- [x] This PR/Issue is labelled as a bug/feature/enhancement/breaking change
- [x] File dates have been updated to reflect modification date
- [x] This change conforms to the conventions described in the README
