### PR TITLE
Use `Nextsim` namespace for XIOS tests

### DIFF
--- a/core/test/XiosAxis_test.cpp
+++ b/core/test/XiosAxis_test.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file    XiosAxis_test.cpp
  * @author  Joe Wallwork <jw2423@cam.ac.uk
- * @date    21 June 2024
+ * @date    27 June 2024
  * @brief   Tests for XIOS axes
  * @details
  * This test is designed to test axis functionality of the C++ interface

--- a/core/test/XiosAxis_test.cpp
+++ b/core/test/XiosAxis_test.cpp
@@ -16,6 +16,8 @@
 
 #include <iostream>
 
+namespace Nextsim {
+
 /*!
  * TestXiosAxis
  *
@@ -29,19 +31,19 @@ MPI_TEST_CASE("TestXiosAxis", 2)
 {
 
     // Enable XIOS in the 'config'
-    Nextsim::Configurator::clearStreams();
+    Configurator::clearStreams();
     std::stringstream config;
     config << "[xios]" << std::endl << "enable = true" << std::endl;
     std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
-    Nextsim::Configurator::addStream(std::move(pcstream));
+    Configurator::addStream(std::move(pcstream));
 
     // Initialize an Xios instance called xios_handler
-    Nextsim::Xios xios_handler;
+    Xios xios_handler;
     REQUIRE(xios_handler.isInitialized());
     REQUIRE(xios_handler.getClientMPISize() == 2);
 
     // Set timestep as a minimum
-    xios_handler.setCalendarTimestep(Nextsim::Duration("P0-0T01:00:00"));
+    xios_handler.setCalendarTimestep(Duration("P0-0T01:00:00"));
 
     // --- Tests for axis API
     const std::string axisId = { "axis_A" };
@@ -63,4 +65,5 @@ MPI_TEST_CASE("TestXiosAxis", 2)
 
     xios_handler.close_context_definition();
     xios_handler.context_finalize();
+}
 }

--- a/core/test/XiosCalendar_test.cpp
+++ b/core/test/XiosCalendar_test.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file    XiosCalendar_test.cpp
  * @author  Joe Wallwork <jw2423@cam.ac.uk
- * @date    21 June 2024
+ * @date    27 June 2024
  * @brief   Tests for XIOS calandars
  * @details
  * This test is designed to test calendar functionality of the C++ interface

--- a/core/test/XiosCalendar_test.cpp
+++ b/core/test/XiosCalendar_test.cpp
@@ -16,6 +16,8 @@
 
 #include <iostream>
 
+namespace Nextsim {
+
 /*!
  * TestXiosCalendar
  *
@@ -29,14 +31,14 @@ MPI_TEST_CASE("TestXiosInitialization", 2)
 {
 
     // Enable XIOS in the 'config'
-    Nextsim::Configurator::clearStreams();
+    Configurator::clearStreams();
     std::stringstream config;
     config << "[xios]" << std::endl << "enable = true" << std::endl;
     std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
-    Nextsim::Configurator::addStream(std::move(pcstream));
+    Configurator::addStream(std::move(pcstream));
 
     // Initialize an Xios instance called xios_handler
-    Nextsim::Xios xios_handler;
+    Xios xios_handler;
     REQUIRE(xios_handler.isInitialized());
     REQUIRE(xios_handler.getClientMPISize() == 2);
 
@@ -44,17 +46,17 @@ MPI_TEST_CASE("TestXiosInitialization", 2)
     // Calendar type
     REQUIRE(xios_handler.getCalendarType() == "Gregorian");
     // Calendar origin
-    Nextsim::TimePoint origin("2020-01-23T00:08:15Z");
+    TimePoint origin("2020-01-23T00:08:15Z");
     xios_handler.setCalendarOrigin(origin);
     REQUIRE(origin == xios_handler.getCalendarOrigin());
     REQUIRE(origin.format() == "2020-01-23T00:08:15Z");
     // Calendar start
-    Nextsim::TimePoint start("2023-03-17T17:11:00Z");
+    TimePoint start("2023-03-17T17:11:00Z");
     xios_handler.setCalendarStart(start);
     REQUIRE(start == xios_handler.getCalendarStart());
     REQUIRE(start.format() == "2023-03-17T17:11:00Z");
     // Timestep
-    Nextsim::Duration timestep("P0-0T01:30:00");
+    Duration timestep("P0-0T01:30:00");
     REQUIRE(timestep.seconds() == doctest::Approx(5400.0));
     xios_handler.setCalendarTimestep(timestep);
     REQUIRE(xios_handler.getCalendarTimestep().seconds() == doctest::Approx(5400.0));
@@ -66,4 +68,6 @@ MPI_TEST_CASE("TestXiosInitialization", 2)
     REQUIRE(xios_handler.getCurrentDate(false) == "2023-03-17 17:11:00");
 
     xios_handler.context_finalize();
+}
+
 }

--- a/core/test/XiosDomain_test.cpp
+++ b/core/test/XiosDomain_test.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file    XiosDomain_test.cpp
  * @author  Joe Wallwork <jw2423@cam.ac.uk
- * @date    21 June 2024
+ * @date    27 June 2024
  * @brief   Tests for XIOS domains
  * @details
  * This test is designed to test domain functionality of the C++ interface

--- a/core/test/XiosDomain_test.cpp
+++ b/core/test/XiosDomain_test.cpp
@@ -16,6 +16,8 @@
 
 #include <iostream>
 
+namespace Nextsim {
+
 /*!
  * TestXiosDomin
  *
@@ -29,21 +31,21 @@ MPI_TEST_CASE("TestXiosDomain", 2)
 {
 
     // Enable XIOS in the 'config'
-    Nextsim::Configurator::clearStreams();
+    Configurator::clearStreams();
     std::stringstream config;
     config << "[xios]" << std::endl << "enable = true" << std::endl;
     std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
-    Nextsim::Configurator::addStream(std::move(pcstream));
+    Configurator::addStream(std::move(pcstream));
 
     // Initialize an Xios instance called xios_handler
-    Nextsim::Xios xios_handler;
+    Xios xios_handler;
     REQUIRE(xios_handler.isInitialized());
     const size_t size = xios_handler.getClientMPISize();
     REQUIRE(size == 2);
     const size_t rank = xios_handler.getClientMPIRank();
 
     // Set timestep as a minimum
-    xios_handler.setCalendarTimestep(Nextsim::Duration("P0-0T01:00:00"));
+    xios_handler.setCalendarTimestep(Duration("P0-0T01:00:00"));
 
     // --- Tests for domain API
     const std::string domainId = { "domain_A" };
@@ -117,4 +119,5 @@ MPI_TEST_CASE("TestXiosDomain", 2)
 
     xios_handler.close_context_definition();
     xios_handler.context_finalize();
+}
 }

--- a/core/test/XiosField_test.cpp
+++ b/core/test/XiosField_test.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file    XiosField_test.cpp
  * @author  Joe Wallwork <jw2423@cam.ac.uk
- * @date    21 June 2024
+ * @date    27 June 2024
  * @brief   Tests for XIOS axes
  * @details
  * This test is designed to test axis functionality of the C++ interface

--- a/core/test/XiosField_test.cpp
+++ b/core/test/XiosField_test.cpp
@@ -16,6 +16,8 @@
 
 #include <iostream>
 
+namespace Nextsim {
+
 /*!
  * TestXiosField
  *
@@ -29,21 +31,21 @@ MPI_TEST_CASE("TestXiosField", 2)
 {
 
     // Enable XIOS in the 'config'
-    Nextsim::Configurator::clearStreams();
+    Configurator::clearStreams();
     std::stringstream config;
     config << "[xios]" << std::endl << "enable = true" << std::endl;
     std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
-    Nextsim::Configurator::addStream(std::move(pcstream));
+    Configurator::addStream(std::move(pcstream));
 
     // Initialize an Xios instance called xios_handler
-    Nextsim::Xios xios_handler;
+    Xios xios_handler;
     REQUIRE(xios_handler.isInitialized());
     const size_t size = xios_handler.getClientMPISize();
     REQUIRE(size == 2);
     const size_t rank = xios_handler.getClientMPIRank();
 
     // Set timestep as a minimum
-    xios_handler.setCalendarTimestep(Nextsim::Duration("P0-0T01:00:00"));
+    xios_handler.setCalendarTimestep(Duration("P0-0T01:00:00"));
 
     // Axis setup
     xios_handler.createAxis("axis_A");
@@ -77,4 +79,5 @@ MPI_TEST_CASE("TestXiosField", 2)
 
     xios_handler.close_context_definition();
     xios_handler.context_finalize();
+}
 }

--- a/core/test/XiosFile_test.cpp
+++ b/core/test/XiosFile_test.cpp
@@ -16,6 +16,8 @@
 
 #include <iostream>
 
+namespace Nextsim {
+
 /*!
  * TestXiosInitialization
  *
@@ -29,21 +31,21 @@ MPI_TEST_CASE("TestXiosFile", 2)
 {
 
     // Enable XIOS in the 'config'
-    Nextsim::Configurator::clearStreams();
+    Configurator::clearStreams();
     std::stringstream config;
     config << "[xios]" << std::endl << "enable = true" << std::endl;
     std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
-    Nextsim::Configurator::addStream(std::move(pcstream));
+    Configurator::addStream(std::move(pcstream));
 
     // Initialize an Xios instance called xios_handler
-    Nextsim::Xios xios_handler;
+    Xios xios_handler;
     REQUIRE(xios_handler.isInitialized());
     const size_t size = xios_handler.getClientMPISize();
     REQUIRE(size == 2);
     const size_t rank = xios_handler.getClientMPIRank();
 
     // Set timestep as a minimum
-    xios_handler.setCalendarTimestep(Nextsim::Duration("P0-0T01:00:00"));
+    xios_handler.setCalendarTimestep(Duration("P0-0T01:00:00"));
 
     // Axis setup
     xios_handler.createAxis("axis_A");
@@ -88,4 +90,5 @@ MPI_TEST_CASE("TestXiosFile", 2)
 
     xios_handler.close_context_definition();
     xios_handler.context_finalize();
+}
 }

--- a/core/test/XiosFile_test.cpp
+++ b/core/test/XiosFile_test.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file    XiosFile_test.cpp
  * @author  Joe Wallwork <jw2423@cam.ac.uk
- * @date    21 June 2024
+ * @date    27 June 2024
  * @brief   Tests for XIOS axes
  * @details
  * This test is designed to test axis functionality of the C++ interface

--- a/core/test/XiosGrid_test.cpp
+++ b/core/test/XiosGrid_test.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file    XiosGrid_test.cpp
  * @author  Joe Wallwork <jw2423@cam.ac.uk
- * @date    21 June 2024
+ * @date    27 June 2024
  * @brief   Tests for XIOS axes
  * @details
  * This test is designed to test axis functionality of the C++ interface

--- a/core/test/XiosGrid_test.cpp
+++ b/core/test/XiosGrid_test.cpp
@@ -16,6 +16,8 @@
 
 #include <iostream>
 
+namespace Nextsim {
+
 /*!
  * TestXiosGrid
  *
@@ -29,21 +31,21 @@ MPI_TEST_CASE("TestXiosGrid", 2)
 {
 
     // Enable XIOS in the 'config'
-    Nextsim::Configurator::clearStreams();
+    Configurator::clearStreams();
     std::stringstream config;
     config << "[xios]" << std::endl << "enable = true" << std::endl;
     std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
-    Nextsim::Configurator::addStream(std::move(pcstream));
+    Configurator::addStream(std::move(pcstream));
 
     // Initialize an Xios instance called xios_handler
-    Nextsim::Xios xios_handler;
+    Xios xios_handler;
     REQUIRE(xios_handler.isInitialized());
     const size_t size = xios_handler.getClientMPISize();
     REQUIRE(size == 2);
     const size_t rank = xios_handler.getClientMPIRank();
 
     // Set timestep as a minimum
-    xios_handler.setCalendarTimestep(Nextsim::Duration("P0-0T01:30:00"));
+    xios_handler.setCalendarTimestep(Duration("P0-0T01:30:00"));
 
     // Axis setup
     xios_handler.createAxis("axis_A");
@@ -95,4 +97,5 @@ MPI_TEST_CASE("TestXiosGrid", 2)
 
     xios_handler.close_context_definition();
     xios_handler.context_finalize();
+}
 }

--- a/core/test/XiosWrite_test.cpp
+++ b/core/test/XiosWrite_test.cpp
@@ -16,6 +16,8 @@
 
 #include <iostream>
 
+namespace Nextsim {
+
 /*!
  * TestXiosWrite
  *
@@ -29,23 +31,23 @@ MPI_TEST_CASE("TestXiosWrite", 2)
 {
 
     // Enable XIOS in the 'config'
-    Nextsim::Configurator::clearStreams();
+    Configurator::clearStreams();
     std::stringstream config;
     config << "[xios]" << std::endl << "enable = true" << std::endl;
     std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
-    Nextsim::Configurator::addStream(std::move(pcstream));
+    Configurator::addStream(std::move(pcstream));
 
     // Initialize an Xios instance called xios_handler
-    Nextsim::Xios xios_handler;
+    Xios xios_handler;
     REQUIRE(xios_handler.isInitialized());
     const size_t size = xios_handler.getClientMPISize();
     REQUIRE(size == 2);
     const size_t rank = xios_handler.getClientMPIRank();
 
     // Calendar setup
-    xios_handler.setCalendarOrigin(Nextsim::TimePoint("2020-01-23T00:08:15Z"));
-    xios_handler.setCalendarStart(Nextsim::TimePoint("2023-03-17T17:11:00Z"));
-    xios_handler.setCalendarTimestep(Nextsim::Duration("P0-0T01:30:00"));
+    xios_handler.setCalendarOrigin(TimePoint("2020-01-23T00:08:15Z"));
+    xios_handler.setCalendarStart(TimePoint("2023-03-17T17:11:00Z"));
+    xios_handler.setCalendarTimestep(Duration("P0-0T01:30:00"));
 
     // Axis setup
     const int n1 = 2;
@@ -133,4 +135,5 @@ MPI_TEST_CASE("TestXiosWrite", 2)
     delete[] field_4D;
 
     xios_handler.context_finalize();
+}
 }

--- a/core/test/XiosWrite_test.cpp
+++ b/core/test/XiosWrite_test.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file    XiosWrite_test.cpp
  * @author  Joe Wallwork <jw2423@cam.ac.uk
- * @date    21 June 2024
+ * @date    27 June 2024
  * @brief   Tests for XIOS write method
  * @details
  * This test is designed to test the write method of the C++ interface


### PR DESCRIPTION
# Use `Nextsim` namespace for XIOS tests
## Fixes \#589

### Task List
- [x] Defined the tests that specify a complete and functioning change (*It may help to create a [design specification & test specification](../../../wiki/Specification-Template)*)
- [x] Implemented the source code change that satisfies the tests
- [x] Documented the feature by providing worked example
- [x] Updated the README or other documentation
- [x] Completed the pre-Request checklist below

# Test Description

Minor change, putting the XIOS tests in the `Nextsim` namespace to avoid multiple uses of `Nextsim::`.

---
### Pre-Request Checklist

- [x] The requirements of this pull request are fully captured in an issue or design specification and are linked and summarised in the description of this PR
- [x] No new warnings are generated
- [x] The documentation has been updated (or an issue has been created to track the corresponding change)
- [x] Methods and Tests are commented such that they can be understood without having to obtain additional context
- [x] This PR/Issue is labelled as a bug/feature/enhancement/breaking change
- [x] File dates have been updated to reflect modification date
- [x] This change conforms to the conventions described in the README