### PR TITLE
WIP: Grid boundary handling

### DIFF
--- a/dynamics/CMakeLists.txt
+++ b/dynamics/CMakeLists.txt
@@ -4,6 +4,7 @@ add_subdirectory(src)
 #endif()
 
 add_subdirectory(tests)
+add_subdirectory(applications)
 
 set(NextsimSources
     "${NextsimSources}"

--- a/dynamics/applications/CMakeLists.txt
+++ b/dynamics/applications/CMakeLists.txt
@@ -1,0 +1,29 @@
+# Include dynamics headers
+set(DynamicsSrc "../src")
+set(SRC_DIR "${DynamicsSrc}")
+set(CoreSrc "../../core/src")
+set(Core_DIR "${CoreSrc}")
+set(INCLUDE_DIR "${DynamicsSrc}/include" "${CoreSrc}/include")
+
+set(NEXTSIMLIB nextsimlib)
+
+#include_directories(${INCLUDE_DIR})
+
+add_executable(benchmark_mehlmann_sasip_mevp benchmark_mehlmann_sasip_mevp.cpp
+          "${SRC_DIR}/stopwatch.cpp"
+          "${SRC_DIR}/DGTransport.cpp"
+          "${SRC_DIR}/Interpolations.cpp"
+          "${SRC_DIR}/ParametricMesh.cpp"
+          "${SRC_DIR}/ParametricMap.cpp"
+          "${SRC_DIR}/cgParametricMomentum.cpp"
+          "${SRC_DIR}/VectorManipulations.cpp"
+          )
+target_link_libraries(benchmark_mehlmann_sasip_mevp LINK_PUBLIC
+          ${NEXTSIMLIB}
+	  Eigen3::Eigen)
+
+target_include_directories(benchmark_mehlmann_sasip_mevp
+    PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}"
+    "${NextsimIncludeDirs}"
+)

--- a/dynamics/applications/benchmark_mehlmann_sasip_mevp.cpp
+++ b/dynamics/applications/benchmark_mehlmann_sasip_mevp.cpp
@@ -1,0 +1,323 @@
+/*!
+ * @file benchmark_mehlmann_mevp.cpp
+ * @date 24 July 2022
+ * @author Thomas Richter <thomas.richter@ovgu.de>
+ */
+
+#include "Interpolations.hpp"
+#include "ParametricMesh.hpp"
+#include "ParametricTools.hpp"
+#include "DGTransport.hpp"
+
+#include "Tools.hpp"
+#include "cgParametricMomentum.hpp"
+#include "cgVector.hpp"
+#include "dgInitial.hpp"
+#include "dgLimit.hpp"
+#include "dgVisu.hpp"
+#include "mevp.hpp"
+#include "stopwatch.hpp"
+
+#include <cassert>
+#include <chrono>
+#include <filesystem>
+#include <iomanip>
+#include <iostream>
+#include <vector>
+
+
+Nextsim::COORDINATES CoordinateSystem = Nextsim::CARTESIAN;
+
+bool WRITE_VTK = true;
+
+namespace Nextsim {
+extern Timer GlobalTimer;
+}
+
+inline constexpr double SQR(double x) { return x * x; }
+
+//////////////////////////////////////////////////// Benchmark testcase from [Mehlmann / Richter, ...]
+//! Description of the problem data, wind & ocean fields
+
+namespace ReferenceScale {
+constexpr double T = 2.0 * 24 * 60. * 60.; //!< Time horizon 2 days
+  //constexpr double T = 60. * 60.; //!< 1 hour only... !!! 
+
+  
+constexpr double L = 512000.0; //!< Size of domain !!!
+constexpr double vmax_ocean = 0.01; //!< Maximum velocity of ocean
+double vmax_atm = 30.0 / exp(1.0); //!< Max. vel. of wind
+}
+
+class OceanX : public Nextsim::Interpolations::Function {
+public:
+    double operator()(double x, double y) const
+    {
+        return ReferenceScale::vmax_ocean * (2.0 * y / ReferenceScale::L - 1.0);
+    }
+};
+class OceanY : public Nextsim::Interpolations::Function {
+public:
+    double operator()(double x, double y) const
+    {
+        return ReferenceScale::vmax_ocean * (1.0 - 2.0 * x / ReferenceScale::L);
+    }
+};
+
+struct AtmX : public Nextsim::Interpolations::Function {
+    double time;
+
+public:
+    void settime(double t) { time = t; }
+    double operator()(double x, double y) const
+    {
+        constexpr double oneday = 24.0 * 60.0 * 60.0;
+        //! Center of cyclone (in m)
+        double cM = 256000. + 51200. * time / oneday;
+
+        //! scaling factor to reduce wind away from center
+        double scale = exp(1.0) / 100.0 * exp(-0.01e-3 * sqrt(SQR(x - cM) + SQR(y - cM))) * 1.e-3;
+
+        double alpha = 72.0 / 180.0 * M_PI;
+	
+        return -scale * ReferenceScale::vmax_atm * (cos(alpha) * (x - cM) + sin(alpha) * (y - cM));
+    }
+};
+struct AtmY : public Nextsim::Interpolations::Function {
+    double time;
+
+public:
+    void settime(double t) { time = t; }
+    double operator()(double x, double y) const
+    {
+        constexpr double oneday = 24.0 * 60.0 * 60.0;
+        //! Center of cyclone (in m)
+        double cM = 256000. + 51200. * time / oneday;
+
+        //! scaling factor to reduce wind away from center
+        double scale = exp(1.0) / 100.0 * exp(-0.01e-3 * sqrt(SQR(x - cM) + SQR(y - cM))) * 1.e-3;
+
+        double alpha = 72.0 / 180.0 * M_PI;
+
+        return -scale * ReferenceScale::vmax_atm * (-sin(alpha) * (x - cM) + cos(alpha) * (y - cM));
+    }
+};
+class InitialH : public Nextsim::Interpolations::Function {
+public:
+    double operator()(double x, double y) const
+    {
+      //      double pos = (pow(sin(M_PI*4.0*x/ReferenceScale::L),2.)*pow(sin(M_PI*4.0*y/ReferenceScale::L),2.))>0.2?1:0.0;
+      double pos = 1;
+      return pos*(0.3 + 0.005 * (sin(6.e-5 * x) + sin(3.e-5 * y)));
+    }
+};
+class InitialA : public Nextsim::Interpolations::Function {
+public:
+    double operator()(double x, double y) const
+  {
+    //    double pos = (pow(sin(M_PI*4.0*x/ReferenceScale::L),2.)*pow(sin(M_PI*4.0*y/ReferenceScale::L),2.))>0.2?1:0.001;
+    double pos = 1.0;
+    return pos;
+  }
+};
+//////////////////////////////////////////////////
+
+void create_mesh(const std::string& meshname, const size_t Nx, const double distort)
+{
+    std::ofstream OUT(meshname.c_str());
+    OUT << "ParametricMesh 2.0" << std::endl
+        << Nx << "\t" << Nx << std::endl;
+    for (size_t iy = 0; iy <= Nx; ++iy)
+        for (size_t ix = 0; ix <= Nx; ++ix)
+            OUT << ReferenceScale::L * ix / Nx + ReferenceScale::L * distort * sin(M_PI * ix / Nx * 3.0) * sin(M_PI * iy / Nx) << "\t"
+                << ReferenceScale::L * iy / Nx + ReferenceScale::L * distort * sin(M_PI * iy / Nx * 2.0) * sin(M_PI * ix / Nx * 2.0) << std::endl;
+
+
+    OUT << "landmask 0" << std::endl;
+    
+    if (1) // std-setup, dirichlet everywhere
+    {
+        // dirichlet info
+      OUT << "dirichlet " << 2*Nx+2*Nx << std::endl;
+      for (size_t i = 0; i < Nx; ++i)
+	OUT << i << "\t" << 0 << std::endl; // lower
+      for (size_t i = 0; i < Nx; ++i)
+	OUT << Nx * (Nx - 1) + i << "\t" << 2 << std::endl; // upper
+      
+      for (size_t i = 0; i < Nx; ++i)
+	OUT << i * Nx << "\t" << 3 << std::endl; // left
+      for (size_t i = 0; i < Nx; ++i)
+	OUT << i * Nx + Nx - 1 << "\t" << 1 << std::endl; // right
+      
+        OUT << "periodic 0" << std::endl;
+    } else {
+        OUT << "dirichlet 0" << std::endl;
+        OUT << "periodic 2" << std::endl;
+
+        OUT << 2 * Nx << std::endl; // horizontal (x-)
+        for (size_t i = 0; i < Nx; ++i)
+            OUT << Nx * (Nx - 1) + i << "\t" << i << "\t0" << std::endl; // left
+        for (size_t i = 0; i < Nx; ++i)
+            OUT << Nx - 1 + i * Nx << "\t" << i * Nx << "\t1" << std::endl;
+    }
+    OUT.close();
+}
+
+
+
+template <int CG, int DGadvection>
+void run_benchmark(const size_t NX, double distort)
+{
+    //! Define the spatial mesh
+    create_mesh("tmp-benchmark.smesh", NX, distort);
+    Nextsim::ParametricMesh smesh(CoordinateSystem);
+    smesh.readmesh("tmp-benchmark.smesh");
+
+    //! Compose name of output directory and create it
+    std::string resultsdir = "Benchmark_" + std::to_string(CG) + "_" + std::to_string(DGadvection) + "__" + std::to_string(NX);
+    std::filesystem::create_directory(resultsdir);
+
+    //! Main class to handle the momentum equation. This class also stores the CG velocity vector
+    Nextsim::CGParametricMomentum<CG> momentum(smesh);
+
+    //! define the time mesh
+    constexpr double dt_adv = 120.; //!< Time step of advection problem
+    
+    constexpr size_t NT = ReferenceScale::T / dt_adv + 1.e-4; //!< Number of Advections steps
+
+    //! MEVP parameters
+    constexpr double alpha = 1500.0;
+    constexpr double beta = 1500.0;
+    constexpr size_t NT_evp = 100; //100;
+
+    //! Rheology-Parameters
+    Nextsim::VPParameters VP;
+
+    std::cout << "Time step size (advection) " << dt_adv << "\t" << NT << " time steps" << std::endl
+              << "MEVP subcycling NTevp " << NT_evp << "\t alpha/beta " << alpha << " / " << beta << std::endl
+              << "CG/DG " << CG << "\t" << DGadvection  << std::endl;
+
+    //! VTK output
+    constexpr double T_vtk = ReferenceScale::T/48.; // 48.0 * 60.0 * 60.0; // every our
+    constexpr size_t NT_vtk = T_vtk / dt_adv + 1.e-4;
+    //! LOG message
+    constexpr double T_log = 10.0 * 60.0; // every 30 minute
+    constexpr size_t NT_log = T_log / dt_adv + 1.e-4;
+
+    ////////////////////////////////////////////////// Forcing
+    Nextsim::Interpolations::Function2CG(smesh, momentum.GetOceanx(), OceanX());
+    Nextsim::Interpolations::Function2CG(smesh, momentum.GetOceany(), OceanY());
+    AtmX AtmForcingX;
+    AtmY AtmForcingY;
+    AtmForcingX.settime(0.0);
+    AtmForcingY.settime(0.0);
+    Nextsim::Interpolations::Function2CG(smesh, momentum.GetAtmx(), AtmForcingX);
+    Nextsim::Interpolations::Function2CG(smesh, momentum.GetAtmy(), AtmForcingY);
+
+
+    ////////////////////////////////////////////////// Variables and Initial Values
+    Nextsim::DGVector<DGadvection> H(smesh), A(smesh); //!< ice height and concentration
+    Nextsim::Interpolations::Function2DG(smesh, H, InitialH());
+    Nextsim::Interpolations::Function2DG(smesh, A, InitialA());
+
+    ////////////////////////////////////////////////// i/o of initial condition
+    Nextsim::GlobalTimer.start("time loop - i/o");
+    if (1) // write initial?
+        if (WRITE_VTK) {
+            Nextsim::VTK::write_cg_velocity(resultsdir + "/vel", 0, momentum.GetVx(), momentum.GetVy(), smesh);
+            Nextsim::VTK::write_dg(resultsdir + "/A", 0, A, smesh);
+            Nextsim::VTK::write_dg(resultsdir + "/H", 0, H, smesh);
+            Nextsim::VTK::write_dg(resultsdir + "/Shear", 0, Nextsim::Tools::Shear(smesh, momentum.GetE11(), momentum.GetE12(), momentum.GetE22()), smesh);
+        }
+    Nextsim::GlobalTimer.stop("time loop - i/o");
+
+    ////////////////////////////////////////////////// Initialize transport
+    Nextsim::DGTransport<DGadvection> dgtransport(smesh);
+    dgtransport.settimesteppingscheme("rk2");
+
+    ////////////////////////////////////////////////// Main Loop
+    Nextsim::GlobalTimer.start("time loop");
+    for (size_t timestep = 1; timestep <= NT; ++timestep) {
+        double time = dt_adv * timestep;
+        double timeInMinutes = time / 60.0;
+        double timeInHours = time / 60.0 / 60.0;
+        double timeInDays = time / 60.0 / 60.0 / 24.;
+
+        if (timestep % NT_log == 0)
+            std::cout << "\rAdvection step " << timestep << "\t " << std::setprecision(2)
+                      << std::fixed << std::setw(10) << std::right << time << "s\t" << std::setw(8)
+                      << std::right << timeInMinutes << "m\t" << std::setw(6) << std::right
+                      << timeInHours << "h\t" << std::setw(6) << std::right << timeInDays << "d\t\t"
+                      << std::flush;
+
+        //////////////////////////////////////////////////
+        //! Initialize time-dependent forcing
+        Nextsim::GlobalTimer.start("time loop - forcing");
+        AtmForcingX.settime(time);
+        AtmForcingY.settime(time);
+        Nextsim::Interpolations::Function2CG(smesh, momentum.GetAtmx(), AtmForcingX);
+        Nextsim::Interpolations::Function2CG(smesh, momentum.GetAtmy(), AtmForcingY);
+        Nextsim::GlobalTimer.stop("time loop - forcing");
+
+        //////////////////////////////////////////////////
+        //! Advection step
+        Nextsim::GlobalTimer.start("time loop - advection");
+
+        // interpolates CG velocity to DG and reinits normal velocity
+        dgtransport.prepareAdvection(momentum.GetVx(), momentum.GetVy());
+
+        // performs the transport steps
+	dgtransport.step(dt_adv, A);
+	dgtransport.step(dt_adv, H);
+	
+        //! Gauss-point limiting
+        Nextsim::LimitMax(A, 1.0);
+        Nextsim::LimitMin(A, 0.0);
+        Nextsim::LimitMin(H, 0.0);
+        Nextsim::GlobalTimer.stop("time loop - advection");
+
+        //////////////////////////////////////////////////
+        Nextsim::GlobalTimer.start("time loop - mevp");
+        momentum.prepareIteration(H, A);
+        // MEVP subcycling
+        for (size_t mevpstep = 0; mevpstep < NT_evp; ++mevpstep) {
+	  momentum.mEVPStep(VP, NT_evp, alpha, beta, dt_adv, H, A);
+	  //	  momentum.VPStep(VP, dt_adv, H, A);
+	  // <- MPI
+        }
+        Nextsim::GlobalTimer.stop("time loop - mevp");
+
+        //////////////////////////////////////////////////
+        if (WRITE_VTK) // Output
+            if ((timestep % NT_vtk == 0)) {
+                std::cout << "VTK output at day " << time / 24. / 60. / 60. << std::endl;
+
+                int printstep = timestep / NT_vtk + 1.e-4;
+                Nextsim::GlobalTimer.start("time loop - i/o");
+                Nextsim::VTK::write_cg_velocity(resultsdir + "/vel", printstep, momentum.GetVx(), momentum.GetVy(), smesh);
+                Nextsim::VTK::write_dg(resultsdir + "/A", printstep, A, smesh);
+                Nextsim::VTK::write_dg(resultsdir + "/H", printstep, H, smesh);
+                Nextsim::VTK::write_dg(resultsdir + "/Delta", printstep, Nextsim::Tools::Delta(smesh, momentum.GetE11(), momentum.GetE12(), momentum.GetE22(), VP.DeltaMin), smesh);
+                Nextsim::VTK::write_dg(resultsdir + "/Shear", printstep, Nextsim::Tools::Shear(smesh, momentum.GetE11(), momentum.GetE12(), momentum.GetE22()), smesh);
+                Nextsim::GlobalTimer.stop("time loop - i/o");
+            }
+    }
+    Nextsim::GlobalTimer.stop("time loop");
+
+    std::cout << std::endl;
+    Nextsim::GlobalTimer.print();
+}
+
+int main()
+{
+  int NN[5] = {256,512};
+  for (int n=0;n<5;++n)
+    {
+      // run_benchmark<1, 1, 3>(NN[n], 0.0);
+      // run_benchmark<1, 3, 3>(NN[n], 0.0);
+      // run_benchmark<1, 6, 3>(NN[n], 0.0);
+      run_benchmark<2, 1>(NN[n], 0.0);
+      run_benchmark<2, 3>(NN[n], 0.0);
+      run_benchmark<2, 6>(NN[n], 0.0);
+    }
+}

--- a/dynamics/src/DGTransport.cpp
+++ b/dynamics/src/DGTransport.cpp
@@ -9,61 +9,42 @@
 #include "codeGenerationDGinGauss.hpp"
 
 namespace Nextsim {
-
-
+  
 #define EDGEDOFS(DG) ((DG == 1) ? 1 : ((DG == 3) ? 2 : 3))
 
-//! returns the localization of the cell vector to the edges
-  /*!
-   * writes the cell-basis on the edges in the edge basis
-   *
-   * CELL:
-   * DGdegree 0:      1
-   * DGdegree 1-2:    + (x-1/2), (y-1/2),
-   * DGdegree 3-5:    + (x-1/2)^2-1/12, (y-1/2)^2-1/12, (x-1/2)(y-1/2)
-   * DGdegree 6-7:    + (y-1/2)(x-1/2)^2-1/12, (x-1/2)(y-1/2)^2-1/12
-   *
-   * EDGE:
-   * DGdegree 0:    1
-   * DGdegree 1: +  (t-1/2)
-   * DGdegree 2: +  (t-1/2)^2-1/12
-   *
+
+
+
+  /*! 
+   * returns the localization of the cell vector to the edges. 
+   * EDGE=0 bottom, EDGE=1 right, EDGE=2 top, EDGE=3 left
    */
-template <int DG>
+template <int DG, int EDGE>
 Eigen::Matrix<Nextsim::FloatType, 1, EDGEDOFS(DG)>
-leftedgeofcell(const DGVector<DG>& cv, size_t eid);
-template <int DG>
-Eigen::Matrix<Nextsim::FloatType, 1, EDGEDOFS(DG)>
-rightedgeofcell(const DGVector<DG>& cv, size_t eid);
-template <int DG>
-Eigen::Matrix<Nextsim::FloatType, 1, EDGEDOFS(DG)>
-bottomedgeofcell(const DGVector<DG>& cv, size_t eid);
-template <int DG>
-Eigen::Matrix<Nextsim::FloatType, 1, EDGEDOFS(DG)>
-topedgeofcell(const DGVector<DG>& cv, size_t eid);
+valueonedge(const DGVector<DG>& cv, size_t eid);
 
 // dG0 (1 in cell, 1 on edge)
-template <>
+template <> // left
 Eigen::Matrix<Nextsim::FloatType, 1, 1>
-leftedgeofcell(const DGVector<1>& cv, size_t eid)
+valueonedge<1,3>(const DGVector<1>& cv, size_t eid)
 {
     return Eigen::Matrix<Nextsim::FloatType, 1, 1>(cv(eid, 0));
 }
 template <>
 Eigen::Matrix<Nextsim::FloatType, 1, 1>
-rightedgeofcell(const DGVector<1>& cv, size_t eid)
+valueonedge<1,1>(const DGVector<1>& cv, size_t eid)
 {
     return Eigen::Matrix<Nextsim::FloatType, 1, 1>(cv(eid, 0));
 }
 template <>
 Eigen::Matrix<Nextsim::FloatType, 1, 1>
-bottomedgeofcell(const DGVector<1>& cv, size_t eid)
+valueonedge<1,0>(const DGVector<1>& cv, size_t eid)
 {
     return Eigen::Matrix<Nextsim::FloatType, 1, 1>(cv(eid, 0));
 }
 template <>
 Eigen::Matrix<Nextsim::FloatType, 1, 1>
-topedgeofcell(const DGVector<1>& cv, size_t eid)
+valueonedge<1,2>(const DGVector<1>& cv, size_t eid)
 {
     return Eigen::Matrix<Nextsim::FloatType, 1, 1>(cv(eid, 0));
 }
@@ -71,25 +52,25 @@ topedgeofcell(const DGVector<1>& cv, size_t eid)
 // dG1 (3 in cell, 2 on edge)
 template <>
 Eigen::Matrix<Nextsim::FloatType, 1, 2>
-leftedgeofcell(const DGVector<3>& cv, size_t eid)
+valueonedge<3,3>(const DGVector<3>& cv, size_t eid)
 {
     return Eigen::Matrix<Nextsim::FloatType, 1, 2>(cv(eid, 0) - 0.5 * cv(eid, 1), cv(eid, 2));
 }
 template <>
 Eigen::Matrix<Nextsim::FloatType, 1, 2>
-rightedgeofcell(const DGVector<3>& cv, size_t eid)
+valueonedge<3,1>(const DGVector<3>& cv, size_t eid)
 {
     return Eigen::Matrix<Nextsim::FloatType, 1, 2>(cv(eid, 0) + 0.5 * cv(eid, 1), cv(eid, 2));
 }
 template <>
 Eigen::Matrix<Nextsim::FloatType, 1, 2>
-bottomedgeofcell(const DGVector<3>& cv, size_t eid)
+valueonedge<3,0>(const DGVector<3>& cv, size_t eid)
 {
     return Eigen::Matrix<Nextsim::FloatType, 1, 2>(cv(eid, 0) - 0.5 * cv(eid, 2), cv(eid, 1));
 }
 template <>
 Eigen::Matrix<Nextsim::FloatType, 1, 2>
-topedgeofcell(const DGVector<3>& cv, size_t eid)
+valueonedge<3,2>(const DGVector<3>& cv, size_t eid)
 {
     return Eigen::Matrix<Nextsim::FloatType, 1, 2>(cv(eid, 0) + 0.5 * cv(eid, 2), cv(eid, 1));
 }
@@ -97,37 +78,36 @@ topedgeofcell(const DGVector<3>& cv, size_t eid)
 // dG2 (6 in cell, 3 on edge)
 template <>
 Eigen::Matrix<Nextsim::FloatType, 1, 3>
-leftedgeofcell(const DGVector<6>& cv, size_t eid)
+valueonedge<6,3>(const DGVector<6>& cv, size_t eid)
 {
     return Eigen::Matrix<Nextsim::FloatType, 1, 3>(cv(eid, 0) - 0.5 * cv(eid, 1) + 1. / 6. * cv(eid, 3),
         cv(eid, 2) - 0.5 * cv(eid, 5), cv(eid, 4));
 }
 template <>
 Eigen::Matrix<Nextsim::FloatType, 1, 3>
-rightedgeofcell(const DGVector<6>& cv, size_t eid)
+valueonedge<6,1>(const DGVector<6>& cv, size_t eid)
 {
     return Eigen::Matrix<Nextsim::FloatType, 1, 3>(cv(eid, 0) + 0.5 * cv(eid, 1) + 1. / 6. * cv(eid, 3),
         cv(eid, 2) + 0.5 * cv(eid, 5), cv(eid, 4));
 }
 template <>
 Eigen::Matrix<Nextsim::FloatType, 1, 3>
-bottomedgeofcell(const DGVector<6>& cv, size_t eid)
+valueonedge<6,0>(const DGVector<6>& cv, size_t eid)
 {
     return Eigen::Matrix<Nextsim::FloatType, 1, 3>(cv(eid, 0) - 0.5 * cv(eid, 2) + 1. / 6. * cv(eid, 4),
         cv(eid, 1) - 0.5 * cv(eid, 5), cv(eid, 3));
 }
 template <>
 Eigen::Matrix<Nextsim::FloatType, 1, 3>
-topedgeofcell(const DGVector<6>& cv, size_t eid)
+valueonedge<6,2>(const DGVector<6>& cv, size_t eid)
 {
     return Eigen::Matrix<Nextsim::FloatType, 1, 3>(cv(eid, 0) + 0.5 * cv(eid, 2) + 1. / 6. * cv(eid, 4),
         cv(eid, 1) + 0.5 * cv(eid, 5), cv(eid, 3));
 }
-
 // dG2+ (8 in cell, 3 on edge)
 template <>
 Eigen::Matrix<Nextsim::FloatType, 1, 3>
-leftedgeofcell(const DGVector<8>& cv, size_t eid)
+valueonedge<8,3>(const DGVector<8>& cv, size_t eid)
 {
     return Eigen::Matrix<Nextsim::FloatType, 1, 3>(cv(eid, 0) - 0.5 * cv(eid, 1) + 1. / 6. * cv(eid, 3),
 						   cv(eid, 2) - 0.5 * cv(eid, 5) + 1./6. * cv(eid,6),
@@ -135,7 +115,7 @@ leftedgeofcell(const DGVector<8>& cv, size_t eid)
 }
 template <>
 Eigen::Matrix<Nextsim::FloatType, 1, 3>
-rightedgeofcell(const DGVector<8>& cv, size_t eid)
+valueonedge<8,1>(const DGVector<8>& cv, size_t eid)
 {
   return Eigen::Matrix<Nextsim::FloatType, 1, 3>(cv(eid, 0) + 0.5 * cv(eid, 1) + 1. / 6. * cv(eid, 3),
 						 cv(eid, 2) + 0.5 * cv(eid, 5) + 1. / 6. * cv(eid, 6),
@@ -143,7 +123,7 @@ rightedgeofcell(const DGVector<8>& cv, size_t eid)
 }
 template <>
 Eigen::Matrix<Nextsim::FloatType, 1, 3>
-bottomedgeofcell(const DGVector<8>& cv, size_t eid)
+valueonedge<8,0>(const DGVector<8>& cv, size_t eid)
 {
   return Eigen::Matrix<Nextsim::FloatType, 1, 3>(cv(eid, 0) - 0.5 * cv(eid, 2) + 1. / 6. * cv(eid, 4),
 						 cv(eid, 1) - 0.5 * cv(eid, 5) + 1. / 6. * cv(eid, 7), 
@@ -151,7 +131,7 @@ bottomedgeofcell(const DGVector<8>& cv, size_t eid)
 }
   template <>
 Eigen::Matrix<Nextsim::FloatType, 1, 3>
-topedgeofcell(const DGVector<8>& cv, size_t eid) 
+valueonedge<8,2>(const DGVector<8>& cv, size_t eid) 
 {
   return Eigen::Matrix<Nextsim::FloatType, 1, 3>(cv(eid, 0) + 0.5 * cv(eid, 2) + 1. / 6. * cv(eid, 4),
 						 cv(eid, 1) + 0.5 * cv(eid, 5) + 1. / 6. * cv(eid, 7),
@@ -167,8 +147,8 @@ topedgeofcell(const DGVector<8>& cv, size_t eid)
   // The way to compute the normal vector does not differ between
   // the Cartesian and the Sperical version. This is, since the normal
   // is not the actual normal but a scaled version of it. The weight
-  // that is missing is corrected in the two fucntions
-  // edge_term_X and edge_term_Y. Here, we omit the scaling with
+  // that is missing is corrected in the function edge_term
+  // Here, we omit the scaling with
   // cos(theta) and simple use ds = |J| as length scale
   // (instead of ds = (d_theta^2 + cos(theta)^2 d_phi^2)^1/2
   //
@@ -196,13 +176,17 @@ void DGTransport<DG>::reinitnormalvelocity()
 	  
 	  // un-normed tangent vector of left edge (pointing up). normal is (y,-x)
 	  const Eigen::Matrix<Nextsim::FloatType, 1, 2> tangent_left = smesh.edgevector(ey, ey + smesh.nx + 1);
-	  normalvel_Y.row(ey) += 0.5 * (tangent_left(0, 1) * leftedgeofcell<DG>(velx, cy) - tangent_left(0, 0) * leftedgeofcell<DG>(vely, cy));
+	  normalvel_Y.row(ey) += 0.5 * (tangent_left(0, 1) * valueonedge<DG,3>(velx, cy) - tangent_left(0, 0) * valueonedge<DG,3>(vely, cy));
 	  
 	  // un-normed tangent vector of left edge (pointing up). normal is (y,-x)
 	  const Eigen::Matrix<Nextsim::FloatType, 1, 2> tangent_right = smesh.edgevector(ey + 1, ey + smesh.nx + 2);
-	  normalvel_Y.row(ey + 1) += 0.5 * (tangent_right(0, 1) * rightedgeofcell<DG>(velx, cy) - tangent_right(0, 0) * rightedgeofcell<DG>(vely, cy));
+	  normalvel_Y.row(ey + 1) += 0.5 * (tangent_right(0, 1) * valueonedge<DG,1>(velx, cy) - tangent_right(0, 0) * valueonedge<DG,1>(vely, cy));
         }
-	// we need an adjustment along the boundaries.. This is done later on.
+
+        // scale normal at outer boundaries. Should this also be done at land-masks? Or not relevant sionce always Dirichlet?
+	normalvel_Y.row(iy * (smesh.nx + 1)) *= 2.0;
+	normalvel_Y.row((iy + 1) * (smesh.nx + 1) - 1) *= 2.0;
+	
     }
 
 #pragma omp parallel for
@@ -223,39 +207,43 @@ void DGTransport<DG>::reinitnormalvelocity()
 	  
             // un-normed tangent vector of bottom edge (pointing right). normal is (-y,x)
             const Eigen::Matrix<Nextsim::FloatType, 1, 2> tangent_bottom = smesh.edgevector(nx, nx + 1);
-
-            normalvel_X.row(cx) += 0.5 * (-tangent_bottom(0, 1) * bottomedgeofcell<DG>(velx, cx) + tangent_bottom(0, 0) * bottomedgeofcell<DG>(vely, cx));
+            normalvel_X.row(cx) += 0.5 * (-tangent_bottom(0, 1) * valueonedge<DG,0>(velx, cx) + tangent_bottom(0, 0) * valueonedge<DG,0>(vely, cx));
 
             // un-normed tangent vector of top edge (pointing right). normal is (-y,x)
             const Eigen::Matrix<Nextsim::FloatType, 1, 2> tangent_top = smesh.edgevector(nx + smesh.nx + 1, nx + smesh.nx + 2);
-
-            normalvel_X.row(cx + smesh.nx) += 0.5 * (-tangent_top(0, 1) * topedgeofcell<DG>(velx, cx) + tangent_top(0, 0) * topedgeofcell<DG>(vely, cx));
+            normalvel_X.row(cx + smesh.nx) += 0.5 * (-tangent_top(0, 1) * valueonedge<DG,2>(velx, cx) + tangent_top(0, 0) * valueonedge<DG,2>(vely, cx));
         }
+
+	
+	// scale boundary
+	normalvel_X.row(ix) *= 2.0;
+	normalvel_X.row(ix + smesh.ny * smesh.nx) *= 2.0;
+	
     }
 
-    // Take care of the boundaries. Usually, the normal velocity is the average velocity
-    // from left and from the right. Hence, we get the factor 0.5 above. At boundaries,
-    // the normal is set only once, from the inside. These edges must be scaled with 2.0
+
+    // Not making so much sense... On dirichlet boundaries the velocity is zero.
     
-    for (size_t seg = 0 ; seg<4; ++seg) // run over the 4 segments (bot, right, top, left)
-      {
-#pragma omp parallel for
-	for (size_t i = 0; i<smesh.dirichlet[seg].size();++i)
-	  {
-	    const size_t eid = smesh.dirichlet[seg][i];  //! The i of the boundary element 
-	    const size_t ix = eid % smesh.nx;            //! x & y indices of the element
-           const size_t iy = eid / smesh.nx;
+    
+//     for (size_t seg = 0 ; seg<4; ++seg) // run over the 4 segments (bot, right, top, left)
+//       {
+// #pragma omp parallel for
+// 	for (size_t i = 0; i<smesh.dirichlet[seg].size();++i)
+// 	  {
+// 	    const size_t eid = smesh.dirichlet[seg][i];  //! The i of the boundary element 
+// 	    const size_t ix = eid % smesh.nx;            //! x & y indices of the element
+//            const size_t iy = eid / smesh.nx;
 	   
-           if (seg==0) // bottom
-             normalvel_X.row(smesh.nx*iy + ix) *= 2.0;
-           else if (seg==1) // right
-             normalvel_Y.row((smesh.nx+1)*iy + ix+1) *= 2.0;
-           else if (seg==2) // top
-             normalvel_X.row(smesh.nx*(iy+1) + ix) *= 2.0;
-           else if (seg==3) // left
-             normalvel_Y.row((smesh.nx+1)*iy + ix) *= 2.0;
-         }
-      }
+//            if (seg==0) // bottom
+//              normalvel_X.row(smesh.nx*iy + ix) *= 2.0;
+//            else if (seg==1) // right
+//              normalvel_Y.row((smesh.nx+1)*iy + ix+1) *= 2.0;
+//            else if (seg==2) // top
+//              normalvel_X.row(smesh.nx*(iy+1) + ix) *= 2.0;
+//            else if (seg==3) // left
+//              normalvel_Y.row((smesh.nx+1)*iy + ix) *= 2.0;
+//          }
+//       }
 }
 
 ////////////////////////////////////////////////// PREPARE
@@ -298,15 +286,37 @@ void DGTransport<DG>::cell_term(const ParametricMesh& smesh, double dt,
   } else {
     //std::cout << "element id " << eid  << " lm " << smesh.landmask[eid] << " " << phi.row(eid) << std::endl;
   }
+
+
+
+
+  // here, veloicity and phi are evaluated in Gauss points. 
+  // vx.row(eid) is a 1 x DG matrix (row-vector), PSI is a matrix of size DG x NQ (no. quad points)
+  // * is the Matrix-Matrix Multiplication, result is a 1 x NQ matrix (row vector)
   const Eigen::Matrix<Nextsim::FloatType, 1, GAUSSPOINTS(DG)> vx_gauss = vx.row(eid) * PSI<DG, GAUSSPOINTS1D(DG)>; //!< velocity in GP
   const Eigen::Matrix<Nextsim::FloatType, 1, GAUSSPOINTS(DG)> vy_gauss = vy.row(eid) * PSI<DG, GAUSSPOINTS1D(DG)>;
-  const Eigen::Matrix<Nextsim::FloatType, 1, GAUSSPOINTS(DG)> phi_gauss = (phi.row(eid) * PSI<DG, GAUSSPOINTS1D(DG)>).array();
+  const Eigen::Matrix<Nextsim::FloatType, 1, GAUSSPOINTS(DG)> phi_gauss = phi.row(eid) * PSI<DG, GAUSSPOINTS1D(DG)>;
+
   
-  phiup.row(eid) += dt * (parammap.AdvectionCellTermX[eid].array().rowwise() * vx_gauss.array() + parammap.AdvectionCellTermY[eid].array().rowwise() * vy_gauss.array()).matrix() * phi_gauss.transpose();
+  // Das parammap.AdvectionCellTermX/Y[eid] ist die Matrix, die ich Dir aufgeschrieben habe
+  // Groesse der Matrix ist jeweils  DG x NQ
+  // Das .array() sorgt dafuer, dass die Matrizen nicht mehr als Matrizen aufgefasst werden sondern einfach als Felder. Das Produkt '*' hat
+  // dann eine andere Bedeutung
+  // Wenn X ein DG x NQ array  ist und Y ein 1 x NQ array, dann bedeutet:
+  //    X.rowwise() * Y
+  // dass eine Matrix der Groesse DG x NG rauskommt mit (X.rowwise() * Y)_ij = X_ij * Y_j
+  // es wird also einfach elementweise multipliziert
+  // Am Ende wird diese Matrix mit .matrix() wieder als Matrix interpretiert, also eine DG x NQ matrix
+  // und mit phi_gauss.transpose(), einer NQ x 1 - Matrix multipliziert. Im Ergebnis ists dann ein Vektor, also eine DG x 1 - Matrix.
+  phiup.row(eid) += dt * (parammap.AdvectionCellTermX[eid].array().rowwise() * vx_gauss.array() +
+			  parammap.AdvectionCellTermY[eid].array().rowwise() * vy_gauss.array()).matrix() *
+    phi_gauss.transpose();
+
+  
 }
 ////////////////////////////////////////////////// BOUNDARY HANDLING
 
-
+// could be template over edge... but, sign is changing from left/right, bottom/top
 template <int DG>
 void boundary_lower(const ParametricMesh& smesh, const double dt, DGVector<DG>& phiup,
     const DGVector<DG>& phi, const EdgeVector<EDGEDOFS(DG)>& normalvel_X, const size_t c, const size_t e)
@@ -314,7 +324,7 @@ void boundary_lower(const ParametricMesh& smesh, const double dt, DGVector<DG>& 
     // GP = DGEDGE
     LocalEdgeVector<EDGEDOFS(DG)> vel_gauss = normalvel_X.row(e) * PSIe<EDGEDOFS(DG), EDGEDOFS(DG)>;
     // block<1, 2>(e, 0) * PSIe<2,2>;
-    LocalEdgeVector<EDGEDOFS(DG)> tmp = ((bottomedgeofcell<DG>(phi, c) * PSIe<EDGEDOFS(DG), EDGEDOFS(DG)>).array() * (-vel_gauss.array()).max(0));
+    LocalEdgeVector<EDGEDOFS(DG)> tmp = ((valueonedge<DG,0>(phi, c) * PSIe<EDGEDOFS(DG), EDGEDOFS(DG)>).array() * (-vel_gauss.array()).max(0));
     phiup.row(c) -= dt * tmp * PSIe_w<DG, EDGEDOFS(DG), 0>;
 }
 template <int DG>
@@ -322,7 +332,7 @@ void boundary_upper(const ParametricMesh& smesh, const double dt, DGVector<DG>& 
     const DGVector<DG>& phi, const EdgeVector<EDGEDOFS(DG)>& normalvel_X, const size_t c, const size_t e)
 {
     LocalEdgeVector<EDGEDOFS(DG)> vel_gauss = normalvel_X.row(e) * PSIe<EDGEDOFS(DG), EDGEDOFS(DG)>;
-    LocalEdgeVector<EDGEDOFS(DG)> tmp = ((topedgeofcell<DG>(phi, c) * PSIe<EDGEDOFS(DG), EDGEDOFS(DG)>).array() * (vel_gauss.array()).max(0));
+    LocalEdgeVector<EDGEDOFS(DG)> tmp = ((valueonedge<DG,2>(phi, c) * PSIe<EDGEDOFS(DG), EDGEDOFS(DG)>).array() * (vel_gauss.array()).max(0));
     phiup.row(c) -= dt * tmp * PSIe_w<DG, EDGEDOFS(DG), 2>;
 }
 template <int DG>
@@ -330,7 +340,7 @@ void boundary_left(const ParametricMesh& smesh, const double dt, DGVector<DG>& p
     const DGVector<DG>& phi, const EdgeVector<EDGEDOFS(DG)>& normalvel_Y, const size_t c, const size_t e)
 {
     LocalEdgeVector<EDGEDOFS(DG)> vel_gauss = normalvel_Y.row(e) * PSIe<EDGEDOFS(DG), EDGEDOFS(DG)>;
-    LocalEdgeVector<EDGEDOFS(DG)> tmp = ((leftedgeofcell<DG>(phi, c) * PSIe<EDGEDOFS(DG), EDGEDOFS(DG)>).array() * (-vel_gauss.array()).max(0));
+    LocalEdgeVector<EDGEDOFS(DG)> tmp = ((valueonedge<DG,3>(phi, c) * PSIe<EDGEDOFS(DG), EDGEDOFS(DG)>).array() * (-vel_gauss.array()).max(0));
     phiup.row(c) -= dt * tmp * PSIe_w<DG, EDGEDOFS(DG), 3>;
 }
 template <int DG>
@@ -338,7 +348,7 @@ void boundary_right(const ParametricMesh& smesh, const double dt, DGVector<DG>& 
     const DGVector<DG>& phi, const EdgeVector<EDGEDOFS(DG)>& normalvel_Y, const size_t c, const size_t e)
 {
     LocalEdgeVector<EDGEDOFS(DG)> vel_gauss = normalvel_Y.row(e) * PSIe<EDGEDOFS(DG), EDGEDOFS(DG)>;
-    LocalEdgeVector<EDGEDOFS(DG)> tmp = ((rightedgeofcell<DG>(phi, c) * PSIe<EDGEDOFS(DG), EDGEDOFS(DG)>).array() * (vel_gauss.array().max(0)));
+    LocalEdgeVector<EDGEDOFS(DG)> tmp = ((valueonedge<DG,3>(phi, c) * PSIe<EDGEDOFS(DG), EDGEDOFS(DG)>).array() * (vel_gauss.array().max(0)));
     phiup.row(c) -= dt * tmp * PSIe_w<DG, EDGEDOFS(DG), 1>;
 }
 
@@ -346,70 +356,43 @@ void boundary_right(const ParametricMesh& smesh, const double dt, DGVector<DG>& 
 
 ////////////////////////////////////////////////// EDGE TERMS
 
-template<>
-inline void DGTransport<1>::edge_term_X(const ParametricMesh& smesh, const double dt, DGVector<1>& phiup, const DGVector<1>& phi, // DG0 (1)
-					       const EdgeVector<1>& normalvel_X, const size_t c1, const size_t c2, const size_t ie)
+/*!
+ *
+ *  +-----+-----+
+ *  |     |     |
+ *  |     |     |
+ *  |     |     |
+ *  +-----+-----+
+ *
+ *  eid1, eid2 the two elements at the edge
+ *  EOE1, EOE2 the position of the edge seen from the element
+ *             (0=bottom, 1=right, 2=top, 3=left)
+ *  edgeid index of edge
+ */
+template<int DG>
+template<int EOE1, int EOE2>
+inline void DGTransport<DG>::edge_term(const ParametricMesh& smesh,
+				       const double dt,
+				       DGVector<DG>& phiup,
+				       const DGVector<DG>& phi, // DG1 (3)
+				       const EdgeVector<EDGEDOFS(DG)>& normalvel,
+				       const size_t eid1, const size_t eid2,
+				       const size_t edgeid)
 {
-  if (smesh.landmask[c1]==0) return;
-  if (smesh.landmask[c2]==0) return;
+  if (smesh.landmask[eid1]==0) return; // nothing to do if land element
+  if (smesh.landmask[eid2]==0) return;
   
-    double bottom = phi(c1, 0);
-    double top = phi(c2, 0);
-    double vel = normalvel_X(ie, 0);
-
-    phiup(c1, 0) -= dt * (std::max(vel, 0.) * bottom + std::min(vel, 0.) * top);
-    phiup(c2, 0) += dt * (std::max(vel, 0.) * bottom + std::min(vel, 0.) * top);
-}
-template<>
-inline void DGTransport<1>::edge_term_Y(const ParametricMesh& smesh, const double dt, DGVector<1>& phiup, const DGVector<1>& phi, // DG0 (1)
-    const EdgeVector<1>& normalvel_Y, const size_t c1, const size_t c2, const size_t ie)
-{
-  if (smesh.landmask[c1]==0) return;
-  if (smesh.landmask[c2]==0) return;
-  
-    double left = phi(c1, 0);
-    double right = phi(c2, 0);
-    double vel = normalvel_Y(ie, 0);
-
-    phiup(c1, 0) -= dt * (std::max(vel, 0.) * left + std::min(vel, 0.) * right);
-    phiup(c2, 0) += dt * (std::max(vel, 0.) * left + std::min(vel, 0.) * right);
-}
-
-template <int DG>
-inline void DGTransport<DG>::edge_term_X(const ParametricMesh& smesh, const double dt, DGVector<DG>& phiup, const DGVector<DG>& phi, // DG1 (3)
-    const EdgeVector<EDGEDOFS(DG)>& normalvel_X, const size_t c1, const size_t c2, const size_t ie)
-{
-  if (smesh.landmask[c1]==0) return;
-  if (smesh.landmask[c2]==0) return;
-  
-  const LocalEdgeVector<GAUSSPOINTS1D(DG)> vel_gauss = normalvel_X.row(ie) * PSIe<EDGEDOFS(DG), GAUSSPOINTS1D(DG)>;
+  const LocalEdgeVector<GAUSSPOINTS1D(DG)> vel_gauss = normalvel.row(edgeid) * PSIe<EDGEDOFS(DG), GAUSSPOINTS1D(DG)>;
 
   const LocalEdgeVector<GAUSSPOINTS1D(DG)> tmp =
-    (vel_gauss.array().max(0) * (topedgeofcell<DG>   (phi, c1) * PSIe<EDGEDOFS(DG), GAUSSPOINTS1D(DG)>).array() + 
-     vel_gauss.array().min(0) * (bottomedgeofcell<DG>(phi, c2) * PSIe<EDGEDOFS(DG), GAUSSPOINTS1D(DG)>).array() );
+    (vel_gauss.array().max(0) * (valueonedge<DG,EOE1>(phi, eid1) * PSIe<EDGEDOFS(DG), GAUSSPOINTS1D(DG)>).array() + 
+     vel_gauss.array().min(0) * (valueonedge<DG,EOE2>(phi, eid2) * PSIe<EDGEDOFS(DG), GAUSSPOINTS1D(DG)>).array() );
     
-    phiup.row(c1) -= dt * tmp * PSIe_w<DG, GAUSSPOINTS1D(DG), 2>;
-    phiup.row(c2) += dt * tmp * PSIe_w<DG, GAUSSPOINTS1D(DG), 0>;
+  phiup.row(eid1) -= dt * tmp * PSIe_w<DG, GAUSSPOINTS1D(DG), EOE1>;
+  phiup.row(eid2) += dt * tmp * PSIe_w<DG, GAUSSPOINTS1D(DG), EOE2>;
 }
 
 
-template <int DG>
-inline void DGTransport<DG>::edge_term_Y(const ParametricMesh& smesh, const double dt, DGVector<DG>& phiup, const DGVector<DG>& phi, // DG1 (3)
-    const EdgeVector<EDGEDOFS(DG)>& normalvel_Y, const size_t c1, const size_t c2, const size_t ie)
-{
-  if (smesh.landmask[c1]==0) return;
-  if (smesh.landmask[c2]==0) return;
-  
-    const LocalEdgeVector<GAUSSPOINTS1D(DG)> vel_gauss = normalvel_Y.row(ie) * PSIe<EDGEDOFS(DG), GAUSSPOINTS1D(DG)>;
-
-    const LocalEdgeVector<EDGEDOFS(DG)> tmp =
-      (vel_gauss.array().max(0) * (rightedgeofcell<DG>(phi, c1) * PSIe<EDGEDOFS(DG), EDGEDOFS(DG)>).array() +
-       vel_gauss.array().min(0) * (leftedgeofcell <DG>(phi, c2) * PSIe<EDGEDOFS(DG), EDGEDOFS(DG)>).array());
-
-    // - [[psi]] sind we're on the left side
-    phiup.row(c1) -= dt * tmp * PSIe_w<DG, EDGEDOFS(DG), 1>;
-    phiup.row(c2) += dt * tmp * PSIe_w<DG, EDGEDOFS(DG), 3>;
-}
 
 template <int DG>
 void DGTransport<DG>::DGTransportOperator(const ParametricMesh& smesh, const double dt,
@@ -432,7 +415,7 @@ void DGTransport<DG>::DGTransportOperator(const ParametricMesh& smesh, const dou
         size_t ic = iy * smesh.nx; // first index of left cell in row
         size_t ie = iy * (smesh.nx + 1) + 1; // first index of inner velocity in row
 	for (size_t i = 0; i < smesh.nx - 1; ++i, ++ic, ++ie)
-            edge_term_Y(smesh, dt, phiup, phi, normalvel_Y, ic, ic + 1, ie);
+	  edge_term<1,3>(smesh, dt, phiup, phi, normalvel_Y, ic, ic + 1, ie);
     }
 
     // X - edges, only inner ones
@@ -441,35 +424,62 @@ void DGTransport<DG>::DGTransportOperator(const ParametricMesh& smesh, const dou
         size_t ic = ix; // first index of left cell in column
         size_t ie = ix + smesh.nx; // first index of inner velocity in column
         for (size_t i = 0; i < smesh.ny - 1; ++i, ic += smesh.nx, ie += smesh.nx)
-            edge_term_X(smesh, dt, phiup, phi, normalvel_X, ic, ic + smesh.nx, ie);
+	  edge_term<2,0>(smesh, dt, phiup, phi, normalvel_X, ic, ic + smesh.nx, ie);
     }
    
 
-    // Periodic
+    // Periodic boundaries: These are like usual edges within the domain
+    //#pragma omp parallel for      <<== not sure about parallelization
     for (size_t pc = 0 ; pc<smesh.periodic.size(); ++pc)
       {
-#pragma omp parallel for
-	for (size_t i = 0; i<smesh.periodic[pc].size();++i)
-	  {
-	    if (smesh.periodic[pc][i][0]==0) // X-edge (bottom / top)
-	      edge_term_X(smesh, dt, phiup, phi, normalvel_X, smesh.periodic[pc][i][1], smesh.periodic[pc][i][2], smesh.periodic[pc][i][3]);
-	    else if (smesh.periodic[pc][i][0]==1) // Y-edge (left / right)
-	      edge_term_Y(smesh, dt, phiup, phi, normalvel_Y, smesh.periodic[pc][i][1], smesh.periodic[pc][i][2], smesh.periodic[pc][i][3]);
-	    else
-	      {
-		std::cerr << "Wrong periodic boundary information in the mesh. Boundary side " << smesh.periodic[pc][i][0] << " not valid" << std::endl;
-		abort();
-	      }
-	  }
+	// hm... possible to use eoe1/2 as template parameters???
+	if      ( (smesh.periodic[pc].eoe1==0)&&(smesh.periodic[pc].eoe2==0) )
+	  edge_term<0,0>(smesh, dt, phiup, phi, normalvel_X, smesh.periodic[pc].eid1, smesh.periodic[pc].eid2, smesh.periodic[pc].edgeid);
+	else if ( (smesh.periodic[pc].eoe1==0)&&(smesh.periodic[pc].eoe2==1) )
+	  edge_term<0,1>(smesh, dt, phiup, phi, normalvel_X, smesh.periodic[pc].eid1, smesh.periodic[pc].eid2, smesh.periodic[pc].edgeid);
+	else if ( (smesh.periodic[pc].eoe1==0)&&(smesh.periodic[pc].eoe2==2) )
+	  edge_term<0,2>(smesh, dt, phiup, phi, normalvel_X, smesh.periodic[pc].eid1, smesh.periodic[pc].eid2, smesh.periodic[pc].edgeid);
+	else if ( (smesh.periodic[pc].eoe1==0)&&(smesh.periodic[pc].eoe2==3) )
+	  edge_term<0,3>(smesh, dt, phiup, phi, normalvel_X, smesh.periodic[pc].eid1, smesh.periodic[pc].eid2, smesh.periodic[pc].edgeid);
+
+	else if ( (smesh.periodic[pc].eoe1==2)&&(smesh.periodic[pc].eoe2==0) )
+	  edge_term<2,0>(smesh, dt, phiup, phi, normalvel_X, smesh.periodic[pc].eid1, smesh.periodic[pc].eid2, smesh.periodic[pc].edgeid);
+	else if ( (smesh.periodic[pc].eoe1==2)&&(smesh.periodic[pc].eoe2==1) )
+	  edge_term<2,1>(smesh, dt, phiup, phi, normalvel_X, smesh.periodic[pc].eid1, smesh.periodic[pc].eid2, smesh.periodic[pc].edgeid);
+	else if ( (smesh.periodic[pc].eoe1==2)&&(smesh.periodic[pc].eoe2==2) )
+	  edge_term<2,2>(smesh, dt, phiup, phi, normalvel_X, smesh.periodic[pc].eid1, smesh.periodic[pc].eid2, smesh.periodic[pc].edgeid);
+	else if ( (smesh.periodic[pc].eoe1==2)&&(smesh.periodic[pc].eoe2==3) )
+	  edge_term<2,3>(smesh, dt, phiup, phi, normalvel_X, smesh.periodic[pc].eid1, smesh.periodic[pc].eid2, smesh.periodic[pc].edgeid);
+
+	else if ( (smesh.periodic[pc].eoe1==1)&&(smesh.periodic[pc].eoe2==0) )
+	  edge_term<1,0>(smesh, dt, phiup, phi, normalvel_Y, smesh.periodic[pc].eid1, smesh.periodic[pc].eid2, smesh.periodic[pc].edgeid);
+	else if ( (smesh.periodic[pc].eoe1==1)&&(smesh.periodic[pc].eoe2==1) )
+	  edge_term<1,1>(smesh, dt, phiup, phi, normalvel_Y, smesh.periodic[pc].eid1, smesh.periodic[pc].eid2, smesh.periodic[pc].edgeid);
+	else if ( (smesh.periodic[pc].eoe1==1)&&(smesh.periodic[pc].eoe2==2) )
+	  edge_term<1,2>(smesh, dt, phiup, phi, normalvel_Y, smesh.periodic[pc].eid1, smesh.periodic[pc].eid2, smesh.periodic[pc].edgeid);
+	else if ( (smesh.periodic[pc].eoe1==1)&&(smesh.periodic[pc].eoe2==3) )
+	  edge_term<1,3>(smesh, dt, phiup, phi, normalvel_Y, smesh.periodic[pc].eid1, smesh.periodic[pc].eid2, smesh.periodic[pc].edgeid);
+
+	else if ( (smesh.periodic[pc].eoe1==3)&&(smesh.periodic[pc].eoe2==0) )
+	  edge_term<3,0>(smesh, dt, phiup, phi, normalvel_Y, smesh.periodic[pc].eid1, smesh.periodic[pc].eid2, smesh.periodic[pc].edgeid);
+	else if ( (smesh.periodic[pc].eoe1==3)&&(smesh.periodic[pc].eoe2==1) )
+	  edge_term<3,1>(smesh, dt, phiup, phi, normalvel_Y, smesh.periodic[pc].eid1, smesh.periodic[pc].eid2, smesh.periodic[pc].edgeid);
+	else if ( (smesh.periodic[pc].eoe1==3)&&(smesh.periodic[pc].eoe2==2) )
+	  edge_term<3,2>(smesh, dt, phiup, phi, normalvel_Y, smesh.periodic[pc].eid1, smesh.periodic[pc].eid2, smesh.periodic[pc].edgeid);
+	else if ( (smesh.periodic[pc].eoe1==3)&&(smesh.periodic[pc].eoe2==3) )
+	  edge_term<3,3>(smesh, dt, phiup, phi, normalvel_Y, smesh.periodic[pc].eid1, smesh.periodic[pc].eid2, smesh.periodic[pc].edgeid);
+	else
+	  abort();
       }
+
     
-    // Dirichlet
+    // open boundaries: integrate one-sided edge term
     for (size_t seg = 0 ; seg<4; ++seg) // run over the 4 segments (bot, right, top, left)
       {
 #pragma omp parallel for
-	for (size_t i = 0; i<smesh.dirichlet[seg].size();++i)
+	for (size_t i = 0; i<smesh.open[seg].size();++i)
 	  {
-	    const size_t eid = smesh.dirichlet[seg][i];
+	    const size_t eid = smesh.open[seg][i];
 	    const size_t ix = eid % smesh.nx; // compute 'coordinate' of element
 	    const size_t iy = eid / smesh.nx;
     
@@ -483,11 +493,14 @@ void DGTransport<DG>::DGTransportOperator(const ParametricMesh& smesh, const dou
 	      boundary_left (smesh, dt, phiup, phi, normalvel_Y, eid, (smesh.nx+1)*iy+ix);
 	    else
 	      {
-		std::cerr << "Wrong Dirichlet boundary information in the mesh. Boundary side " << smesh.dirichlet[seg][i] << " not valid" << std::endl;
+		std::cerr << "Wrong open boundary information in the mesh. Boundary side " << smesh.open[seg][i] << " not valid" << std::endl;
 		abort();
 	      }
 	  }
       }
+
+
+    // Dirichlet: nothing to be done in advection as v=0 on the boundary
    
 #pragma omp parallel for
     for (size_t eid = 0; eid < smesh.nelements; ++eid)

--- a/dynamics/src/ParametricMesh.cpp
+++ b/dynamics/src/ParametricMesh.cpp
@@ -7,8 +7,8 @@ namespace Nextsim {
 
 void ParametricMesh::readmesh(std::string fname)
 {
-    reset();
-
+  reset();
+  
     std::ifstream IN(fname.c_str());
     if (IN.fail()) {
         std::cerr << "ParametricMesh :: Could not open mesh file " << fname << std::endl;
@@ -19,17 +19,19 @@ void ParametricMesh::readmesh(std::string fname)
     IN >> status;
 
     if (status != "ParametricMesh") {
-        std::cerr << "ParametricMesh :: Wrong file format " << fname << "\t" << status << std::endl
+        std::cerr << "ParametricMesh :: Wrong file format " << fname << "\t" << status
+                  << std::endl
                   << "'ParametricMesh' expected" << std::endl;
         abort();
     }
 
     std::string version;
     IN >> version;
+    
+    if (statuslog>0)
+      std::cout << "ParametricMesh :: Reading " << fname << " V" << version  << std::endl;
 
-    if (statuslog > 0)
-        std::cout << "ParametricMesh :: Reading " << fname << " V" << version << std::endl;
-
+    
     if ((version != "1.0") && (version != "2.0")) {
         std::cerr << "ParametricMesh :: Wrong file format version " << fname << std::endl;
         abort();
@@ -37,13 +39,11 @@ void ParametricMesh::readmesh(std::string fname)
 
     IN >> nx >> ny;
 
-    if (statuslog > 0)
-        std::cout << "ParametricMesh :: Reading mesh with " << nx << " * " << ny << " elements"
-                  << std::endl;
+    if (statuslog>0)
+      std::cout << "ParametricMesh :: Reading mesh with " << nx << " * " << ny << " elements" << std::endl;
 
     if ((nx < 1) || (ny < 1)) {
-        std::cerr << "ParametricMesh :: Wrong mesh dimensions (nx,ny) << " << nx << " " << ny
-                  << std::endl;
+        std::cerr << "ParametricMesh :: Wrong mesh dimensions (nx,ny) << " << nx << " " << ny << std::endl;
         abort();
     }
 
@@ -63,62 +63,62 @@ void ParametricMesh::readmesh(std::string fname)
     // Boundary
     if (version == "1.0") // all four boundaries are dirichlet
     {
-        for (size_t i = 0; i < nx; ++i) // lower
-            dirichlet[0].push_back(i);
+      for (size_t i = 0; i < nx; ++i) // lower
+	dirichlet[0].push_back(i);
+      
+      for (size_t i = 0; i < ny; ++i) // right
+	dirichlet[1].push_back(i * nx + nx - 1);
+      
+      for (size_t i = 0; i < nx; ++i) // upper
+	dirichlet[2].push_back(i + nx * (ny - 1));
+      
+      for (size_t i = 0; i < ny; ++i) // left
+	dirichlet[3].push_back(i * nx);
 
-        for (size_t i = 0; i < ny; ++i) // right
-            dirichlet[1].push_back(i * nx + nx - 1);
-
-        for (size_t i = 0; i < nx; ++i) // upper
-            dirichlet[2].push_back(i + nx * (ny - 1));
-
-        for (size_t i = 0; i < ny; ++i) // left
-            dirichlet[3].push_back(i * nx);
-
-        landmask.resize(nx * ny, true); // set landmask
+      landmask.resize(nx*ny,true); // set landmask
     } else if (version == "2.0") // landmask, dirichlet and periodic boundary as additional lists
     {
         IN >> status;
-
         if (status != "landmask") {
-            std::cerr << "V2.0 Expecting landmask information after nodes." << std::endl
+	  std::cerr << "V2.0 Expecting landmask information after nodes." << std::endl
                       << "\tlandmask ne" << std::endl
-                      << "where ne is the number of elements. Should match nx * ny" << std::endl
-                      << "If all is land, just provide " << std::endl
-                      << "   landmask 0" << std::endl;
+		    << "where ne is the number of elements. Should match nx * ny" << std::endl
+		    << "If all is land, just provide " << std::endl
+		    << "   landmask 0" <<  std::endl;
             abort();
-        }
-        size_t ne;
-        IN >> ne;
+	}
+	size_t ne;
+	IN >> ne;
 
-        if (ne == 0) {
-            landmask.resize(nx * ny, true);
-        } else {
-            assert(ne == nx * ny);
-            landmask.resize(nx * ny, false);
-            bool lm;
-            for (size_t i = 0; i < nx * ny; ++i) {
-                IN >> lm;
+	if (ne == 0)
+	  {
+	    landmask.resize(nx*ny,true);
+	  }
+	else 
+	  {
+	    assert(ne == nx * ny);
+	    landmask.resize(nx*ny,false);
+	    bool lm;
+	    for (size_t i=0;i<nx*ny;++i)
+	      {
+		IN >> lm;
+		if (lm)
+		  landmask[i] = true;
 
-                if (lm)
-                    landmask[i] = true;
+		if (IN.eof()) {
+		  std::cerr << "ParametricMesh :: Unexpected eof << " << fname << std::endl;
+		  abort();
+		}
+	      }
+	  }
 
-                if (IN.eof()) {
-                    std::cerr << "ParametricMesh :: Unexpected eof << " << fname << std::endl;
-                    abort();
-                }
-            }
-        }
-
+      
         IN >> status;
-
         if (status != "dirichlet") {
             std::cerr << "V2.0 Expecting Dirichlet information after list of elements" << std::endl
                       << "\tdirichlet nd" << std::endl
                       << "where nd is the number of dirichlet edges" << std::endl
-                      << "Then, for each edge we expect a line with two entries: id-of-element "
-                         "[0,1,2,3] for the edge"
-                      << std::endl;
+		      << "Then, for each edge we expect a line with two entries: id-of-element [0,1,2,3] for the edge" << std::endl;
             abort();
         }
         size_t nd;
@@ -128,64 +128,61 @@ void ParametricMesh::readmesh(std::string fname)
             std::cout << "reading " << nd << " dirichlet segments" << std::endl;
 
         for (size_t i = 0; i < nd; ++i) {
-            size_t n0, n1;
-            IN >> n0 >> n1; // read the element and the side
-            assert(n0 < nx * ny);
-            assert(n0 >= 0);
+	  size_t n0, n1;
+	  IN >> n0 >> n1; // read the element and the side
+	  assert (n0<nx*ny);
+	  assert (n0>=0);
 
-            dirichlet[n1].push_back(n0);
+	  dirichlet[n1].push_back(n0);
 
-            if (IN.eof()) {
-                std::cerr << "ParametricMesh :: Unexpected eof << " << fname << std::endl;
-                abort();
-            }
+	  if (IN.eof()) {
+	    std::cerr << "ParametricMesh :: Unexpected eof << " << fname << std::endl;
+	    abort();
+	  }
         }
 
         IN >> status;
         if (status != "periodic") {
             std::cerr << "Expecting Periodic information after Dirichlet" << std::endl
                       << "\tperiodic nd" << std::endl
-                      << "where nd is the number of periodic segments" << std::endl;
+                      << "where nd is the number of periodic edges" << std::endl
+		      << "For each periodic edge: element-id1, element-id2, edge-of-element1, edge-of-element2" << std::endl;
             std::cerr << "Instead, got: " << status << std::endl;
             abort();
         }
         IN >> nd;
+	if (statuslog > 0)
+	  std::cout << "reading " << nd << " periodic edges" << std::endl;
+
         periodic.clear();
         periodic.resize(nd);
         for (size_t i = 0; i < nd; ++i) {
-            periodic[i].clear();
-            size_t nind;
-            IN >> nind;
-            if (statuslog > 0)
-                std::cout << "reading periodic segment " << i << " with " << nind << " entries"
-                          << std::endl;
+	    periodic[i].clear();
+	    IN >> periodic[i].eid1 >> periodic[i].eid2 >> periodic[i].eoe1 >> periodic[i].eoe2;
 
-            for (size_t j = 0; j < nind; ++j) {
-                size_t n0, n1, n2;
-                IN >> n0 >> n1 >> n2; // read the elements and the side
-                assert(n2 == 0 || n2 == 1);
-                if (n2 == 0) // X-edge, bottom / top
-                {
-                    periodic[i].push_back(std::array<size_t, 4>({ n2, n0, n1, n0 }));
-                } else if (n2 == 1) // Y-edge, left / right
-                {
-                    size_t ix = n0 % nx;
-                    size_t iy = n0 / nx;
-                    periodic[i].push_back(
-                        std::array<size_t, 4>({ n2, n0, n1, iy * (nx + 1) + ix }));
-                } else
-                    abort();
-            }
+	    size_t ix = periodic[i].eid1 % nx;
+	    size_t iy = periodic[i].eid1 / nx;
+	    
+	    if      (periodic[i].eoe1 == 0) // bottom 
+	      periodic[i].edgeid = nx*iy + ix;
+	    else if (periodic[i].eoe1 == 2) // top
+	      periodic[i].edgeid = nx*(iy+1) + ix;
+	    else if (periodic[i].eoe1 == 3) // left 
+	      periodic[i].edgeid = (nx+1)*iy + ix;
+	    else if (periodic[i].eoe1 == 1) // right
+	      periodic[i].edgeid = (nx+1)*iy + ix + 1;
+	    
         }
     }
 
     IN.close();
 
+
+
     if (statuslog > 0) {
         std::cout << "ParametricMesh :: read mesh file " << fname << std::endl
                   << "             nx,ny = " << nx << " , " << ny << std::endl
-                  << "             " << nelements << " elements,  " << nnodes << " nodes"
-                  << std::endl;
+                  << "             " << nelements << " elements,  " << nnodes << " nodes" << std::endl;
     }
 }
 

--- a/dynamics/src/include/DGTransport.hpp
+++ b/dynamics/src/include/DGTransport.hpp
@@ -162,11 +162,12 @@ private:
 							  const EdgeVector<EDGEDOFS(DG)>& normalvel_Y,
 							  const DGVector<DG>& phi, DGVector<DG>& phiup);
 
-  void edge_term_X(const ParametricMesh& smesh, const double dt, DGVector<DG>& phiup, const DGVector<DG>& phi, 
-		   const EdgeVector<EDGEDOFS(DG)>& normalvel_Y, const size_t c1, const size_t c2, const size_t ie);
-  void edge_term_Y(const ParametricMesh& smesh, const double dt, DGVector<DG>& phiup, const DGVector<DG>& phi, 
-		   const EdgeVector<EDGEDOFS(DG)>& normalvel_Y, const size_t c1, const size_t c2, const size_t ie);
-    
+  template<int EOE1, int EOE2>
+  void edge_term(const ParametricMesh& smesh, const double dt, DGVector<DG>& phiup, const DGVector<DG>& phi, 
+		 const EdgeVector<EDGEDOFS(DG)>& normalvel,
+		 const size_t eid1, const size_t eid2,
+		 const size_t edgeid);
+  
   void cell_term(const ParametricMesh& smesh, double dt,
 		 DGVector<DG>& phiup, const DGVector<DG>& phi,
 		 const DGVector<DG>& vx,

--- a/dynamics/src/include/VectorManipulations.hpp
+++ b/dynamics/src/include/VectorManipulations.hpp
@@ -25,106 +25,95 @@ namespace Nextsim
   
   namespace VectorManipulations
   {
+
     
     template<int CG>
     void CGAveragePeriodic(const ParametricMesh& smesh, CGVector<CG>& v) 
     {
-      // the two segments bottom, right, top, left, are each processed in parallel
-      for (size_t seg=0;seg<smesh.periodic.size();++seg)
-	{
-	  //#pragma omp parallel for
-	  for (size_t i = 0; i < smesh.periodic[seg].size(); ++i) {
-
-	    const size_t ptype  = smesh.periodic[seg][i][0];
-	    const size_t eid_lb = smesh.periodic[seg][i][2];
-	    const size_t eid_rt = smesh.periodic[seg][i][1];
+      
+      for (size_t i = 0; i < smesh.periodic.size(); ++i) {
 	
-	    size_t ix_lb = eid_lb % smesh.nx;
-	    size_t iy_lb = eid_lb / smesh.nx;
-	    size_t i0_lb = (CG * smesh.nx + 1) * CG * iy_lb + CG * ix_lb; // lower/left index in left/bottom element
-	    size_t ix_rt = eid_rt % smesh.nx;
-	    size_t iy_rt = eid_rt / smesh.nx;
-	    size_t i0_rt = (CG * smesh.nx + 1) * CG * iy_rt + CG * ix_rt; // lower/left index in right/top element
+	const size_t ptype  = smesh.periodic[i].eoe1;
+	const size_t eid_lb = smesh.periodic[i].eid1;
+	const size_t eid_rt = smesh.periodic[i].eid2;
 	
-	    if (ptype == 0) // X-edge, bottom/top
+	size_t ix_lb = eid_lb % smesh.nx;
+	size_t iy_lb = eid_lb / smesh.nx;
+	size_t i0_lb = (CG * smesh.nx + 1) * CG * iy_lb + CG * ix_lb; // lower/left index in left/bottom element
+	size_t ix_rt = eid_rt % smesh.nx;
+	size_t iy_rt = eid_rt / smesh.nx;
+	size_t i0_rt = (CG * smesh.nx + 1) * CG * iy_rt + CG * ix_rt; // lower/left index in right/top element
+	
+	if (ptype == 0) // X-edge, bottom/top
+	  {
+	    for (size_t j=0;j<=CG;++j)
 	      {
-		for (size_t j=0;j<=CG;++j)
-		  {
-		    v(i0_lb+j) =0.5 * (v(i0_lb+j) +  v(i0_rt+ CG * (CG * smesh.nx + 1) + j));
-		    v(i0_rt+ CG * (CG * smesh.nx + 1) + j) = v(i0_lb+j);
-		  }
+		v(i0_lb+j) =0.5 * (v(i0_lb+j) +  v(i0_rt+ CG * (CG * smesh.nx + 1) + j));
+		v(i0_rt+ CG * (CG * smesh.nx + 1) + j) = v(i0_lb+j);
 	      }
-	    else if (ptype == 1) // Y-edge, left/right
-	      {
-		for (size_t j=0;j<=CG;++j)
-		  {
-		    const size_t i1 = i0_lb +      j * (CG * smesh.nx+1);
-		    const size_t i2 = i0_rt + CG + j * (CG * smesh.nx+1);
-		    v(i1) = 0.5 * (v(i1) + v(i2));
-		    v(i2) = v(i1);
-		  }
-	      }
-	    else
-	      abort();
 	  }
-	}
-
-
+	else if (ptype == 1) // Y-edge, left/right
+	  {
+	    for (size_t j=0;j<=CG;++j)
+	      {
+		const size_t i1 = i0_lb +      j * (CG * smesh.nx+1);
+		const size_t i2 = i0_rt + CG + j * (CG * smesh.nx+1);
+		v(i1) = 0.5 * (v(i1) + v(i2));
+		v(i2) = v(i1);
+	      }
+	  }
+	else
+	  abort();
+      }
     }
 
     template <int CG>
     void CGAddPeriodic(const ParametricMesh& smesh, CGVector<CG>& v)
     {
-      // the two segments bottom, right, top, left, are each processed in parallel
-      for (size_t seg=0;seg<smesh.periodic.size();++seg)
-	{
-	  //#pragma omp parallel for
-	  for (size_t i = 0; i < smesh.periodic[seg].size(); ++i) {
+      //#pragma omp parallel for
+      for (size_t i = 0; i < smesh.periodic.size(); ++i) {
 
-	    const size_t ptype  = smesh.periodic[seg][i][0];
-	    const size_t eid_lb = smesh.periodic[seg][i][2];
-	    const size_t eid_rt = smesh.periodic[seg][i][1];
+	const size_t ptype  = smesh.periodic[i].eoe1;
+	const size_t eid_lb = smesh.periodic[i].eid1;
+	const size_t eid_rt = smesh.periodic[i].eid2;
 	
-	    size_t ix_lb = eid_lb % smesh.nx;
-	    size_t iy_lb = eid_lb / smesh.nx;
-	    size_t i0_lb = (CG * smesh.nx + 1) * CG * iy_lb + CG * ix_lb; // lower/left index in left/bottom element
-	    size_t ix_rt = eid_rt % smesh.nx;
-	    size_t iy_rt = eid_rt / smesh.nx;
-	    size_t i0_rt = (CG * smesh.nx + 1) * CG * iy_rt + CG * ix_rt; // lower/left index in right/top element
+	size_t ix_lb = eid_lb % smesh.nx;
+	size_t iy_lb = eid_lb / smesh.nx;
+	size_t i0_lb = (CG * smesh.nx + 1) * CG * iy_lb + CG * ix_lb; // lower/left index in left/bottom element
+	size_t ix_rt = eid_rt % smesh.nx;
+	size_t iy_rt = eid_rt / smesh.nx;
+	size_t i0_rt = (CG * smesh.nx + 1) * CG * iy_rt + CG * ix_rt; // lower/left index in right/top element
+	
 
-
-	    //      problem: wenn man bis CG geht, dann werden die ecken je doppelt addiert...
-	    //               wenn man eins vorher aufhoert, dann ist in der ecke was falsch?
-	    if (ptype == 0) // X-edge, bottom/top
+	//      problem: wenn man bis CG geht, dann werden die ecken je doppelt addiert...
+	//               wenn man eins vorher aufhoert, dann ist in der ecke was falsch?
+	if (ptype == 0) // X-edge, bottom/top
+	  {
+	    for (size_t j=0;j<CG;++j)
 	      {
-		for (size_t j=0;j<CG;++j)
-		  {
-		    v(i0_lb+j) += v(i0_rt+ CG * (CG * smesh.nx + 1) + j);
-		    v(i0_rt+ CG * (CG * smesh.nx + 1) + j) = v(i0_lb+j);
+		v(i0_lb+j) += v(i0_rt+ CG * (CG * smesh.nx + 1) + j);
+		v(i0_rt+ CG * (CG * smesh.nx + 1) + j) = v(i0_lb+j);
 		  }
-	      }
-	    else if (ptype == 1) // Y-edge, left/right
-	      {
-		for (size_t j=0;j<CG;++j)
-		  {
-		    const size_t i1 = i0_lb +      j * (CG * smesh.nx+1);
-		    const size_t i2 = i0_rt + CG + j * (CG * smesh.nx+1);
-
-		    v(i1) += v(i2);
-		    v(i2)  = v(i1);
-		  }
-	      }
-	    else
-	      abort();
 	  }
-	}
+	else if (ptype == 1) // Y-edge, left/right
+	  {
+	    for (size_t j=0;j<CG;++j)
+	      {
+		const size_t i1 = i0_lb +      j * (CG * smesh.nx+1);
+		const size_t i2 = i0_rt + CG + j * (CG * smesh.nx+1);
+		
+		v(i1) += v(i2);
+		v(i2)  = v(i1);
+	      }
+	  }
+	else
+	  abort();
+      }
     }
 
 
-    
+
   }
-
-
   
 }
 

--- a/dynamics/src/include/cgParametricMomentum.hpp
+++ b/dynamics/src/include/cgParametricMomentum.hpp
@@ -201,12 +201,10 @@ public:
         const size_t cy, CGVector<CG>& tx, CGVector<CG>& ty) const;
 
     //! Sets the velocity vector to zero along the boundary
-    void DirichletZero()
-    {
-        DirichletZero(vx);
-        DirichletZero(vy);
-    }
     void DirichletZero(CGVector<CG>& v) const;
+
+    //! Sets normal component of velocity to zero along freeslip boundaries
+    void FreeSlipZero(CGVector<CG>& vx,CGVector<CG>& vy) const;
 
   /*!
    * AddPeriodic is to be called, after (sigma, Nabla Phi) is computed
@@ -218,7 +216,6 @@ public:
    * the average of them
    */
   void AveragePeriodic(CGVector<CG>& v);
-  void CheckPeriodicity(CGVector<CG>& v);
 };
 
 template <int CG>


### PR DESCRIPTION
# Grid boundary handling
## Fixes \#537

---
# Change Description

## Periodic boundary

a periodic boundary element consists of
- an edge (given by its id)
- two elements on the left/right or bottom/top of the edge
- two indices specifying where the edge is as seen from the element

## Dirichlet-type conditions:

- dirichlet (v=0)
- open (free inflow/outflow with zero concentration on inflow)
- freeslip (normal velocity zero)

the all have the interface std::array<std::vector<size_t>, 4> where the outer index corresponds to elements that have boundary on the bottom, right, top, left and the inner index to corresponding id of the element.

## Code changes

Handling of periodic boundaries required several changes in DGTransport.cpp and cgParametricMomentum.cpp This mostly includes restructuring code and adding the edge (bottom, right, top, left) as template parameter.

Further, code is added to deal with open and freeslip boundaries.

---
# Test Description

There is a test in the (new) application folder.

---
# Documentation Impact

TODO

