### PR TITLE
Drop XIOS `isDefined*` and `areDefined*` methods

### DIFF
--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -462,117 +462,152 @@ void Xios::createDomain(const std::string domainId)
 }
 
 /*!
- * Set the local longitude size for a given domain
+ * Set the global number of points in the x-direction for a given domain
  *
  * @param the domain ID
- * @param the local longitude size
+ * @param the global number of points in the x-direction
+ */
+void Xios::setDomainGlobalXSize(const std::string domainId, const size_t size)
+{
+    xios::CDomain* domain = getDomain(domainId);
+    if (cxios_is_defined_domain_ni_glo(domain)) {
+        Logged::warning("Xios: Overwriting global x-size for domain '" + domainId + "'");
+    }
+    cxios_set_domain_ni_glo(domain, (int)size);
+    if (!cxios_is_defined_domain_ni_glo(domain)) {
+        throw std::runtime_error("Xios: Failed to set global x-size for domain '" + domainId + "'");
+    }
+}
+
+/*!
+ * Set the global number of points in the y-direction for a given domain
+ *
+ * @param the domain ID
+ * @param the global number of points in the y-direction
+ */
+void Xios::setDomainGlobalYSize(const std::string domainId, const size_t size)
+{
+    xios::CDomain* domain = getDomain(domainId);
+    if (cxios_is_defined_domain_nj_glo(domain)) {
+        Logged::warning("Xios: Overwriting global y-size for domain '" + domainId + "'");
+    }
+    cxios_set_domain_nj_glo(domain, (int)size);
+    if (!cxios_is_defined_domain_nj_glo(domain)) {
+        throw std::runtime_error("Xios: Failed to set global y-size for domain '" + domainId + "'");
+    }
+}
+
+/*!
+ * Set the local number of points in the x-direction for a given domain
+ *
+ * @param the domain ID
+ * @param the local number of points in the x-direction
  */
 void Xios::setDomainLocalXSize(const std::string domainId, const size_t size)
 {
     xios::CDomain* domain = getDomain(domainId);
     if (cxios_is_defined_domain_ni(domain)) {
-        Logged::warning("Xios: Overwriting longitude size for domain '" + domainId + "'");
+        Logged::warning("Xios: Overwriting local x-size for domain '" + domainId + "'");
     }
     cxios_set_domain_ni(domain, (int)size);
     if (!cxios_is_defined_domain_ni(domain)) {
-        throw std::runtime_error(
-            "Xios: Failed to set longitude size for domain '" + domainId + "'");
+        throw std::runtime_error("Xios: Failed to set local x-size for domain '" + domainId + "'");
     }
 }
 
 /*!
- * Set the local latitude size for a given domain
+ * Set the local number of points in the y-direction for a given domain
  *
  * @param the domain ID
- * @param the local longitude size
+ * @param the local number of points in the y-direction
  */
 void Xios::setDomainLocalYSize(const std::string domainId, const size_t size)
 {
     xios::CDomain* domain = getDomain(domainId);
     if (cxios_is_defined_domain_nj(domain)) {
-        Logged::warning("Xios: Overwriting latitude size for domain '" + domainId + "'");
+        Logged::warning("Xios: Overwriting local y-size for domain '" + domainId + "'");
     }
     cxios_set_domain_nj(domain, (int)size);
     if (!cxios_is_defined_domain_nj(domain)) {
-        throw std::runtime_error("Xios: Failed to set latitude size for domain '" + domainId + "'");
+        throw std::runtime_error("Xios: Failed to set local y-size for domain '" + domainId + "'");
     }
 }
 
 /*!
- * Set the local start longitude for a given domain
+ * Set the local starting x-index for a given domain
  *
  * @param the domain ID
- * @return the local start longitude
+ * @return the local starting x-index
  */
 void Xios::setDomainLocalXStart(const std::string domainId, const size_t start)
 {
     xios::CDomain* domain = getDomain(domainId);
     if (cxios_is_defined_domain_ibegin(domain)) {
-        Logged::warning("Xios: Overwriting longitude start for domain '" + domainId + "'");
+        Logged::warning("Xios: Overwriting local starting x-index for domain '" + domainId + "'");
     }
     cxios_set_domain_ibegin(domain, (int)start);
     if (!cxios_is_defined_domain_ibegin(domain)) {
         throw std::runtime_error(
-            "Xios: Failed to set longitude start for domain '" + domainId + "'");
+            "Xios: Failed to set local starting x-index for domain '" + domainId + "'");
     }
 }
 
 /*!
- * Set the local start latitude for a given domain
+ * Set the local starting y-index for a given domain
  *
  * @param the domain ID
- * @return the local start latitude
+ * @return the local starting y-index
  */
 void Xios::setDomainLocalYStart(const std::string domainId, const size_t start)
 {
     xios::CDomain* domain = getDomain(domainId);
     if (cxios_is_defined_domain_jbegin(domain)) {
-        Logged::warning("Xios: Overwriting latitude start for domain '" + domainId + "'");
+        Logged::warning("Xios: Overwriting local starting y-index for domain '" + domainId + "'");
     }
     cxios_set_domain_jbegin(domain, (int)start);
     if (!cxios_is_defined_domain_jbegin(domain)) {
         throw std::runtime_error(
-            "Xios: Failed to set latitude start for domain '" + domainId + "'");
+            "Xios: Failed to set local starting y-index for domain '" + domainId + "'");
     }
 }
 
 /*!
- * Set the local longitude values for a given domain
+ * Set the local x-values for a given domain
  *
  * @param the domain ID
- * @return the local longitude values
+ * @return the local x-values
  */
 void Xios::setDomainLocalXValues(const std::string domainId, std::vector<double> values)
 {
     xios::CDomain* domain = getDomain(domainId);
     if (cxios_is_defined_domain_lonvalue_1d(domain)) {
-        Logged::warning("Xios: Overwriting longitude values for domain '" + domainId + "'");
+        Logged::warning("Xios: Overwriting local x-values for domain '" + domainId + "'");
     }
     int size = getDomainLocalXSize(domainId);
     cxios_set_domain_lonvalue_1d(domain, values.data(), &size);
     if (!cxios_is_defined_domain_lonvalue_1d(domain)) {
         throw std::runtime_error(
-            "Xios: Failed to set longitude values for domain '" + domainId + "'");
+            "Xios: Failed to set local x-values for domain '" + domainId + "'");
     }
 }
 
 /*!
- * Set the local latitude values for a given domain
+ * Set the local y-values for a given domain
  *
  * @param the domain ID
- * @return the local latitude values
+ * @return the local y-values
  */
 void Xios::setDomainLocalYValues(const std::string domainId, std::vector<double> values)
 {
     xios::CDomain* domain = getDomain(domainId);
     if (cxios_is_defined_domain_latvalue_1d(domain)) {
-        Logged::warning("Xios: Overwriting latitude values for domain '" + domainId + "'");
+        Logged::warning("Xios: Overwriting local y-values for domain '" + domainId + "'");
     }
     int size = getDomainLocalYSize(domainId);
     cxios_set_domain_latvalue_1d(domain, values.data(), &size);
     if (!cxios_is_defined_domain_latvalue_1d(domain)) {
         throw std::runtime_error(
-            "Xios: Failed to set latitude values for domain '" + domainId + "'");
+            "Xios: Failed to set local y-values for domain '" + domainId + "'");
     }
 }
 
@@ -591,44 +626,6 @@ void Xios::setDomainType(const std::string domainId, const std::string domainTyp
     cxios_set_domain_type(domain, domainType.c_str(), domainType.length());
     if (!cxios_is_defined_domain_type(domain)) {
         throw std::runtime_error("Xios: Failed to set type for domain '" + domainId + "'");
-    }
-}
-
-/*!
- * Set the global longitude size for a given domain
- *
- * @param the domain ID
- * @param global longitude size to set
- */
-void Xios::setDomainGlobalXSize(const std::string domainId, const size_t size)
-{
-    xios::CDomain* domain = getDomain(domainId);
-    if (cxios_is_defined_domain_ni_glo(domain)) {
-        Logged::warning("Xios: Overwriting global longitude size for domain '" + domainId + "'");
-    }
-    cxios_set_domain_ni_glo(domain, (int)size);
-    if (!cxios_is_defined_domain_ni_glo(domain)) {
-        throw std::runtime_error(
-            "Xios: Failed to set global longitude size for domain '" + domainId + "'");
-    }
-}
-
-/*!
- * Set the global latitude size for a given domain
- *
- * @param the domain ID
- * @param global latitude size to set
- */
-void Xios::setDomainGlobalYSize(const std::string domainId, const size_t size)
-{
-    xios::CDomain* domain = getDomain(domainId);
-    if (cxios_is_defined_domain_nj_glo(domain)) {
-        Logged::warning("Xios: Overwriting global latitude size for domain '" + domainId + "'");
-    }
-    cxios_set_domain_nj_glo(domain, (int)size);
-    if (!cxios_is_defined_domain_nj_glo(domain)) {
-        throw std::runtime_error(
-            "Xios: Failed to set global latitude size for domain '" + domainId + "'");
     }
 }
 
@@ -652,17 +649,16 @@ std::string Xios::getDomainType(const std::string domainId)
 }
 
 /*!
- * Get the global longitude size for a given domain
+ * Get the global number of points in the x-direction for a given domain
  *
  * @param the domain ID
- * @return the corresponding global longitude size
+ * @return the global number of points in the x-direction
  */
 size_t Xios::getDomainGlobalXSize(const std::string domainId)
 {
     xios::CDomain* domain = getDomain(domainId);
     if (!cxios_is_defined_domain_ni_glo(domain)) {
-        throw std::runtime_error(
-            "Xios: Undefined global longitude size for domain '" + domainId + "'");
+        throw std::runtime_error("Xios: Undefined global x-size for domain '" + domainId + "'");
     }
     int size;
     cxios_get_domain_ni_glo(domain, &size);
@@ -670,17 +666,16 @@ size_t Xios::getDomainGlobalXSize(const std::string domainId)
 }
 
 /*!
- * Get the global latitude size for a given domain
+ * Get the global number of points in the y-direction for a given domain
  *
  * @param the domain ID
- * @return the corresponding global latitude size
+ * @return the global number of points in the y-direction
  */
 size_t Xios::getDomainGlobalYSize(const std::string domainId)
 {
     xios::CDomain* domain = getDomain(domainId);
     if (!cxios_is_defined_domain_nj_glo(domain)) {
-        throw std::runtime_error(
-            "Xios: Undefined global latitude size for domain '" + domainId + "'");
+        throw std::runtime_error("Xios: Undefined global y-size for domain '" + domainId + "'");
     }
     int size;
     cxios_get_domain_nj_glo(domain, &size);
@@ -688,16 +683,16 @@ size_t Xios::getDomainGlobalYSize(const std::string domainId)
 }
 
 /*!
- * Get the local longitude size for a given domain
+ * Get the local number of points in the x-direction for a given domain
  *
  * @param the domain ID
- * @return the corresponding local longitude size
+ * @return the local number of points in the x-direction
  */
 size_t Xios::getDomainLocalXSize(const std::string domainId)
 {
     xios::CDomain* domain = getDomain(domainId);
     if (!cxios_is_defined_domain_ni(domain)) {
-        throw std::runtime_error("Xios: Undefined longitude size for domain '" + domainId + "'");
+        throw std::runtime_error("Xios: Undefined local x-size for domain '" + domainId + "'");
     }
     int size;
     cxios_get_domain_ni(domain, &size);
@@ -705,16 +700,16 @@ size_t Xios::getDomainLocalXSize(const std::string domainId)
 }
 
 /*!
- * Get the local latitude size for a given domain
+ * Get the local number of points in the y-direction for a given domain
  *
  * @param the domain ID
- * @return the corresponding local latitude size
+ * @return the local number of points in the y-direction
  */
 size_t Xios::getDomainLocalYSize(const std::string domainId)
 {
     xios::CDomain* domain = getDomain(domainId);
     if (!cxios_is_defined_domain_nj(domain)) {
-        throw std::runtime_error("Xios: Undefined latitude size for domain '" + domainId + "'");
+        throw std::runtime_error("Xios: Undefined local y-size for domain '" + domainId + "'");
     }
     int size;
     cxios_get_domain_nj(domain, &size);
@@ -722,16 +717,17 @@ size_t Xios::getDomainLocalYSize(const std::string domainId)
 }
 
 /*!
- * Get the local starting longitude for a given domain
+ * Get the local starting x-index for a given domain
  *
  * @param the domain ID
- * @return the local starting longitude of the corresponding domain
+ * @return the local starting x-index
  */
 size_t Xios::getDomainLocalXStart(const std::string domainId)
 {
     xios::CDomain* domain = getDomain(domainId);
     if (!cxios_is_defined_domain_ibegin(domain)) {
-        throw std::runtime_error("Xios: Undefined longitude start for domain '" + domainId + "'");
+        throw std::runtime_error(
+            "Xios: Undefined local starting x-index for domain '" + domainId + "'");
     }
     int start;
     cxios_get_domain_ibegin(domain, &start);
@@ -739,16 +735,17 @@ size_t Xios::getDomainLocalXStart(const std::string domainId)
 }
 
 /*!
- * Get the local starting latitude for a given domain
+ * Get the local starting y-index for a given domain
  *
  * @param the domain ID
- * @return the local starting latitude of the corresponding domain
+ * @return the local starting y-index
  */
 size_t Xios::getDomainLocalYStart(const std::string domainId)
 {
     xios::CDomain* domain = getDomain(domainId);
     if (!cxios_is_defined_domain_jbegin(domain)) {
-        throw std::runtime_error("Xios: Undefined latitude start for domain '" + domainId + "'");
+        throw std::runtime_error(
+            "Xios: Undefined local starting y-index for domain '" + domainId + "'");
     }
     int start;
     cxios_get_domain_jbegin(domain, &start);
@@ -756,16 +753,16 @@ size_t Xios::getDomainLocalYStart(const std::string domainId)
 }
 
 /*!
- * Get the local longitude values for a given domain
+ * Get the local x-values for a given domain
  *
  * @param the domain ID
- * @return the local longitude values of the corresponding domain
+ * @return the local x-values
  */
 std::vector<double> Xios::getDomainLocalXValues(const std::string domainId)
 {
     xios::CDomain* domain = getDomain(domainId);
     if (!cxios_is_defined_domain_lonvalue_1d(domain)) {
-        throw std::runtime_error("Xios: Undefined longitude values for domain '" + domainId + "'");
+        throw std::runtime_error("Xios: Undefined local x-values for domain '" + domainId + "'");
     }
     int size = getDomainLocalXSize(domainId);
     double* values = new double[size];
@@ -776,16 +773,16 @@ std::vector<double> Xios::getDomainLocalXValues(const std::string domainId)
 }
 
 /*!
- * Get the local latitude values for a given domain
+ * Get the local y-values for a given domain
  *
  * @param the domain ID
- * @return the local latitude values of the corresponding domain
+ * @return the local y-values
  */
 std::vector<double> Xios::getDomainLocalYValues(const std::string domainId)
 {
     xios::CDomain* domain = getDomain(domainId);
     if (!cxios_is_defined_domain_latvalue_1d(domain)) {
-        throw std::runtime_error("Xios: Undefined latitude values for domain '" + domainId + "'");
+        throw std::runtime_error("Xios: Undefined local y-values for domain '" + domainId + "'");
     }
     int size = getDomainLocalYSize(domainId);
     double* values = new double[size];

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -467,7 +467,7 @@ void Xios::createDomain(const std::string domainId)
  * @param the domain ID
  * @param the local longitude size
  */
-void Xios::setDomainLocalLongitudeSize(const std::string domainId, const size_t size)
+void Xios::setDomainLocalXSize(const std::string domainId, const size_t size)
 {
     xios::CDomain* domain = getDomain(domainId);
     if (cxios_is_defined_domain_ni(domain)) {
@@ -486,7 +486,7 @@ void Xios::setDomainLocalLongitudeSize(const std::string domainId, const size_t 
  * @param the domain ID
  * @param the local longitude size
  */
-void Xios::setDomainLocalLatitudeSize(const std::string domainId, const size_t size)
+void Xios::setDomainLocalYSize(const std::string domainId, const size_t size)
 {
     xios::CDomain* domain = getDomain(domainId);
     if (cxios_is_defined_domain_nj(domain)) {
@@ -504,7 +504,7 @@ void Xios::setDomainLocalLatitudeSize(const std::string domainId, const size_t s
  * @param the domain ID
  * @return the local start longitude
  */
-void Xios::setDomainLocalLongitudeStart(const std::string domainId, const size_t start)
+void Xios::setDomainLocalXStart(const std::string domainId, const size_t start)
 {
     xios::CDomain* domain = getDomain(domainId);
     if (cxios_is_defined_domain_ibegin(domain)) {
@@ -523,7 +523,7 @@ void Xios::setDomainLocalLongitudeStart(const std::string domainId, const size_t
  * @param the domain ID
  * @return the local start latitude
  */
-void Xios::setDomainLocalLatitudeStart(const std::string domainId, const size_t start)
+void Xios::setDomainLocalYStart(const std::string domainId, const size_t start)
 {
     xios::CDomain* domain = getDomain(domainId);
     if (cxios_is_defined_domain_jbegin(domain)) {
@@ -542,13 +542,13 @@ void Xios::setDomainLocalLatitudeStart(const std::string domainId, const size_t 
  * @param the domain ID
  * @return the local longitude values
  */
-void Xios::setDomainLocalLongitudeValues(const std::string domainId, std::vector<double> values)
+void Xios::setDomainLocalXValues(const std::string domainId, std::vector<double> values)
 {
     xios::CDomain* domain = getDomain(domainId);
     if (cxios_is_defined_domain_lonvalue_1d(domain)) {
         Logged::warning("Xios: Overwriting longitude values for domain '" + domainId + "'");
     }
-    int size = getDomainLocalLongitudeSize(domainId);
+    int size = getDomainLocalXSize(domainId);
     cxios_set_domain_lonvalue_1d(domain, values.data(), &size);
     if (!cxios_is_defined_domain_lonvalue_1d(domain)) {
         throw std::runtime_error(
@@ -562,13 +562,13 @@ void Xios::setDomainLocalLongitudeValues(const std::string domainId, std::vector
  * @param the domain ID
  * @return the local latitude values
  */
-void Xios::setDomainLocalLatitudeValues(const std::string domainId, std::vector<double> values)
+void Xios::setDomainLocalYValues(const std::string domainId, std::vector<double> values)
 {
     xios::CDomain* domain = getDomain(domainId);
     if (cxios_is_defined_domain_latvalue_1d(domain)) {
         Logged::warning("Xios: Overwriting latitude values for domain '" + domainId + "'");
     }
-    int size = getDomainLocalLatitudeSize(domainId);
+    int size = getDomainLocalYSize(domainId);
     cxios_set_domain_latvalue_1d(domain, values.data(), &size);
     if (!cxios_is_defined_domain_latvalue_1d(domain)) {
         throw std::runtime_error(
@@ -600,7 +600,7 @@ void Xios::setDomainType(const std::string domainId, const std::string domainTyp
  * @param the domain ID
  * @param global longitude size to set
  */
-void Xios::setDomainGlobalLongitudeSize(const std::string domainId, const size_t size)
+void Xios::setDomainGlobalXSize(const std::string domainId, const size_t size)
 {
     xios::CDomain* domain = getDomain(domainId);
     if (cxios_is_defined_domain_ni_glo(domain)) {
@@ -619,7 +619,7 @@ void Xios::setDomainGlobalLongitudeSize(const std::string domainId, const size_t
  * @param the domain ID
  * @param global latitude size to set
  */
-void Xios::setDomainGlobalLatitudeSize(const std::string domainId, const size_t size)
+void Xios::setDomainGlobalYSize(const std::string domainId, const size_t size)
 {
     xios::CDomain* domain = getDomain(domainId);
     if (cxios_is_defined_domain_nj_glo(domain)) {
@@ -657,7 +657,7 @@ std::string Xios::getDomainType(const std::string domainId)
  * @param the domain ID
  * @return the corresponding global longitude size
  */
-size_t Xios::getDomainGlobalLongitudeSize(const std::string domainId)
+size_t Xios::getDomainGlobalXSize(const std::string domainId)
 {
     xios::CDomain* domain = getDomain(domainId);
     if (!cxios_is_defined_domain_ni_glo(domain)) {
@@ -675,7 +675,7 @@ size_t Xios::getDomainGlobalLongitudeSize(const std::string domainId)
  * @param the domain ID
  * @return the corresponding global latitude size
  */
-size_t Xios::getDomainGlobalLatitudeSize(const std::string domainId)
+size_t Xios::getDomainGlobalYSize(const std::string domainId)
 {
     xios::CDomain* domain = getDomain(domainId);
     if (!cxios_is_defined_domain_nj_glo(domain)) {
@@ -693,7 +693,7 @@ size_t Xios::getDomainGlobalLatitudeSize(const std::string domainId)
  * @param the domain ID
  * @return the corresponding local longitude size
  */
-size_t Xios::getDomainLocalLongitudeSize(const std::string domainId)
+size_t Xios::getDomainLocalXSize(const std::string domainId)
 {
     xios::CDomain* domain = getDomain(domainId);
     if (!cxios_is_defined_domain_ni(domain)) {
@@ -710,7 +710,7 @@ size_t Xios::getDomainLocalLongitudeSize(const std::string domainId)
  * @param the domain ID
  * @return the corresponding local latitude size
  */
-size_t Xios::getDomainLocalLatitudeSize(const std::string domainId)
+size_t Xios::getDomainLocalYSize(const std::string domainId)
 {
     xios::CDomain* domain = getDomain(domainId);
     if (!cxios_is_defined_domain_nj(domain)) {
@@ -727,7 +727,7 @@ size_t Xios::getDomainLocalLatitudeSize(const std::string domainId)
  * @param the domain ID
  * @return the local starting longitude of the corresponding domain
  */
-size_t Xios::getDomainLocalLongitudeStart(const std::string domainId)
+size_t Xios::getDomainLocalXStart(const std::string domainId)
 {
     xios::CDomain* domain = getDomain(domainId);
     if (!cxios_is_defined_domain_ibegin(domain)) {
@@ -744,7 +744,7 @@ size_t Xios::getDomainLocalLongitudeStart(const std::string domainId)
  * @param the domain ID
  * @return the local starting latitude of the corresponding domain
  */
-size_t Xios::getDomainLocalLatitudeStart(const std::string domainId)
+size_t Xios::getDomainLocalYStart(const std::string domainId)
 {
     xios::CDomain* domain = getDomain(domainId);
     if (!cxios_is_defined_domain_jbegin(domain)) {
@@ -761,13 +761,13 @@ size_t Xios::getDomainLocalLatitudeStart(const std::string domainId)
  * @param the domain ID
  * @return the local longitude values of the corresponding domain
  */
-std::vector<double> Xios::getDomainLocalLongitudeValues(const std::string domainId)
+std::vector<double> Xios::getDomainLocalXValues(const std::string domainId)
 {
     xios::CDomain* domain = getDomain(domainId);
     if (!cxios_is_defined_domain_lonvalue_1d(domain)) {
         throw std::runtime_error("Xios: Undefined longitude values for domain '" + domainId + "'");
     }
-    int size = getDomainLocalLongitudeSize(domainId);
+    int size = getDomainLocalXSize(domainId);
     double* values = new double[size];
     cxios_get_domain_lonvalue_1d(domain, values, &size);
     std::vector<double> vec(values, values + size);
@@ -781,13 +781,13 @@ std::vector<double> Xios::getDomainLocalLongitudeValues(const std::string domain
  * @param the domain ID
  * @return the local latitude values of the corresponding domain
  */
-std::vector<double> Xios::getDomainLocalLatitudeValues(const std::string domainId)
+std::vector<double> Xios::getDomainLocalYValues(const std::string domainId)
 {
     xios::CDomain* domain = getDomain(domainId);
     if (!cxios_is_defined_domain_latvalue_1d(domain)) {
         throw std::runtime_error("Xios: Undefined latitude values for domain '" + domainId + "'");
     }
-    int size = getDomainLocalLatitudeSize(domainId);
+    int size = getDomainLocalYSize(domainId);
     double* values = new double[size];
     cxios_get_domain_latvalue_1d(domain, values, &size);
     std::vector<double> vec(values, values + size);

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -467,7 +467,7 @@ void Xios::createDomain(const std::string domainId)
  * @param the domain ID
  * @param the local longitude size
  */
-void Xios::setDomainLongitudeSize(const std::string domainId, const size_t size)
+void Xios::setDomainLocalLongitudeSize(const std::string domainId, const size_t size)
 {
     xios::CDomain* domain = getDomain(domainId);
     if (cxios_is_defined_domain_ni(domain)) {
@@ -486,7 +486,7 @@ void Xios::setDomainLongitudeSize(const std::string domainId, const size_t size)
  * @param the domain ID
  * @param the local longitude size
  */
-void Xios::setDomainLatitudeSize(const std::string domainId, const size_t size)
+void Xios::setDomainLocalLatitudeSize(const std::string domainId, const size_t size)
 {
     xios::CDomain* domain = getDomain(domainId);
     if (cxios_is_defined_domain_nj(domain)) {
@@ -504,7 +504,7 @@ void Xios::setDomainLatitudeSize(const std::string domainId, const size_t size)
  * @param the domain ID
  * @return the local start longitude
  */
-void Xios::setDomainLongitudeStart(const std::string domainId, const size_t start)
+void Xios::setDomainLocalLongitudeStart(const std::string domainId, const size_t start)
 {
     xios::CDomain* domain = getDomain(domainId);
     if (cxios_is_defined_domain_ibegin(domain)) {
@@ -523,7 +523,7 @@ void Xios::setDomainLongitudeStart(const std::string domainId, const size_t star
  * @param the domain ID
  * @return the local start latitude
  */
-void Xios::setDomainLatitudeStart(const std::string domainId, const size_t start)
+void Xios::setDomainLocalLatitudeStart(const std::string domainId, const size_t start)
 {
     xios::CDomain* domain = getDomain(domainId);
     if (cxios_is_defined_domain_jbegin(domain)) {
@@ -542,13 +542,13 @@ void Xios::setDomainLatitudeStart(const std::string domainId, const size_t start
  * @param the domain ID
  * @return the local longitude values
  */
-void Xios::setDomainLongitudeValues(const std::string domainId, std::vector<double> values)
+void Xios::setDomainLocalLongitudeValues(const std::string domainId, std::vector<double> values)
 {
     xios::CDomain* domain = getDomain(domainId);
     if (cxios_is_defined_domain_lonvalue_1d(domain)) {
         Logged::warning("Xios: Overwriting longitude values for domain '" + domainId + "'");
     }
-    int size = getDomainLongitudeSize(domainId);
+    int size = getDomainLocalLongitudeSize(domainId);
     cxios_set_domain_lonvalue_1d(domain, values.data(), &size);
     if (!cxios_is_defined_domain_lonvalue_1d(domain)) {
         throw std::runtime_error(
@@ -562,13 +562,13 @@ void Xios::setDomainLongitudeValues(const std::string domainId, std::vector<doub
  * @param the domain ID
  * @return the local latitude values
  */
-void Xios::setDomainLatitudeValues(const std::string domainId, std::vector<double> values)
+void Xios::setDomainLocalLatitudeValues(const std::string domainId, std::vector<double> values)
 {
     xios::CDomain* domain = getDomain(domainId);
     if (cxios_is_defined_domain_latvalue_1d(domain)) {
         Logged::warning("Xios: Overwriting latitude values for domain '" + domainId + "'");
     }
-    int size = getDomainLatitudeSize(domainId);
+    int size = getDomainLocalLatitudeSize(domainId);
     cxios_set_domain_latvalue_1d(domain, values.data(), &size);
     if (!cxios_is_defined_domain_latvalue_1d(domain)) {
         throw std::runtime_error(
@@ -693,7 +693,7 @@ size_t Xios::getDomainGlobalLatitudeSize(const std::string domainId)
  * @param the domain ID
  * @return the corresponding local longitude size
  */
-size_t Xios::getDomainLongitudeSize(const std::string domainId)
+size_t Xios::getDomainLocalLongitudeSize(const std::string domainId)
 {
     xios::CDomain* domain = getDomain(domainId);
     if (!cxios_is_defined_domain_ni(domain)) {
@@ -710,7 +710,7 @@ size_t Xios::getDomainLongitudeSize(const std::string domainId)
  * @param the domain ID
  * @return the corresponding local latitude size
  */
-size_t Xios::getDomainLatitudeSize(const std::string domainId)
+size_t Xios::getDomainLocalLatitudeSize(const std::string domainId)
 {
     xios::CDomain* domain = getDomain(domainId);
     if (!cxios_is_defined_domain_nj(domain)) {
@@ -727,7 +727,7 @@ size_t Xios::getDomainLatitudeSize(const std::string domainId)
  * @param the domain ID
  * @return the local starting longitude of the corresponding domain
  */
-size_t Xios::getDomainLongitudeStart(const std::string domainId)
+size_t Xios::getDomainLocalLongitudeStart(const std::string domainId)
 {
     xios::CDomain* domain = getDomain(domainId);
     if (!cxios_is_defined_domain_ibegin(domain)) {
@@ -744,7 +744,7 @@ size_t Xios::getDomainLongitudeStart(const std::string domainId)
  * @param the domain ID
  * @return the local starting latitude of the corresponding domain
  */
-size_t Xios::getDomainLatitudeStart(const std::string domainId)
+size_t Xios::getDomainLocalLatitudeStart(const std::string domainId)
 {
     xios::CDomain* domain = getDomain(domainId);
     if (!cxios_is_defined_domain_jbegin(domain)) {
@@ -761,13 +761,13 @@ size_t Xios::getDomainLatitudeStart(const std::string domainId)
  * @param the domain ID
  * @return the local longitude values of the corresponding domain
  */
-std::vector<double> Xios::getDomainLongitudeValues(const std::string domainId)
+std::vector<double> Xios::getDomainLocalLongitudeValues(const std::string domainId)
 {
     xios::CDomain* domain = getDomain(domainId);
     if (!cxios_is_defined_domain_lonvalue_1d(domain)) {
         throw std::runtime_error("Xios: Undefined longitude values for domain '" + domainId + "'");
     }
-    int size = getDomainLongitudeSize(domainId);
+    int size = getDomainLocalLongitudeSize(domainId);
     double* values = new double[size];
     cxios_get_domain_lonvalue_1d(domain, values, &size);
     std::vector<double> vec(values, values + size);
@@ -781,13 +781,13 @@ std::vector<double> Xios::getDomainLongitudeValues(const std::string domainId)
  * @param the domain ID
  * @return the local latitude values of the corresponding domain
  */
-std::vector<double> Xios::getDomainLatitudeValues(const std::string domainId)
+std::vector<double> Xios::getDomainLocalLatitudeValues(const std::string domainId)
 {
     xios::CDomain* domain = getDomain(domainId);
     if (!cxios_is_defined_domain_latvalue_1d(domain)) {
         throw std::runtime_error("Xios: Undefined latitude values for domain '" + domainId + "'");
     }
-    int size = getDomainLatitudeSize(domainId);
+    int size = getDomainLocalLatitudeSize(domainId);
     double* values = new double[size];
     cxios_get_domain_latvalue_1d(domain, values, &size);
     std::vector<double> vec(values, values + size);

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -797,7 +797,7 @@ xios::CGridGroup* Xios::getGridGroup()
     xios::CGridGroup* group = NULL;
     cxios_gridgroup_handle_create(&group, groupId.c_str(), groupId.length());
     if (!group) {
-        throw std::runtime_error("Xios: Null pointer for grid_definition group");
+        throw std::runtime_error("Xios: Null pointer for group 'grid_definition'");
     }
     return group;
 }
@@ -813,7 +813,7 @@ xios::CGrid* Xios::getGrid(const std::string gridId)
     xios::CGrid* grid = NULL;
     cxios_grid_handle_create(&grid, gridId.c_str(), gridId.length());
     if (!grid) {
-        throw std::runtime_error("Xios: Null pointer for grid with ID '" + gridId + "'");
+        throw std::runtime_error("Xios: Null pointer for grid '" + gridId + "'");
     }
     return grid;
 }
@@ -828,7 +828,7 @@ void Xios::createGrid(const std::string gridId)
     xios::CGrid* grid = NULL;
     cxios_xml_tree_add_grid(getGridGroup(), &grid, gridId.c_str(), gridId.length());
     if (!grid) {
-        throw std::runtime_error("Xios: Null pointer for grid with ID '" + gridId + "'");
+        throw std::runtime_error("Xios: Null pointer for grid '" + gridId + "'");
     }
 }
 
@@ -840,8 +840,12 @@ void Xios::createGrid(const std::string gridId)
  */
 std::string Xios::getGridName(const std::string gridId)
 {
+    xios::CGrid* grid = getGrid(gridId);
+    if (!cxios_is_defined_grid_name(grid)) {
+        throw std::runtime_error("Xios: Undefined name for grid '" + gridId + "'");
+    }
     char cStr[cStrLen];
-    cxios_get_grid_name(getGrid(gridId), cStr, cStrLen);
+    cxios_get_grid_name(grid, cStr, cStrLen);
     std::string gridName(cStr, cStrLen);
     boost::algorithm::trim_right(gridName);
     return gridName;
@@ -855,18 +859,14 @@ std::string Xios::getGridName(const std::string gridId)
  */
 void Xios::setGridName(const std::string gridId, const std::string gridName)
 {
-    cxios_set_grid_name(getGrid(gridId), gridName.c_str(), gridName.length());
-}
-
-/*!
- * Verify whether a name has been defined for a given grid ID
- *
- * @param the grid ID
- * @return `true` if the name has been set, otherwise `false`
- */
-bool Xios::isDefinedGridName(const std::string gridId)
-{
-    return cxios_is_defined_grid_name(getGrid(gridId));
+    xios::CGrid* grid = getGrid(gridId);
+    if (cxios_is_defined_grid_name(grid)) {
+        Logged::warning("Xios: Overwriting name for grid '" + gridId + "'");
+    }
+    cxios_set_grid_name(grid, gridName.c_str(), gridName.length());
+    if (!cxios_is_defined_grid_name(grid)) {
+        throw std::runtime_error("Xios: Failed to set name for grid '" + gridId + "'");
+    }
 }
 
 /*!

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -926,7 +926,7 @@ xios::CFieldGroup* Xios::getFieldGroup()
     xios::CFieldGroup* group = NULL;
     cxios_fieldgroup_handle_create(&group, groupId.c_str(), groupId.length());
     if (!group) {
-        throw std::runtime_error("Xios: Null pointer for field_definition group");
+        throw std::runtime_error("Xios: Null pointer for group 'field_definition'");
     }
     return group;
 }
@@ -942,7 +942,7 @@ xios::CField* Xios::getField(const std::string fieldId)
     xios::CField* field = NULL;
     cxios_field_handle_create(&field, fieldId.c_str(), fieldId.length());
     if (!field) {
-        throw std::runtime_error("Xios: Null pointer for field with ID '" + fieldId + "'");
+        throw std::runtime_error("Xios: Null pointer for field '" + fieldId + "'");
     }
     return field;
 }
@@ -957,7 +957,7 @@ void Xios::createField(const std::string fieldId)
     xios::CField* field = NULL;
     cxios_xml_tree_add_field(getFieldGroup(), &field, fieldId.c_str(), fieldId.length());
     if (!field) {
-        throw std::runtime_error("Xios: Null pointer for field with ID '" + fieldId + "'");
+        throw std::runtime_error("Xios: Null pointer for field '" + fieldId + "'");
     }
 }
 
@@ -969,7 +969,14 @@ void Xios::createField(const std::string fieldId)
  */
 void Xios::setFieldName(const std::string fieldId, const std::string fieldName)
 {
-    cxios_set_field_name(getField(fieldId), fieldName.c_str(), fieldName.length());
+    xios::CField* field = getField(fieldId);
+    if (cxios_is_defined_field_name(field)) {
+        Logged::warning("Xios: Overwriting name for field '" + fieldId + "'");
+    }
+    cxios_set_field_name(field, fieldName.c_str(), fieldName.length());
+    if (!cxios_is_defined_field_name(field)) {
+        throw std::runtime_error("Xios: Failed to set name for field '" + fieldId + "'");
+    }
 }
 
 /*!
@@ -980,7 +987,14 @@ void Xios::setFieldName(const std::string fieldId, const std::string fieldName)
  */
 void Xios::setFieldOperation(const std::string fieldId, const std::string operation)
 {
-    cxios_set_field_operation(getField(fieldId), operation.c_str(), operation.length());
+    xios::CField* field = getField(fieldId);
+    if (cxios_is_defined_field_operation(field)) {
+        Logged::warning("Xios: Overwriting operation for field '" + fieldId + "'");
+    }
+    cxios_set_field_operation(field, operation.c_str(), operation.length());
+    if (!cxios_is_defined_field_operation(field)) {
+        throw std::runtime_error("Xios: Failed to set operation for field '" + fieldId + "'");
+    }
 }
 
 /*!
@@ -991,7 +1005,14 @@ void Xios::setFieldOperation(const std::string fieldId, const std::string operat
  */
 void Xios::setFieldGridRef(const std::string fieldId, const std::string gridRef)
 {
-    cxios_set_field_grid_ref(getField(fieldId), gridRef.c_str(), gridRef.length());
+    xios::CField* field = getField(fieldId);
+    if (cxios_is_defined_field_grid_ref(field)) {
+        Logged::warning("Xios: Overwriting grid reference for field '" + fieldId + "'");
+    }
+    cxios_set_field_grid_ref(field, gridRef.c_str(), gridRef.length());
+    if (!cxios_is_defined_field_grid_ref(field)) {
+        throw std::runtime_error("Xios: Failed to set grid reference for field '" + fieldId + "'");
+    }
 }
 
 /*!
@@ -1002,8 +1023,12 @@ void Xios::setFieldGridRef(const std::string fieldId, const std::string gridRef)
  */
 std::string Xios::getFieldName(const std::string fieldId)
 {
+    xios::CField* field = getField(fieldId);
+    if (!cxios_is_defined_field_name(field)) {
+        throw std::runtime_error("Xios: Undefined name for field '" + fieldId + "'");
+    }
     char cStr[cStrLen];
-    cxios_get_field_name(getField(fieldId), cStr, cStrLen);
+    cxios_get_field_name(field, cStr, cStrLen);
     std::string fieldName(cStr, cStrLen);
     boost::algorithm::trim_right(fieldName);
     return fieldName;
@@ -1017,8 +1042,12 @@ std::string Xios::getFieldName(const std::string fieldId)
  */
 std::string Xios::getFieldOperation(const std::string fieldId)
 {
+    xios::CField* field = getField(fieldId);
+    if (!cxios_is_defined_field_operation(field)) {
+        throw std::runtime_error("Xios: Undefined operation for field '" + fieldId + "'");
+    }
     char cStr[cStrLen];
-    cxios_get_field_operation(getField(fieldId), cStr, cStrLen);
+    cxios_get_field_operation(field, cStr, cStrLen);
     std::string operation(cStr, cStrLen);
     boost::algorithm::trim_right(operation);
     return operation;
@@ -1032,44 +1061,15 @@ std::string Xios::getFieldOperation(const std::string fieldId)
  */
 std::string Xios::getFieldGridRef(const std::string fieldId)
 {
+    xios::CField* field = getField(fieldId);
+    if (!cxios_is_defined_field_grid_ref(field)) {
+        throw std::runtime_error("Xios: Undefined grid reference for field '" + fieldId + "'");
+    }
     char cStr[cStrLen];
-    cxios_get_field_grid_ref(getField(fieldId), cStr, cStrLen);
+    cxios_get_field_grid_ref(field, cStr, cStrLen);
     std::string gridRef(cStr, cStrLen);
     boost::algorithm::trim_right(gridRef);
     return gridRef;
-}
-
-/*!
- * Verify whether a name has been defined for a given field ID
- *
- * @param the field ID
- * @return `true` if the name has been set, otherwise `false`
- */
-bool Xios::isDefinedFieldName(const std::string fieldId)
-{
-    return cxios_is_defined_field_name(getField(fieldId));
-}
-
-/*!
- * Verify whether an operation has been defined for a given field ID
- *
- * @param the field ID
- * @return `true` if the operation has been set, otherwise `false`
- */
-bool Xios::isDefinedFieldOperation(const std::string fieldId)
-{
-    return cxios_is_defined_field_operation(getField(fieldId));
-}
-
-/*!
- * Verify whether a grid reference has been defined for a given field ID
- *
- * @param the field ID
- * @return `true` if the grid reference has been set, otherwise `false`
- */
-bool Xios::isDefinedFieldGridRef(const std::string fieldId)
-{
-    return cxios_is_defined_field_grid_ref(getField(fieldId));
 }
 
 /*!

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file    Xios.cpp
  * @author  Joe Wallwork <jw2423@cam.ac.uk
- * @date    24 July 2024
+ * @date    26 July 2024
  * @brief   XIOS interface implementation
  * @details
  *
@@ -426,7 +426,7 @@ xios::CDomainGroup* Xios::getDomainGroup()
     xios::CDomainGroup* group = NULL;
     cxios_domaingroup_handle_create(&group, groupId.c_str(), groupId.length());
     if (!group) {
-        throw std::runtime_error("Xios: Null pointer for domain_definition group");
+        throw std::runtime_error("Xios: Null pointer for group 'domain_definition'");
     }
     return group;
 }
@@ -442,7 +442,7 @@ xios::CDomain* Xios::getDomain(const std::string domainId)
     xios::CDomain* domain = NULL;
     cxios_domain_handle_create(&domain, domainId.c_str(), domainId.length());
     if (!domain) {
-        throw std::runtime_error("Xios: Null pointer for domain with ID '" + domainId + "'");
+        throw std::runtime_error("Xios: Null pointer for domain '" + domainId + "'");
     }
     return domain;
 }
@@ -457,7 +457,7 @@ void Xios::createDomain(const std::string domainId)
     xios::CDomain* domain = NULL;
     cxios_xml_tree_add_domain(getDomainGroup(), &domain, domainId.c_str(), domainId.length());
     if (!domain) {
-        throw std::runtime_error("Xios: Null pointer for domain with ID '" + domainId + "'");
+        throw std::runtime_error("Xios: Null pointer for domain '" + domainId + "'");
     }
 }
 
@@ -469,7 +469,15 @@ void Xios::createDomain(const std::string domainId)
  */
 void Xios::setDomainLongitudeSize(const std::string domainId, const size_t size)
 {
-    cxios_set_domain_ni(getDomain(domainId), (int)size);
+    xios::CDomain* domain = getDomain(domainId);
+    if (cxios_is_defined_domain_ni(domain)) {
+        Logged::warning("Xios: Overwriting longitude size for domain '" + domainId + "'");
+    }
+    cxios_set_domain_ni(domain, (int)size);
+    if (!cxios_is_defined_domain_ni(domain)) {
+        throw std::runtime_error(
+            "Xios: Failed to set longitude size for domain '" + domainId + "'");
+    }
 }
 
 /*!
@@ -480,7 +488,14 @@ void Xios::setDomainLongitudeSize(const std::string domainId, const size_t size)
  */
 void Xios::setDomainLatitudeSize(const std::string domainId, const size_t size)
 {
-    cxios_set_domain_nj(getDomain(domainId), (int)size);
+    xios::CDomain* domain = getDomain(domainId);
+    if (cxios_is_defined_domain_nj(domain)) {
+        Logged::warning("Xios: Overwriting global latitude size for domain '" + domainId + "'");
+    }
+    cxios_set_domain_nj(domain, (int)size);
+    if (!cxios_is_defined_domain_nj(domain)) {
+        throw std::runtime_error("Xios: Failed to set latitude size for domain '" + domainId + "'");
+    }
 }
 
 /*!
@@ -491,7 +506,15 @@ void Xios::setDomainLatitudeSize(const std::string domainId, const size_t size)
  */
 void Xios::setDomainLongitudeStart(const std::string domainId, const size_t start)
 {
-    cxios_set_domain_ibegin(getDomain(domainId), (int)start);
+    xios::CDomain* domain = getDomain(domainId);
+    if (cxios_is_defined_domain_ibegin(domain)) {
+        Logged::warning("Xios: Overwriting longitude start for domain '" + domainId + "'");
+    }
+    cxios_set_domain_ibegin(domain, (int)start);
+    if (!cxios_is_defined_domain_ibegin(domain)) {
+        throw std::runtime_error(
+            "Xios: Failed to set longitude start for domain '" + domainId + "'");
+    }
 }
 
 /*!
@@ -502,7 +525,15 @@ void Xios::setDomainLongitudeStart(const std::string domainId, const size_t star
  */
 void Xios::setDomainLatitudeStart(const std::string domainId, const size_t start)
 {
-    cxios_set_domain_jbegin(getDomain(domainId), (int)start);
+    xios::CDomain* domain = getDomain(domainId);
+    if (cxios_is_defined_domain_jbegin(domain)) {
+        Logged::warning("Xios: Overwriting latitude start for domain '" + domainId + "'");
+    }
+    cxios_set_domain_jbegin(domain, (int)start);
+    if (!cxios_is_defined_domain_jbegin(domain)) {
+        throw std::runtime_error(
+            "Xios: Failed to set latitude start for domain '" + domainId + "'");
+    }
 }
 
 /*!
@@ -513,8 +544,16 @@ void Xios::setDomainLatitudeStart(const std::string domainId, const size_t start
  */
 void Xios::setDomainLongitudeValues(const std::string domainId, std::vector<double> values)
 {
+    xios::CDomain* domain = getDomain(domainId);
+    if (cxios_is_defined_domain_lonvalue_1d(domain)) {
+        Logged::warning("Xios: Overwriting longitude values for domain '" + domainId + "'");
+    }
     int size = getDomainLongitudeSize(domainId);
-    cxios_set_domain_lonvalue_1d(getDomain(domainId), values.data(), &size);
+    cxios_set_domain_lonvalue_1d(domain, values.data(), &size);
+    if (!cxios_is_defined_domain_lonvalue_1d(domain)) {
+        throw std::runtime_error(
+            "Xios: Failed to set longitude values for domain '" + domainId + "'");
+    }
 }
 
 /*!
@@ -525,8 +564,16 @@ void Xios::setDomainLongitudeValues(const std::string domainId, std::vector<doub
  */
 void Xios::setDomainLatitudeValues(const std::string domainId, std::vector<double> values)
 {
+    xios::CDomain* domain = getDomain(domainId);
+    if (cxios_is_defined_domain_latvalue_1d(domain)) {
+        Logged::warning("Xios: Overwriting latitude values for domain '" + domainId + "'");
+    }
     int size = getDomainLatitudeSize(domainId);
-    cxios_set_domain_latvalue_1d(getDomain(domainId), values.data(), &size);
+    cxios_set_domain_latvalue_1d(domain, values.data(), &size);
+    if (!cxios_is_defined_domain_latvalue_1d(domain)) {
+        throw std::runtime_error(
+            "Xios: Failed to set latitude values for domain '" + domainId + "'");
+    }
 }
 
 /*!
@@ -537,7 +584,14 @@ void Xios::setDomainLatitudeValues(const std::string domainId, std::vector<doubl
  */
 void Xios::setDomainType(const std::string domainId, const std::string domainType)
 {
-    cxios_set_domain_type(getDomain(domainId), domainType.c_str(), domainType.length());
+    xios::CDomain* domain = getDomain(domainId);
+    if (cxios_is_defined_domain_type(domain)) {
+        Logged::warning("Xios: Overwriting type for domain '" + domainId + "'");
+    }
+    cxios_set_domain_type(domain, domainType.c_str(), domainType.length());
+    if (!cxios_is_defined_domain_type(domain)) {
+        throw std::runtime_error("Xios: Failed to set type for domain '" + domainId + "'");
+    }
 }
 
 /*!
@@ -548,7 +602,15 @@ void Xios::setDomainType(const std::string domainId, const std::string domainTyp
  */
 void Xios::setDomainGlobalLongitudeSize(const std::string domainId, const size_t size)
 {
-    cxios_set_domain_ni_glo(getDomain(domainId), (int)size);
+    xios::CDomain* domain = getDomain(domainId);
+    if (cxios_is_defined_domain_ni_glo(domain)) {
+        Logged::warning("Xios: Overwriting global longitude size for domain '" + domainId + "'");
+    }
+    cxios_set_domain_ni_glo(domain, (int)size);
+    if (!cxios_is_defined_domain_ni_glo(domain)) {
+        throw std::runtime_error(
+            "Xios: Failed to set global longitude size for domain '" + domainId + "'");
+    }
 }
 
 /*!
@@ -559,7 +621,15 @@ void Xios::setDomainGlobalLongitudeSize(const std::string domainId, const size_t
  */
 void Xios::setDomainGlobalLatitudeSize(const std::string domainId, const size_t size)
 {
-    cxios_set_domain_nj_glo(getDomain(domainId), (int)size);
+    xios::CDomain* domain = getDomain(domainId);
+    if (cxios_is_defined_domain_nj_glo(domain)) {
+        Logged::warning("Xios: Overwriting global latitude size for domain '" + domainId + "'");
+    }
+    cxios_set_domain_nj_glo(domain, (int)size);
+    if (!cxios_is_defined_domain_nj_glo(domain)) {
+        throw std::runtime_error(
+            "Xios: Failed to set global latitude size for domain '" + domainId + "'");
+    }
 }
 
 /*!
@@ -570,8 +640,12 @@ void Xios::setDomainGlobalLatitudeSize(const std::string domainId, const size_t 
  */
 std::string Xios::getDomainType(const std::string domainId)
 {
+    xios::CDomain* domain = getDomain(domainId);
+    if (!cxios_is_defined_domain_type(domain)) {
+        throw std::runtime_error("Xios: Undefined type for domain '" + domainId + "'");
+    }
     char cStr[cStrLen];
-    cxios_get_domain_type(getDomain(domainId), cStr, cStrLen);
+    cxios_get_domain_type(domain, cStr, cStrLen);
     std::string domainType(cStr, cStrLen);
     boost::algorithm::trim_right(domainType);
     return domainType;
@@ -585,8 +659,13 @@ std::string Xios::getDomainType(const std::string domainId)
  */
 size_t Xios::getDomainGlobalLongitudeSize(const std::string domainId)
 {
+    xios::CDomain* domain = getDomain(domainId);
+    if (!cxios_is_defined_domain_ni_glo(domain)) {
+        throw std::runtime_error(
+            "Xios: Undefined global longitude size for domain '" + domainId + "'");
+    }
     int size;
-    cxios_get_domain_ni_glo(getDomain(domainId), &size);
+    cxios_get_domain_ni_glo(domain, &size);
     return (size_t)size;
 }
 
@@ -598,8 +677,13 @@ size_t Xios::getDomainGlobalLongitudeSize(const std::string domainId)
  */
 size_t Xios::getDomainGlobalLatitudeSize(const std::string domainId)
 {
+    xios::CDomain* domain = getDomain(domainId);
+    if (!cxios_is_defined_domain_nj_glo(domain)) {
+        throw std::runtime_error(
+            "Xios: Undefined global latitude size for domain '" + domainId + "'");
+    }
     int size;
-    cxios_get_domain_nj_glo(getDomain(domainId), &size);
+    cxios_get_domain_nj_glo(domain, &size);
     return (size_t)size;
 }
 
@@ -611,8 +695,12 @@ size_t Xios::getDomainGlobalLatitudeSize(const std::string domainId)
  */
 size_t Xios::getDomainLongitudeSize(const std::string domainId)
 {
+    xios::CDomain* domain = getDomain(domainId);
+    if (!cxios_is_defined_domain_ni(domain)) {
+        throw std::runtime_error("Xios: Undefined longitude size for domain '" + domainId + "'");
+    }
     int size;
-    cxios_get_domain_ni(getDomain(domainId), &size);
+    cxios_get_domain_ni(domain, &size);
     return (size_t)size;
 }
 
@@ -624,8 +712,12 @@ size_t Xios::getDomainLongitudeSize(const std::string domainId)
  */
 size_t Xios::getDomainLatitudeSize(const std::string domainId)
 {
+    xios::CDomain* domain = getDomain(domainId);
+    if (!cxios_is_defined_domain_nj(domain)) {
+        throw std::runtime_error("Xios: Undefined latitude size for domain '" + domainId + "'");
+    }
     int size;
-    cxios_get_domain_nj(getDomain(domainId), &size);
+    cxios_get_domain_nj(domain, &size);
     return (size_t)size;
 }
 
@@ -637,8 +729,12 @@ size_t Xios::getDomainLatitudeSize(const std::string domainId)
  */
 size_t Xios::getDomainLongitudeStart(const std::string domainId)
 {
+    xios::CDomain* domain = getDomain(domainId);
+    if (!cxios_is_defined_domain_ibegin(domain)) {
+        throw std::runtime_error("Xios: Undefined longitude start for domain '" + domainId + "'");
+    }
     int start;
-    cxios_get_domain_ibegin(getDomain(domainId), &start);
+    cxios_get_domain_ibegin(domain, &start);
     return (size_t)start;
 }
 
@@ -650,8 +746,12 @@ size_t Xios::getDomainLongitudeStart(const std::string domainId)
  */
 size_t Xios::getDomainLatitudeStart(const std::string domainId)
 {
+    xios::CDomain* domain = getDomain(domainId);
+    if (!cxios_is_defined_domain_jbegin(domain)) {
+        throw std::runtime_error("Xios: Undefined latitude start for domain '" + domainId + "'");
+    }
     int start;
-    cxios_get_domain_jbegin(getDomain(domainId), &start);
+    cxios_get_domain_jbegin(domain, &start);
     return (size_t)start;
 }
 
@@ -663,9 +763,13 @@ size_t Xios::getDomainLatitudeStart(const std::string domainId)
  */
 std::vector<double> Xios::getDomainLongitudeValues(const std::string domainId)
 {
+    xios::CDomain* domain = getDomain(domainId);
+    if (!cxios_is_defined_domain_lonvalue_1d(domain)) {
+        throw std::runtime_error("Xios: Undefined longitude values for domain '" + domainId + "'");
+    }
     int size = getDomainLongitudeSize(domainId);
     double* values = new double[size];
-    cxios_get_domain_lonvalue_1d(getDomain(domainId), values, &size);
+    cxios_get_domain_lonvalue_1d(domain, values, &size);
     std::vector<double> vec(values, values + size);
     delete[] values;
     return vec;
@@ -679,111 +783,16 @@ std::vector<double> Xios::getDomainLongitudeValues(const std::string domainId)
  */
 std::vector<double> Xios::getDomainLatitudeValues(const std::string domainId)
 {
+    xios::CDomain* domain = getDomain(domainId);
+    if (!cxios_is_defined_domain_latvalue_1d(domain)) {
+        throw std::runtime_error("Xios: Undefined latitude values for domain '" + domainId + "'");
+    }
     int size = getDomainLatitudeSize(domainId);
     double* values = new double[size];
-    cxios_get_domain_latvalue_1d(getDomain(domainId), values, &size);
+    cxios_get_domain_latvalue_1d(domain, values, &size);
     std::vector<double> vec(values, values + size);
     delete[] values;
     return vec;
-}
-
-/*!
- * Verify whether a type has been defined for a given domain ID
- *
- * @param the domain ID
- * @return `true` if the type has been set, otherwise `false`
- */
-bool Xios::isDefinedDomainType(const std::string domainId)
-{
-    return cxios_is_defined_domain_type(getDomain(domainId));
-}
-
-/*!
- * Verify whether a global longitude size has been defined for a given domain ID
- *
- * @param the domain ID
- * @return `true` if the global longitude size has been set, otherwise `false`
- */
-bool Xios::isDefinedDomainGlobalLongitudeSize(const std::string domainId)
-{
-    return cxios_is_defined_domain_ni_glo(getDomain(domainId));
-}
-
-/*!
- * Verify whether a global latitude size has been defined for a given domain ID
- *
- * @param the domain ID
- * @return `true` if the global latitude size has been set, otherwise `false`
- */
-bool Xios::isDefinedDomainGlobalLatitudeSize(const std::string domainId)
-{
-    return cxios_is_defined_domain_nj_glo(getDomain(domainId));
-}
-
-/*!
- * Verify whether a local longitude size has been defined for a given domain ID
- *
- * @param the domain ID
- * @return `true` if the local longitude size has been set, otherwise `false`
- */
-bool Xios::isDefinedDomainLongitudeSize(const std::string domainId)
-{
-    return cxios_is_defined_domain_ni(getDomain(domainId));
-}
-
-/*!
- * Verify whether a local latitude size has been defined for a given domain ID
- *
- * @param the domain ID
- * @return `true` if the local latitude size has been set, otherwise `false`
- */
-bool Xios::isDefinedDomainLatitudeSize(const std::string domainId)
-{
-    return cxios_is_defined_domain_nj(getDomain(domainId));
-}
-
-/*!
- * Verify whether a local starting longitude has been defined for a given domain ID
- *
- * @param the domain ID
- * @return `true` if the local starting longitude has been set, otherwise `false`
- */
-bool Xios::isDefinedDomainLongitudeStart(const std::string domainId)
-{
-    return cxios_is_defined_domain_ibegin(getDomain(domainId));
-}
-
-/*!
- * Verify whether a local starting latitude has been defined for a given domain ID
- *
- * @param the domain ID
- * @return `true` if the local starting latitude has been set, otherwise `false`
- */
-bool Xios::isDefinedDomainLatitudeStart(const std::string domainId)
-{
-    return cxios_is_defined_domain_jbegin(getDomain(domainId));
-}
-
-/*!
- * Verify whether a local longitude values have been defined for a given domain ID
- *
- * @param the domain ID
- * @return `true` if the local longitude values have been set, otherwise `false`
- */
-bool Xios::areDefinedDomainLongitudeValues(const std::string domainId)
-{
-    return cxios_is_defined_domain_lonvalue_1d(getDomain(domainId));
-}
-
-/*!
- * Verify whether a local latitude values have been defined for a given domain ID
- *
- * @param the domain ID
- * @return `true` if the local latitude values have been set, otherwise `false`
- */
-bool Xios::areDefinedDomainLatitudeValues(const std::string domainId)
-{
-    return cxios_is_defined_domain_latvalue_1d(getDomain(domainId));
 }
 
 /*!

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -490,7 +490,7 @@ void Xios::setDomainLatitudeSize(const std::string domainId, const size_t size)
 {
     xios::CDomain* domain = getDomain(domainId);
     if (cxios_is_defined_domain_nj(domain)) {
-        Logged::warning("Xios: Overwriting global latitude size for domain '" + domainId + "'");
+        Logged::warning("Xios: Overwriting latitude size for domain '" + domainId + "'");
     }
     cxios_set_domain_nj(domain, (int)size);
     if (!cxios_is_defined_domain_nj(domain)) {

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -15,6 +15,7 @@
 #if USE_XIOS
 
 #include "Configured.hpp"
+#include "Logged.hpp"
 #include "ModelArray.hpp"
 #include "Time.hpp"
 #include <boost/date_time/posix_time/posix_time.hpp>
@@ -63,8 +64,6 @@ public:
     void setAxisValues(const std::string axisId, std::vector<double> values);
     size_t getAxisSize(const std::string axisId);
     std::vector<double> getAxisValues(const std::string axisId);
-    bool isDefinedAxisSize(const std::string axisId);
-    bool areDefinedAxisValues(const std::string axisId);
 
     /* Domain */
     void createDomain(const std::string domainId);

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -70,21 +70,21 @@ public:
     void setDomainType(const std::string domainId, const std::string domainType);
     void setDomainGlobalLongitudeSize(const std::string domainId, const size_t size);
     void setDomainGlobalLatitudeSize(const std::string domainId, const size_t size);
-    void setDomainLongitudeSize(const std::string domainId, const size_t size);
-    void setDomainLatitudeSize(const std::string domainId, const size_t size);
-    void setDomainLongitudeStart(const std::string domainId, const size_t start);
-    void setDomainLatitudeStart(const std::string domainId, const size_t start);
-    void setDomainLongitudeValues(const std::string domainId, std::vector<double> values);
-    void setDomainLatitudeValues(const std::string domainId, std::vector<double> values);
+    void setDomainLocalLongitudeSize(const std::string domainId, const size_t size);
+    void setDomainLocalLatitudeSize(const std::string domainId, const size_t size);
+    void setDomainLocalLongitudeStart(const std::string domainId, const size_t start);
+    void setDomainLocalLatitudeStart(const std::string domainId, const size_t start);
+    void setDomainLocalLongitudeValues(const std::string domainId, std::vector<double> values);
+    void setDomainLocalLatitudeValues(const std::string domainId, std::vector<double> values);
     std::string getDomainType(const std::string domainId);
     size_t getDomainGlobalLongitudeSize(const std::string domainId);
     size_t getDomainGlobalLatitudeSize(const std::string domainId);
-    size_t getDomainLongitudeSize(const std::string domainId);
-    size_t getDomainLatitudeSize(const std::string domainId);
-    size_t getDomainLongitudeStart(const std::string domainId);
-    size_t getDomainLatitudeStart(const std::string domainId);
-    std::vector<double> getDomainLongitudeValues(const std::string domainId);
-    std::vector<double> getDomainLatitudeValues(const std::string domainId);
+    size_t getDomainLocalLongitudeSize(const std::string domainId);
+    size_t getDomainLocalLatitudeSize(const std::string domainId);
+    size_t getDomainLocalLongitudeStart(const std::string domainId);
+    size_t getDomainLocalLatitudeStart(const std::string domainId);
+    std::vector<double> getDomainLocalLongitudeValues(const std::string domainId);
+    std::vector<double> getDomainLocalLatitudeValues(const std::string domainId);
 
     /* Grid */
     void createGrid(const std::string gridId);

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -1,7 +1,7 @@
 /*!
  * @file    Xios.hpp
  * @author  Joe Wallwork <jw2423@cam.ac.uk
- * @date    24 July 2024
+ * @date    26 July 2024
  * @brief   XIOS interface header
  * @details
  *
@@ -85,15 +85,6 @@ public:
     size_t getDomainLatitudeStart(const std::string domainId);
     std::vector<double> getDomainLongitudeValues(const std::string domainId);
     std::vector<double> getDomainLatitudeValues(const std::string domainId);
-    bool isDefinedDomainType(const std::string domainId);
-    bool isDefinedDomainGlobalLongitudeSize(const std::string domainId);
-    bool isDefinedDomainGlobalLatitudeSize(const std::string domainId);
-    bool isDefinedDomainLongitudeSize(const std::string domainId);
-    bool isDefinedDomainLatitudeSize(const std::string domainId);
-    bool isDefinedDomainLongitudeStart(const std::string domainId);
-    bool isDefinedDomainLatitudeStart(const std::string domainId);
-    bool areDefinedDomainLongitudeValues(const std::string domainId);
-    bool areDefinedDomainLatitudeValues(const std::string domainId);
 
     /* Grid */
     void createGrid(const std::string gridId);

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -68,23 +68,23 @@ public:
     /* Domain */
     void createDomain(const std::string domainId);
     void setDomainType(const std::string domainId, const std::string domainType);
-    void setDomainGlobalLongitudeSize(const std::string domainId, const size_t size);
-    void setDomainGlobalLatitudeSize(const std::string domainId, const size_t size);
-    void setDomainLocalLongitudeSize(const std::string domainId, const size_t size);
-    void setDomainLocalLatitudeSize(const std::string domainId, const size_t size);
-    void setDomainLocalLongitudeStart(const std::string domainId, const size_t start);
-    void setDomainLocalLatitudeStart(const std::string domainId, const size_t start);
-    void setDomainLocalLongitudeValues(const std::string domainId, std::vector<double> values);
-    void setDomainLocalLatitudeValues(const std::string domainId, std::vector<double> values);
+    void setDomainGlobalXSize(const std::string domainId, const size_t size);
+    void setDomainGlobalYSize(const std::string domainId, const size_t size);
+    void setDomainLocalXSize(const std::string domainId, const size_t size);
+    void setDomainLocalYSize(const std::string domainId, const size_t size);
+    void setDomainLocalXStart(const std::string domainId, const size_t start);
+    void setDomainLocalYStart(const std::string domainId, const size_t start);
+    void setDomainLocalXValues(const std::string domainId, std::vector<double> values);
+    void setDomainLocalYValues(const std::string domainId, std::vector<double> values);
     std::string getDomainType(const std::string domainId);
-    size_t getDomainGlobalLongitudeSize(const std::string domainId);
-    size_t getDomainGlobalLatitudeSize(const std::string domainId);
-    size_t getDomainLocalLongitudeSize(const std::string domainId);
-    size_t getDomainLocalLatitudeSize(const std::string domainId);
-    size_t getDomainLocalLongitudeStart(const std::string domainId);
-    size_t getDomainLocalLatitudeStart(const std::string domainId);
-    std::vector<double> getDomainLocalLongitudeValues(const std::string domainId);
-    std::vector<double> getDomainLocalLatitudeValues(const std::string domainId);
+    size_t getDomainGlobalXSize(const std::string domainId);
+    size_t getDomainGlobalYSize(const std::string domainId);
+    size_t getDomainLocalXSize(const std::string domainId);
+    size_t getDomainLocalYSize(const std::string domainId);
+    size_t getDomainLocalXStart(const std::string domainId);
+    size_t getDomainLocalYStart(const std::string domainId);
+    std::vector<double> getDomainLocalXValues(const std::string domainId);
+    std::vector<double> getDomainLocalYValues(const std::string domainId);
 
     /* Grid */
     void createGrid(const std::string gridId);

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -99,7 +99,6 @@ public:
     void createGrid(const std::string gridId);
     void setGridName(const std::string gridId, const std::string name);
     std::string getGridName(const std::string gridId);
-    bool isDefinedGridName(const std::string gridId);
     void gridAddAxis(std::string axisId, const std::string domainId);
     void gridAddDomain(const std::string gridId, const std::string domainId);
     std::vector<std::string> gridGetAxisIds(const std::string gridId);

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -112,9 +112,6 @@ public:
     std::string getFieldName(const std::string fieldId);
     std::string getFieldOperation(const std::string fieldId);
     std::string getFieldGridRef(const std::string fieldId);
-    bool isDefinedFieldName(const std::string fieldId);
-    bool isDefinedFieldOperation(const std::string fieldId);
-    bool isDefinedFieldGridRef(const std::string fieldId);
 
     /* File */
     void createFile(const std::string fileId);

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -112,10 +112,6 @@ public:
     std::string getFileName(const std::string fileId);
     std::string getFileType(const std::string fileId);
     std::string getFileOutputFreq(const std::string fileId);
-    bool validFileId(const std::string fileId);
-    bool isDefinedFileName(const std::string fileId);
-    bool isDefinedFileType(const std::string fileId);
-    bool isDefinedFileOutputFreq(const std::string fileId);
     void fileAddField(const std::string fileId, const std::string fieldId);
     std::vector<std::string> fileGetFieldIds(const std::string fileId);
 

--- a/core/test/XiosAxis_test.cpp
+++ b/core/test/XiosAxis_test.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file    XiosAxis_test.cpp
  * @author  Joe Wallwork <jw2423@cam.ac.uk
- * @date    24 July 2024
+ * @date    26 July 2024
  * @brief   Tests for XIOS axes
  * @details
  * This test is designed to test axis functionality of the C++ interface
@@ -51,15 +51,11 @@ MPI_TEST_CASE("TestXiosAxis", 2)
     xios_handler.createAxis(axisId);
     // Axis size
     const size_t axis_size { 2 };
-    REQUIRE_FALSE(xios_handler.isDefinedAxisSize(axisId));
     xios_handler.setAxisSize(axisId, axis_size);
-    REQUIRE(xios_handler.isDefinedAxisSize(axisId));
     REQUIRE(xios_handler.getAxisSize(axisId) == axis_size);
     // Axis values
     std::vector<double> axisValues { 0, 1 };
-    REQUIRE_FALSE(xios_handler.areDefinedAxisValues(axisId));
     xios_handler.setAxisValues(axisId, axisValues);
-    REQUIRE(xios_handler.areDefinedAxisValues(axisId));
     std::vector<double> axis_A = xios_handler.getAxisValues(axisId);
     REQUIRE(axis_A[0] == doctest::Approx(0));
     REQUIRE(axis_A[1] == doctest::Approx(1));

--- a/core/test/XiosDomain_test.cpp
+++ b/core/test/XiosDomain_test.cpp
@@ -65,27 +65,27 @@ MPI_TEST_CASE("TestXiosDomain", 2)
     REQUIRE(xios_handler.getDomainGlobalLatitudeSize(domainId) == nj_glo);
     // Local longitude size
     const size_t ni = ni_glo / size;
-    xios_handler.setDomainLongitudeSize(domainId, ni);
-    REQUIRE(xios_handler.getDomainLongitudeSize(domainId) == ni);
+    xios_handler.setDomainLocalLongitudeSize(domainId, ni);
+    REQUIRE(xios_handler.getDomainLocalLongitudeSize(domainId) == ni);
     // Local latitude size
     const size_t nj = nj_glo;
-    xios_handler.setDomainLatitudeSize(domainId, nj);
-    REQUIRE(xios_handler.getDomainLatitudeSize(domainId) == nj);
+    xios_handler.setDomainLocalLatitudeSize(domainId, nj);
+    REQUIRE(xios_handler.getDomainLocalLatitudeSize(domainId) == nj);
     // Local longitude start
     const size_t startLon = ni * rank;
-    xios_handler.setDomainLongitudeStart(domainId, startLon);
-    REQUIRE(xios_handler.getDomainLongitudeStart(domainId) == startLon);
+    xios_handler.setDomainLocalLongitudeStart(domainId, startLon);
+    REQUIRE(xios_handler.getDomainLocalLongitudeStart(domainId) == startLon);
     // Local latitude start
     const size_t startLat = 0;
-    xios_handler.setDomainLatitudeStart(domainId, startLat);
-    REQUIRE(xios_handler.getDomainLatitudeStart(domainId) == startLat);
+    xios_handler.setDomainLocalLatitudeStart(domainId, startLat);
+    REQUIRE(xios_handler.getDomainLocalLatitudeStart(domainId) == startLat);
     // Local longitude values
     std::vector<double> vecLon(ni);
     for (size_t i = 0; i < ni; i++) {
         vecLon[i] = -180 + (rank * ni * i) * 360 / ni_glo;
     }
-    xios_handler.setDomainLongitudeValues(domainId, vecLon);
-    std::vector<double> vecLonOut = xios_handler.getDomainLongitudeValues(domainId);
+    xios_handler.setDomainLocalLongitudeValues(domainId, vecLon);
+    std::vector<double> vecLonOut = xios_handler.getDomainLocalLongitudeValues(domainId);
     for (size_t i = 0; i < ni; i++) {
         REQUIRE(vecLonOut[i] == doctest::Approx(vecLon[i]));
     }
@@ -94,8 +94,8 @@ MPI_TEST_CASE("TestXiosDomain", 2)
     for (size_t j = 0; j < nj; j++) {
         vecLat[j] = -90 + j * 180 / nj_glo;
     }
-    xios_handler.setDomainLatitudeValues(domainId, vecLat);
-    std::vector<double> vecLatOut = xios_handler.getDomainLatitudeValues(domainId);
+    xios_handler.setDomainLocalLatitudeValues(domainId, vecLat);
+    std::vector<double> vecLatOut = xios_handler.getDomainLocalLatitudeValues(domainId);
     for (size_t j = 0; j < nj; j++) {
         REQUIRE(vecLatOut[j] == doctest::Approx(vecLat[j]));
     }

--- a/core/test/XiosDomain_test.cpp
+++ b/core/test/XiosDomain_test.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file    XiosDomain_test.cpp
  * @author  Joe Wallwork <jw2423@cam.ac.uk
- * @date    24 July 2024
+ * @date    26 July 2024
  * @brief   Tests for XIOS domains
  * @details
  * This test is designed to test domain functionality of the C++ interface
@@ -52,67 +52,49 @@ MPI_TEST_CASE("TestXiosDomain", 2)
     const std::string domainId = { "domain_A" };
     xios_handler.createDomain(domainId);
     // Domain type
-    REQUIRE_FALSE(xios_handler.isDefinedDomainType(domainId));
     const std::string domainType = { "rectilinear" };
     xios_handler.setDomainType(domainId, domainType);
-    REQUIRE(xios_handler.isDefinedDomainType(domainId));
     REQUIRE(xios_handler.getDomainType(domainId) == domainType);
     // Global longitude size
-    REQUIRE_FALSE(xios_handler.isDefinedDomainGlobalLongitudeSize(domainId));
     const size_t ni_glo = 60;
     xios_handler.setDomainGlobalLongitudeSize(domainId, ni_glo);
-    REQUIRE(xios_handler.isDefinedDomainGlobalLongitudeSize(domainId));
     REQUIRE(xios_handler.getDomainGlobalLongitudeSize(domainId) == ni_glo);
     // Global latitude size
-    REQUIRE_FALSE(xios_handler.isDefinedDomainGlobalLatitudeSize(domainId));
     const size_t nj_glo = 20;
     xios_handler.setDomainGlobalLatitudeSize(domainId, nj_glo);
-    REQUIRE(xios_handler.isDefinedDomainGlobalLatitudeSize(domainId));
     REQUIRE(xios_handler.getDomainGlobalLatitudeSize(domainId) == nj_glo);
     // Local longitude size
-    REQUIRE_FALSE(xios_handler.isDefinedDomainLongitudeSize(domainId));
     const size_t ni = ni_glo / size;
     xios_handler.setDomainLongitudeSize(domainId, ni);
-    REQUIRE_FALSE(xios_handler.isDefinedDomainLatitudeSize(domainId));
     REQUIRE(xios_handler.getDomainLongitudeSize(domainId) == ni);
     // Local latitude size
-    REQUIRE_FALSE(xios_handler.isDefinedDomainLatitudeSize(domainId));
     const size_t nj = nj_glo;
     xios_handler.setDomainLatitudeSize(domainId, nj);
-    REQUIRE(xios_handler.isDefinedDomainLatitudeSize(domainId));
     REQUIRE(xios_handler.getDomainLatitudeSize(domainId) == nj);
     // Local longitude start
-    REQUIRE_FALSE(xios_handler.isDefinedDomainLongitudeStart(domainId));
     const size_t startLon = ni * rank;
     xios_handler.setDomainLongitudeStart(domainId, startLon);
-    REQUIRE(xios_handler.isDefinedDomainLongitudeStart(domainId));
     REQUIRE(xios_handler.getDomainLongitudeStart(domainId) == startLon);
     // Local latitude start
-    REQUIRE_FALSE(xios_handler.isDefinedDomainLatitudeStart(domainId));
     const size_t startLat = 0;
     xios_handler.setDomainLatitudeStart(domainId, startLat);
-    REQUIRE(xios_handler.isDefinedDomainLatitudeStart(domainId));
     REQUIRE(xios_handler.getDomainLatitudeStart(domainId) == startLat);
     // Local longitude values
-    REQUIRE_FALSE(xios_handler.areDefinedDomainLongitudeValues(domainId));
     std::vector<double> vecLon(ni);
     for (size_t i = 0; i < ni; i++) {
         vecLon[i] = -180 + (rank * ni * i) * 360 / ni_glo;
     }
     xios_handler.setDomainLongitudeValues(domainId, vecLon);
-    REQUIRE(xios_handler.areDefinedDomainLongitudeValues(domainId));
     std::vector<double> vecLonOut = xios_handler.getDomainLongitudeValues(domainId);
     for (size_t i = 0; i < ni; i++) {
         REQUIRE(vecLonOut[i] == doctest::Approx(vecLon[i]));
     }
     // Local latitude values
-    REQUIRE_FALSE(xios_handler.areDefinedDomainLatitudeValues(domainId));
     std::vector<double> vecLat(nj);
     for (size_t j = 0; j < nj; j++) {
         vecLat[j] = -90 + j * 180 / nj_glo;
     }
     xios_handler.setDomainLatitudeValues(domainId, vecLat);
-    REQUIRE(xios_handler.areDefinedDomainLatitudeValues(domainId));
     std::vector<double> vecLatOut = xios_handler.getDomainLatitudeValues(domainId);
     for (size_t j = 0; j < nj; j++) {
         REQUIRE(vecLatOut[j] == doctest::Approx(vecLat[j]));

--- a/core/test/XiosDomain_test.cpp
+++ b/core/test/XiosDomain_test.cpp
@@ -57,35 +57,35 @@ MPI_TEST_CASE("TestXiosDomain", 2)
     REQUIRE(xios_handler.getDomainType(domainId) == domainType);
     // Global longitude size
     const size_t ni_glo = 60;
-    xios_handler.setDomainGlobalLongitudeSize(domainId, ni_glo);
-    REQUIRE(xios_handler.getDomainGlobalLongitudeSize(domainId) == ni_glo);
+    xios_handler.setDomainGlobalXSize(domainId, ni_glo);
+    REQUIRE(xios_handler.getDomainGlobalXSize(domainId) == ni_glo);
     // Global latitude size
     const size_t nj_glo = 20;
-    xios_handler.setDomainGlobalLatitudeSize(domainId, nj_glo);
-    REQUIRE(xios_handler.getDomainGlobalLatitudeSize(domainId) == nj_glo);
+    xios_handler.setDomainGlobalYSize(domainId, nj_glo);
+    REQUIRE(xios_handler.getDomainGlobalYSize(domainId) == nj_glo);
     // Local longitude size
     const size_t ni = ni_glo / size;
-    xios_handler.setDomainLocalLongitudeSize(domainId, ni);
-    REQUIRE(xios_handler.getDomainLocalLongitudeSize(domainId) == ni);
+    xios_handler.setDomainLocalXSize(domainId, ni);
+    REQUIRE(xios_handler.getDomainLocalXSize(domainId) == ni);
     // Local latitude size
     const size_t nj = nj_glo;
-    xios_handler.setDomainLocalLatitudeSize(domainId, nj);
-    REQUIRE(xios_handler.getDomainLocalLatitudeSize(domainId) == nj);
+    xios_handler.setDomainLocalYSize(domainId, nj);
+    REQUIRE(xios_handler.getDomainLocalYSize(domainId) == nj);
     // Local longitude start
     const size_t startLon = ni * rank;
-    xios_handler.setDomainLocalLongitudeStart(domainId, startLon);
-    REQUIRE(xios_handler.getDomainLocalLongitudeStart(domainId) == startLon);
+    xios_handler.setDomainLocalXStart(domainId, startLon);
+    REQUIRE(xios_handler.getDomainLocalXStart(domainId) == startLon);
     // Local latitude start
     const size_t startLat = 0;
-    xios_handler.setDomainLocalLatitudeStart(domainId, startLat);
-    REQUIRE(xios_handler.getDomainLocalLatitudeStart(domainId) == startLat);
+    xios_handler.setDomainLocalYStart(domainId, startLat);
+    REQUIRE(xios_handler.getDomainLocalYStart(domainId) == startLat);
     // Local longitude values
     std::vector<double> vecLon(ni);
     for (size_t i = 0; i < ni; i++) {
         vecLon[i] = -180 + (rank * ni * i) * 360 / ni_glo;
     }
-    xios_handler.setDomainLocalLongitudeValues(domainId, vecLon);
-    std::vector<double> vecLonOut = xios_handler.getDomainLocalLongitudeValues(domainId);
+    xios_handler.setDomainLocalXValues(domainId, vecLon);
+    std::vector<double> vecLonOut = xios_handler.getDomainLocalXValues(domainId);
     for (size_t i = 0; i < ni; i++) {
         REQUIRE(vecLonOut[i] == doctest::Approx(vecLon[i]));
     }
@@ -94,8 +94,8 @@ MPI_TEST_CASE("TestXiosDomain", 2)
     for (size_t j = 0; j < nj; j++) {
         vecLat[j] = -90 + j * 180 / nj_glo;
     }
-    xios_handler.setDomainLocalLatitudeValues(domainId, vecLat);
-    std::vector<double> vecLatOut = xios_handler.getDomainLocalLatitudeValues(domainId);
+    xios_handler.setDomainLocalYValues(domainId, vecLat);
+    std::vector<double> vecLatOut = xios_handler.getDomainLocalYValues(domainId);
     for (size_t j = 0; j < nj; j++) {
         REQUIRE(vecLatOut[j] == doctest::Approx(vecLat[j]));
     }

--- a/core/test/XiosField_test.cpp
+++ b/core/test/XiosField_test.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file    XiosField_test.cpp
  * @author  Joe Wallwork <jw2423@cam.ac.uk
- * @date    24 July 2024
+ * @date    26 July 2024
  * @brief   Tests for XIOS axes
  * @details
  * This test is designed to test axis functionality of the C++ interface
@@ -61,21 +61,15 @@ MPI_TEST_CASE("TestXiosField", 2)
     xios_handler.createField(fieldId);
     // Field name
     const std::string fieldName = { "test_field" };
-    REQUIRE_FALSE(xios_handler.isDefinedFieldName(fieldId));
     xios_handler.setFieldName(fieldId, fieldName);
     REQUIRE(xios_handler.getFieldName(fieldId) == fieldName);
-    REQUIRE(xios_handler.isDefinedFieldName(fieldId));
     // Operation
     const std::string operation = { "instant" };
-    REQUIRE_FALSE(xios_handler.isDefinedFieldOperation(fieldId));
     xios_handler.setFieldOperation(fieldId, operation);
-    REQUIRE(xios_handler.isDefinedFieldOperation(fieldId));
     REQUIRE(xios_handler.getFieldOperation(fieldId) == operation);
     // Grid reference
     const std::string gridRef = { "grid_2D" };
-    REQUIRE_FALSE(xios_handler.isDefinedFieldGridRef(fieldId));
     xios_handler.setFieldGridRef(fieldId, gridRef);
-    REQUIRE(xios_handler.isDefinedFieldGridRef(fieldId));
     REQUIRE(xios_handler.getFieldGridRef(fieldId) == gridRef);
 
     xios_handler.close_context_definition();

--- a/core/test/XiosFile_test.cpp
+++ b/core/test/XiosFile_test.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file    XiosFile_test.cpp
  * @author  Joe Wallwork <jw2423@cam.ac.uk
- * @date    24 July 2024
+ * @date    26 July 2024
  * @brief   Tests for XIOS axes
  * @details
  * This test is designed to test axis functionality of the C++ interface
@@ -63,25 +63,18 @@ MPI_TEST_CASE("TestXiosFile", 2)
 
     // --- Tests for file API
     const std::string fileId { "output" };
-    REQUIRE_FALSE(xios_handler.validFileId(fileId));
     xios_handler.createFile(fileId);
-    REQUIRE(xios_handler.validFileId(fileId));
     // File name
     const std::string fileName { "diagnostic" };
     xios_handler.setFileName(fileId, fileName);
-    REQUIRE(xios_handler.isDefinedFileName(fileId));
     REQUIRE(xios_handler.getFileName(fileId) == fileName);
     // File type
     const std::string fileType { "one_file" };
-    REQUIRE_FALSE(xios_handler.isDefinedFileType(fileId));
     xios_handler.setFileType(fileId, fileType);
-    REQUIRE(xios_handler.isDefinedFileType(fileId));
     REQUIRE(xios_handler.getFileType(fileId) == fileType);
     // Output frequency
-    REQUIRE_FALSE(xios_handler.isDefinedFileOutputFreq(fileId));
     const std::string freq { "1ts" };
     xios_handler.setFileOutputFreq(fileId, freq);
-    REQUIRE(xios_handler.isDefinedFileOutputFreq(fileId));
     REQUIRE(xios_handler.getFileOutputFreq(fileId) == freq);
     // Add field
     xios_handler.fileAddField(fileId, "field_A");

--- a/core/test/XiosGrid_test.cpp
+++ b/core/test/XiosGrid_test.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file    XiosGrid_test.cpp
  * @author  Joe Wallwork <jw2423@cam.ac.uk
- * @date    27 June 2024
+ * @date    26 July 2024
  * @brief   Tests for XIOS axes
  * @details
  * This test is designed to test axis functionality of the C++ interface
@@ -79,10 +79,8 @@ MPI_TEST_CASE("TestXiosGrid", 2)
     const std::string gridId = { "grid_2D" };
     xios_handler.createGrid(gridId);
     // Grid name
-    REQUIRE_FALSE(xios_handler.isDefinedGridName(gridId));
     const std::string gridName = { "test_grid" };
     xios_handler.setGridName(gridId, gridName);
-    REQUIRE(xios_handler.isDefinedGridName(gridId));
     REQUIRE(xios_handler.getGridName(gridId) == gridName);
     // Add axis
     xios_handler.gridAddAxis("grid_2D", "axis_A");

--- a/core/test/XiosGrid_test.cpp
+++ b/core/test/XiosGrid_test.cpp
@@ -59,21 +59,21 @@ MPI_TEST_CASE("TestXiosGrid", 2)
     const size_t nj_glo = 20;
     xios_handler.setDomainGlobalLatitudeSize("domain_A", nj_glo);
     const size_t ni = ni_glo / size;
-    xios_handler.setDomainLongitudeSize("domain_A", ni);
+    xios_handler.setDomainLocalLongitudeSize("domain_A", ni);
     const size_t nj = nj_glo;
-    xios_handler.setDomainLatitudeSize("domain_A", nj);
-    xios_handler.setDomainLongitudeStart("domain_A", ni * rank);
-    xios_handler.setDomainLatitudeStart("domain_A", 0);
+    xios_handler.setDomainLocalLatitudeSize("domain_A", nj);
+    xios_handler.setDomainLocalLongitudeStart("domain_A", ni * rank);
+    xios_handler.setDomainLocalLatitudeStart("domain_A", 0);
     std::vector<double> vecLon(ni);
     for (size_t i = 0; i < ni; i++) {
         vecLon[i] = -180 + (rank * ni * i) * 360 / ni_glo;
     }
-    xios_handler.setDomainLongitudeValues("domain_A", vecLon);
+    xios_handler.setDomainLocalLongitudeValues("domain_A", vecLon);
     std::vector<double> vecLat(nj);
     for (size_t j = 0; j < nj; j++) {
         vecLat[j] = -90 + j * 180 / nj_glo;
     }
-    xios_handler.setDomainLatitudeValues("domain_A", vecLat);
+    xios_handler.setDomainLocalLatitudeValues("domain_A", vecLat);
 
     // --- Tests for grid API
     const std::string gridId = { "grid_2D" };

--- a/core/test/XiosGrid_test.cpp
+++ b/core/test/XiosGrid_test.cpp
@@ -55,25 +55,25 @@ MPI_TEST_CASE("TestXiosGrid", 2)
     xios_handler.createDomain("domain_A");
     xios_handler.setDomainType("domain_A", "rectilinear");
     const size_t ni_glo = 60;
-    xios_handler.setDomainGlobalLongitudeSize("domain_A", ni_glo);
+    xios_handler.setDomainGlobalXSize("domain_A", ni_glo);
     const size_t nj_glo = 20;
-    xios_handler.setDomainGlobalLatitudeSize("domain_A", nj_glo);
+    xios_handler.setDomainGlobalYSize("domain_A", nj_glo);
     const size_t ni = ni_glo / size;
-    xios_handler.setDomainLocalLongitudeSize("domain_A", ni);
+    xios_handler.setDomainLocalXSize("domain_A", ni);
     const size_t nj = nj_glo;
-    xios_handler.setDomainLocalLatitudeSize("domain_A", nj);
-    xios_handler.setDomainLocalLongitudeStart("domain_A", ni * rank);
-    xios_handler.setDomainLocalLatitudeStart("domain_A", 0);
+    xios_handler.setDomainLocalYSize("domain_A", nj);
+    xios_handler.setDomainLocalXStart("domain_A", ni * rank);
+    xios_handler.setDomainLocalYStart("domain_A", 0);
     std::vector<double> vecLon(ni);
     for (size_t i = 0; i < ni; i++) {
         vecLon[i] = -180 + (rank * ni * i) * 360 / ni_glo;
     }
-    xios_handler.setDomainLocalLongitudeValues("domain_A", vecLon);
+    xios_handler.setDomainLocalXValues("domain_A", vecLon);
     std::vector<double> vecLat(nj);
     for (size_t j = 0; j < nj; j++) {
         vecLat[j] = -90 + j * 180 / nj_glo;
     }
-    xios_handler.setDomainLocalLatitudeValues("domain_A", vecLat);
+    xios_handler.setDomainLocalYValues("domain_A", vecLat);
 
     // --- Tests for grid API
     const std::string gridId = { "grid_2D" };


### PR DESCRIPTION
# Drop XIOS `isDefined*` and `areDefined*` methods
## Fixes #629

### Task List
- [x] Defined the tests that specify a complete and functioning change (*It may help to create a [design specification & test specification](../../../wiki/Specification-Template)*)
- [x] Implemented the source code change that satisfies the tests
- [x] Documented the feature by providing worked example
- [x] Updated the README or other documentation
- [x] Completed the pre-Request checklist below

---
# Change Description

It's unnecessary for us to provide API functions for checking whether XIOS attributes are defined. We can cut down API size, implement self-testing code, and reduce verbosity by just inlining the associated XIOS functions within the getter and setter methods.

---
### Pre-Request Checklist

- [x] The requirements of this pull request are fully captured in an issue or design specification and are linked and summarised in the description of this PR
- [x] No new warnings are generated
- [x] The documentation has been updated (or an issue has been created to track the corresponding change)
- [x] Methods and Tests are commented such that they can be understood without having to obtain additional context
- [x] This PR/Issue is labelled as a bug/feature/enhancement/breaking change
- [x] File dates have been updated to reflect modification date
- [x] This change conforms to the conventions described in the README
