### PR TITLE
Default the initial 'lastOutputTime' to the model start time.

### DIFF
--- a/core/src/DevStep.cpp
+++ b/core/src/DevStep.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file DevStep.cpp
  *
- * @date Jan 12, 2022
+ * @date 2 Jul 2024
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 
@@ -26,7 +26,13 @@ void DevStep::init()
     tryConfigure(ido);
 }
 
-void DevStep::start(const TimePoint& startTime) { lastOutput = startTime; }
+void DevStep::start(const TimePoint& startTime)
+{
+    // Set the last output time for the restart files to the model start time
+    lastOutput = startTime;
+    // Set the model start time for the diagnostic output files
+    Module::getImplementation<IDiagnosticOutput>().setModelStart(startTime);
+}
 
 void DevStep::iterate(const TimestepTime& tst)
 {

--- a/core/src/modules/DiagnosticOutputModule/include/ConfigOutput.hpp
+++ b/core/src/modules/DiagnosticOutputModule/include/ConfigOutput.hpp
@@ -1,7 +1,7 @@
 /*!
  * @file ConfigOutput.hpp
  *
- * @date 7 Sep 2023
+ * @date 2 Jul 2024
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 
@@ -37,8 +37,9 @@ public:
 
     // IDiagnosticOutput overrides
     void setFilenamePrefix(const std::string& filePrefix) override { m_filePrefix = filePrefix; }
-
+    void setModelStart(const TimePoint& modelStart) override;
     void outputState(const ModelMetadata& meta) override;
+
 
     // ModelComponent overrides
     inline std::string getName() const override { return "ConfigOutput"; };

--- a/core/src/modules/include/IDiagnosticOutput.hpp
+++ b/core/src/modules/include/IDiagnosticOutput.hpp
@@ -1,7 +1,7 @@
 /*!
  * @file IDiagnosticOutput.hpp
  *
- * @date May 25, 2022
+ * @date 2 Jul 2024
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 
@@ -48,6 +48,14 @@ public:
     // Define some of the ModelComponent class functions
     // No data to be set
     void setData(const ModelState::DataMap& state) { }
+
+    /*!
+     * Sets the model start time, which implementations may use to time output events.
+     *
+     * @brief modelStart the TimePoint of the start of the model run.
+     */
+    virtual void setModelStart(const TimePoint& ModelStart) { }
+
 protected:
     const std::map<std::string, std::string> externalNames;
 };


### PR DESCRIPTION
# Default the initial 'lastOutputTime' to the model start time.
## Fixes \#599

# Change Description

Changed the logic for setting the initial value of `ConfigOutput::lastOutputTime`. If no configuration was given for the key `ConfigOutput.start` then a default value should be used. This was previous the TimePoint equivalent to the ISO date string "0-01-01T00:00:00Z". However, this caused output to not trigger, for reasons that are no longer important. The time of the last output represents the time from which to start outputting diagnostic data with the given period.

The logic for setting `lastOutputTime` is (as a result of this PR):

1. Use the date value at `ConfigOutput::start`
2. if that is not set, use the value at `model.start`
3. if that is not set (the start date is the date of the restart file), ingest that start date at `DevStep::start()`.

---
# Documentation Impact

The inline help for the `ConfigOutput` class already states that the default value of `ConfigOutput.start` is `model.start`. So the impact is that the code now matches the doumentation.