### PR TITLE
New ``model.missing_value``

### DIFF
--- a/core/src/MissingData.cpp
+++ b/core/src/MissingData.cpp
@@ -9,7 +9,7 @@
 
 namespace Nextsim {
 
-const double MissingData::defaultValue = -0x1p300;
+const double MissingData::defaultValue = 1.7e38;
 double MissingData::value = MissingData::defaultValue;
 
 } /* namespace Nextsim */

--- a/core/src/MissingData.cpp
+++ b/core/src/MissingData.cpp
@@ -1,8 +1,9 @@
 /*!
  * @file MissingData.cpp
  *
- * @date Jun 14, 2022
+ * @date Jul 17, 2024
  * @author Tim Spain <timothy.spain@nersc.no>
+ * @author Einar Ólason <einar.olason@nersc.no>
  */
 
 #include "include/MissingData.hpp"


### PR DESCRIPTION
# New ``model.missing_value``
## Fixes \#612

### Task List
- [x] Defined the tests that specify a complete and functioning change (*It may help to create a [design specification & test specification](../../../wiki/Specification-Template)*)
- [x] Implemented the source code change that satisfies the tests
- [x] Documented the feature by providing worked example
- [ ] Updated the README or other documentation
- [x] Completed the pre-Request checklist below

---
# Change Description

This PR changes the value of ``model.missing_value`` to be less than the largest permitted float on most systems. This is so that we can easily view the netCDF files output by the model using ncview.

---
# Test Description

Run the dynamics benchmark (``./nextsim --config-files config_benchmark.cfg``) and view the output using ncview. An ``ncdump -h benchmark_32x32.diagnostic.nc| grep 'missing_value'`` should look like this:

```
                cice:missing_value = 1.7e+38 ;
                hice:missing_value = 1.7e+38 ;
                hsnow:missing_value = 1.7e+38 ;
                u:missing_value = 1.7e+38 ;
                v:missing_value = 1.7e+38 ;
```

---
# Documentation Impact

N/A

---
# Other Details

None

---
### Pre-Request Checklist

- [x] The requirements of this pull request are fully captured in an issue or design specification and are linked and summarised in the description of this PR
- [x] No new warnings are generated
- [x] The documentation has been updated (or an issue has been created to track the corresponding change)
- [x] Methods and Tests are commented such that they can be understood without having to obtain additional context
- [x] This PR/Issue is labelled as a bug/feature/enhancement/breaking change
- [x] File dates have been updated to reflect modification date
- [x] This change conforms to the conventions described in the README
