### PR TITLE
Define a default value of damage, if it is not provided.

### DIFF
--- a/core/src/PrognosticData.cpp
+++ b/core/src/PrognosticData.cpp
@@ -60,7 +60,7 @@ void PrognosticData::setData(const ModelState::DataMap& ms)
     m_conc = ms.at("cice");
     m_tice = ms.at("tice");
     m_snow = ms.at("hsnow");
-    // Damage is an optional field, and defaults to zero, if absent
+    // Damage is an optional field, and defaults to 1, if absent
     if (ms.count(damageName) > 0) {
         m_damage = ms.at(damageName);
     } else {


### PR DESCRIPTION
# Define a default value of damage, if it is not provided.
## Fixes \#602

---
# Change Description

Within `BBMDynamics`, separate the data fields that are obtained from the restart file into required and optional fields. Required fields are set immediately, just as before this change. Optional fields, which include the damage field, are mapped to an array type and default value. If the field is present, then the data is set immediately, as before. Otherwise a new `ModelArray` is created of the specified type and filled with the default value. This is then passed into the `setData()` function. 
