### PR TITLE
Fix poor performance of `IceGrowth::initializeThicknesses`

### DIFF
--- a/physics/src/IceGrowth.cpp
+++ b/physics/src/IceGrowth.cpp
@@ -181,7 +181,7 @@ void IceGrowth::initializeThicknessesElement(size_t i, const TimestepTime&)
     }
 
     // reset the new ice volume array
-    newice = 0;
+    newice[i] = 0;
 }
 
 void IceGrowth::newIceFormation(size_t i, const TimestepTime& tst)


### PR DESCRIPTION
# Fix poor performance of `IceGrowth::initializeThicknesses`
## Fixes \#604

# Change Description

The poor performance is a result of the complete `newice` array getting initialized to 0 for every single element. Instead the method `IceGrowth::initializeThicknessesElement` should only write the value for element `i`, as it does for every other array. This single line change gives me roughly a x20 speedup for 2.6e5 elements.

---
# Test Description

---
# Documentation Impact

---
