### PR TITLE
Eliminate Module warnings from tests.

### DIFF
--- a/physics/test/ERA5Atm_test.cpp
+++ b/physics/test/ERA5Atm_test.cpp
@@ -24,6 +24,8 @@
 #define TEST_FILE_SOURCE .
 #endif
 
+extern template class Module::Module<Nextsim::IFluxCalculation>;
+
 namespace Nextsim {
 
 TEST_SUITE_BEGIN("ERA5Atmosphere");

--- a/physics/test/IceGrowth_test.cpp
+++ b/physics/test/IceGrowth_test.cpp
@@ -24,6 +24,7 @@
 #include "include/UniformOcean.hpp"
 #include "include/constants.hpp"
 
+extern template class Module::Module<Nextsim::IIceThermodynamics>;
 namespace Nextsim {
 
 TEST_SUITE_BEGIN("IceGrowth");


### PR DESCRIPTION
# Eliminate Module warnings from tests.
## Fixes \#356 (kind of) 

---
# Change Description

Declare Modularized classes as extern to eliminate the last warnings during compilation (on my computer, at least). 

Compilation warnings such as 
```
In file included from /Users/timpai/nextsim/dg/nextsimdg/physics/test/ERA5Atm_test.cpp:15:
/Users/timpai/nextsim/dg/nextsimdg/physics/test/../../core/src/include/Module.hpp:56:9: warning: instantiation of variable 'Module::Module<Nextsim::IFluxCalculation>::spf' required here, but no definition is available [-Wundefined-var-template]
        spf = generator;
        ^
/Users/timpai/nextsim/dg/nextsimdg/physics/test/ERA5Atm_test.cpp:62:39: note: in instantiation of member function 'Module::Module<Nextsim::IFluxCalculation>::setExternalImplementation' requested here
    Module::Module<IFluxCalculation>::setExternalImplementation(
                                      ^
/Users/timpai/nextsim/dg/nextsimdg/physics/test/../../core/src/include/Module.hpp:101:15: note: forward declaration of template entity is here
    static fn spf;
              ^
/Users/timpai/nextsim/dg/nextsimdg/physics/test/../../core/src/include/Module.hpp:56:9: note: add an explicit instantiation declaration to suppress this warning if 'Module::Module<Nextsim::IFluxCalculation>::spf' is explicitly instantiated in another translation unit
        spf = generator;
        ^
/Users/timpai/nextsim/dg/nextsimdg/physics/test/../../core/src/include/Module.hpp:57:9: warning: instantiation of variable 'Module::Module<Nextsim::IFluxCalculation>::staticInstance' required here, but no definition is available [-Wundefined-var-template]
        staticInstance = std::move(spf());
        ^
/Users/timpai/nextsim/dg/nextsimdg/physics/test/../../core/src/include/Module.hpp:102:31: note: forward declaration of template entity is here
    static std::unique_ptr<I> staticInstance;
                              ^
/Users/timpai/nextsim/dg/nextsimdg/physics/test/../../core/src/include/Module.hpp:57:9: note: add an explicit instantiation declaration to suppress this warning if 'Module::Module<Nextsim::IFluxCalculation>::staticInstance' is explicitly instantiated in another translation unit
        staticInstance = std::move(spf());
        ^
2 warnings generated.

``` 

can be solved by adding 
```
extern template class Module::Module<ModularizedClassName>
```
 just before the test source code.