### PR TITLE
Separate out XIOS Docker build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /build*
 */build
+Dockerfiles/Makefile
 Results
 /.cproject
 /.project

--- a/Dockerfiles/Dockerfile.base
+++ b/Dockerfiles/Dockerfile.base
@@ -1,0 +1,72 @@
+# Build stage with Spack pre-installed and ready to be used
+FROM spack/ubuntu-jammy:0.21 AS builder
+
+
+# What we want to install and how we want to install it
+# is specified in a manifest file (spack.yaml)
+RUN mkdir /opt/spack-environment \
+&&  (echo spack: \
+&&   echo '  packages:' \
+&&   echo '    all:' \
+&&   echo '      compiler: [gcc@11.4.0]' \
+&&   echo '  specs:' \
+&&   echo '  - boost@1.80.0+log+program_options' \
+&&   echo '  - cmake@3.27.7' \
+&&   echo '  - eigen@3.4.0' \
+&&   echo '  - gmake' \
+&&   echo '  - hdf5@1.14.3' \
+&&   echo '  - netcdf-c@4.9.2+mpi+parallel-netcdf' \
+&&   echo '  - netcdf-cxx4@4.3.1' \
+&&   echo '  - netcdf-fortran' \
+&&   echo '  - openmpi@4.1.6' \
+&&   echo '  - zlib-ng@2.1.4' \
+&&   echo '  concretizer:' \
+&&   echo '    unify: true' \
+&&   echo '  config:' \
+&&   echo '    install_missing_compilers: true' \
+&&   echo '    install_tree: /opt/software' \
+&&   echo '  view: /opt/views/view') > /opt/spack-environment/spack.yaml
+
+# Install the software, remove unnecessary deps
+RUN cd /opt/spack-environment && spack env activate . && spack install --fail-fast && spack gc -y
+
+# install perl URI lib
+RUN apt update && apt install -y libany-uri-escape-perl
+
+# Create a directory for any XIOS builds
+RUN mkdir -p /xios
+
+# Strip all the binaries
+RUN find -L /opt/views/view/* -type f -exec readlink -f '{}' \; | \
+    xargs file -i | \
+    grep 'charset=binary' | \
+    grep 'x-executable\|x-archive\|x-sharedlib' | \
+    awk -F: '{print $1}' | xargs strip
+
+# Modifications to the environment that are necessary to run
+RUN cd /opt/spack-environment && \
+    spack env activate --sh -d . > activate.sh
+
+# Bare OS image to run the installed executables
+FROM ubuntu:22.04
+
+COPY --from=builder /opt/spack-environment /opt/spack-environment
+COPY --from=builder /opt/software /opt/software
+COPY --from=builder /xios /xios
+COPY --from=builder /usr /usr
+
+# paths.view is a symlink, so copy the parent to avoid dereferencing and duplicating it
+COPY --from=builder /opt/views /opt/views
+
+RUN { \
+      echo '#!/bin/sh' \
+      && echo '.' /opt/spack-environment/activate.sh \
+      && echo 'exec "$@"'; \
+    } > /entrypoint.sh \
+&& chmod a+x /entrypoint.sh \
+&& ln -s /opt/views/view /opt/view \
+&& apt update && apt install -y ca-certificates python3-dev python3-netcdf4
+
+
+ENTRYPOINT [ "/entrypoint.sh" ]
+CMD [ "/bin/bash" ]

--- a/Dockerfiles/Dockerfile.devenv
+++ b/Dockerfiles/Dockerfile.devenv
@@ -1,74 +1,10 @@
-# Build stage with Spack pre-installed and ready to be used
-FROM spack/ubuntu-jammy:0.21 as builder
+FROM ghcr.io/nextsimhub/nextsimdg-base:latest
 
+WORKDIR /nextsimdg/build
 
-# What we want to install and how we want to install it
-# is specified in a manifest file (spack.yaml)
-RUN mkdir /opt/spack-environment \
-&&  (echo spack: \
-&&   echo '  packages:' \
-&&   echo '    all:' \
-&&   echo '      compiler: [gcc@11.4.0]' \
-&&   echo '  specs:' \
-&&   echo '  - boost@1.80.0+log+program_options' \
-&&   echo '  - cmake@3.27.7' \
-&&   echo '  - eigen@3.4.0' \
-&&   echo '  - gmake' \
-&&   echo '  - hdf5@1.14.3' \
-&&   echo '  - netcdf-c@4.9.2+mpi+parallel-netcdf' \
-&&   echo '  - netcdf-cxx4@4.3.1' \
-&&   echo '  - netcdf-fortran' \
-&&   echo '  - openmpi@4.1.6' \
-&&   echo '  - zlib-ng@2.1.4' \
-&&   echo '  concretizer:' \
-&&   echo '    unify: true' \
-&&   echo '  config:' \
-&&   echo '    install_missing_compilers: true' \
-&&   echo '    install_tree: /opt/software' \
-&&   echo '  view: /opt/views/view') > /opt/spack-environment/spack.yaml
-
-# Install the software, remove unnecessary deps
-RUN cd /opt/spack-environment && spack env activate . && spack install --fail-fast && spack gc -y
-
-# install perl URI lib
-RUN apt update && apt install -y libany-uri-escape-perl
-
-# download and install xios
+# Download and install XIOS
 COPY install-xios.sh .
-RUN spack env activate /opt/spack-environment && bash install-xios.sh
-
-# Strip all the binaries
-RUN find -L /opt/views/view/* -type f -exec readlink -f '{}' \; | \
-    xargs file -i | \
-    grep 'charset=binary' | \
-    grep 'x-executable\|x-archive\|x-sharedlib' | \
-    awk -F: '{print $1}' | xargs strip
-
-# Modifications to the environment that are necessary to run
-RUN cd /opt/spack-environment && \
-    spack env activate --sh -d . > activate.sh
-
-# Bare OS image to run the installed executables
-FROM ubuntu:22.04
-
-COPY --from=builder /opt/spack-environment /opt/spack-environment
-COPY --from=builder /opt/software /opt/software
-COPY --from=builder /xios /xios
-COPY --from=builder /usr /usr
-
-# paths.view is a symlink, so copy the parent to avoid dereferencing and duplicating it
-COPY --from=builder /opt/views /opt/views
-
-RUN { \
-      echo '#!/bin/sh' \
-      && echo '.' /opt/spack-environment/activate.sh \
-      && echo 'exec "$@"'; \
-    } > /entrypoint.sh \
-&& chmod a+x /entrypoint.sh \
-&& ln -s /opt/views/view /opt/view \
-&& apt update && apt install -y ca-certificates python3-dev python3-netcdf4
-
+RUN . /opt/spack-environment/activate.sh && bash install-xios.sh
 
 ENTRYPOINT [ "/entrypoint.sh" ]
 CMD [ "/bin/bash" ]
-

--- a/Dockerfiles/Dockerfile.production
+++ b/Dockerfiles/Dockerfile.production
@@ -1,6 +1,7 @@
 FROM ghcr.io/nextsimhub/nextsimdg-dev-env:latest
 
-RUN git clone https://github.com/nextsimhub/nextsimdg.git /nextsimdg
+RUN git clone https://github.com/nextsimhub/nextsimdg.git /nextsimdg/tmp
+RUN mv /nextsimdg/tmp/* /nextsimdg
 
 WORKDIR /nextsimdg/build
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -165,12 +165,24 @@ You might need to tell cmake which compiler to use, e.g.
 Using Dockerfiles for Development or Production Runs
 ----------------------------------------------------
 
-In the ``Dockerfiles`` directory we provide two ``Dockerfile``'s are provided.
+In the ``Dockerfiles`` directory, three ``Dockerfile``'s are provided.
 
+- ``Dockerfile.base`` - This is the base ``Dockerfile`` used to build other Docker images. It is not intended to be run by users.
 - ``Dockerfile.devenv`` - This is the ``Dockerfile`` used to build the development image (``ghcr.io/nextsimhub/nextsimdg-dev-env``), that is
-  used in the GitHub CI.
-- ``Dockerfile.production`` - This ``Dockerfile`` is based off of the development image and it
-  additionally installs ``nextsim`` so that you can run on any machine with ``docker`` installed.
+  used in the GitHub CI. Based off ``Dockerfile.base``.
+- ``Dockerfile.production`` - This ``Dockerfile`` is based off of the development image and it additionally installs ``nextsim`` (albeit not
+  configured with XIOS or MPI) so that you can run on any machine with ``docker`` installed.
+
+Base Dockerfile
+^^^^^^^^^^^^^^^
+
+The base image is not stored on the nextsimhub `GitHub container registry
+<https://github.com/orgs/nextsimhub/packages>`_ because it is not intended to be run by users.
+However, if a developer needs to rebuild the docker image, they can do so with:
+
+.. code-block:: console
+
+    docker build --file Dockerfile.base . -t ghcr.io/nextsimhub/nextsimdg-base:latest
 
 Development Dockerfile
 ^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
# Separate out XIOS Docker build
## Fixes #625

### Task List
- [x] Defined the tests that specify a complete and functioning change (*It may help to create a [design specification & test specification](../../../wiki/Specification-Template)*)
- [x] Implemented the source code change that satisfies the tests
- [x] Documented the feature by providing worked example
- [x] Updated the README or other documentation
- [x] Completed the pre-Request checklist below

---
# Change Description

Currently, we have a `Dockerfile.devenv` and a `Dockerfile.production`, which depends on it. The former sets up the build dependencies using Spack, as well as installing XIOS. This is inconvenient for updating XIOS because rebuilding the dev-env image requires rebuilding the Spack environment, too.

This PR separates out `Dockerfile.devenv` into two steps: `Dockerfile.base`, which installs the dependencies, and `Dockerfile.devenv`, which pulls in those and installs XIOS.

I've built the images locally, as well as `Dockerfile.production`, which is built on top of `Dockerfile.devenv`. Running the production Docker image built with `mpi=ON` and `xios=ON`, I was able to run the tests successfully. Once the reviewer is happy with the changes, I can push the Docker images to ghcr.

---
### Pre-Request Checklist

- [x] The requirements of this pull request are fully captured in an issue or design specification and are linked and summarised in the description of this PR
- [x] No new warnings are generated
- [x] The documentation has been updated (or an issue has been created to track the corresponding change)
- [x] Methods and Tests are commented such that they can be understood without having to obtain additional context
- [x] This PR/Issue is labelled as a bug/feature/enhancement/breaking change
- [x] File dates have been updated to reflect modification date
- [x] This change conforms to the conventions described in the README
