### PR TITLE
Ignore empty modules

### DIFF
--- a/core/src/modules/CMakeLists.txt
+++ b/core/src/modules/CMakeLists.txt
@@ -5,6 +5,10 @@ set(AllModuleSources "")
 file(GLOB ModuleSubDirs LIST_DIRECTORIES TRUE "*Module")
 
 foreach(ModuleSubDir IN LISTS ModuleSubDirs)
+    # Ignore directories without a module.cfg file
+    IF (NOT EXISTS("${ModuleSubDir}/module.cfg"))
+        CONTINUE()
+    ENDIF()
     IF (NOT EXISTS("include/${ModuleSubDir}.hpp"))
         # Run the header python script
         EXECUTE_PROCESS(COMMAND "${Python_EXECUTABLE}" "${ModuleHeaderScript}" WORKING_DIRECTORY "${ModuleSubDir}")

--- a/core/src/modules/CMakeLists.txt
+++ b/core/src/modules/CMakeLists.txt
@@ -6,9 +6,10 @@ file(GLOB ModuleSubDirs LIST_DIRECTORIES TRUE "*Module")
 
 foreach(ModuleSubDir IN LISTS ModuleSubDirs)
     # Ignore directories without a module.cfg file
-    IF (NOT EXISTS("${ModuleSubDir}/module.cfg"))
+    IF (NOT EXISTS "${ModuleSubDir}/module.cfg")
         CONTINUE()
     ENDIF()
+
     IF (NOT EXISTS("include/${ModuleSubDir}.hpp"))
         # Run the header python script
         EXECUTE_PROCESS(COMMAND "${Python_EXECUTABLE}" "${ModuleHeaderScript}" WORKING_DIRECTORY "${ModuleSubDir}")

--- a/physics/src/modules/CMakeLists.txt
+++ b/physics/src/modules/CMakeLists.txt
@@ -5,6 +5,11 @@ set(AllModuleSources "")
 file(GLOB ModuleSubDirs LIST_DIRECTORIES TRUE "*Module")
 
 foreach(ModuleSubDir IN LISTS ModuleSubDirs)
+    # Ignore directories without a module.cfg file
+    IF (NOT EXISTS "${ModuleSubDir}/module.cfg")
+        CONTINUE()
+    ENDIF()
+
     IF (NOT EXISTS("include/${ModuleSubDir}.hpp"))
         # Run the header python script
         EXECUTE_PROCESS(COMMAND "${Python_EXECUTABLE}" "${ModuleHeaderScript}" WORKING_DIRECTORY "${ModuleSubDir}")


### PR DESCRIPTION
# Pull Request Title
## Fixes #608

---
# Change Description

Ignores any modules that don't contain a `module.cfg` file. These can be left over when changing `git` branches where a module exists to one where it does not. Before this change, the presence of the directory alone would trigger `CMake` to run the module build scripts, which fail due to the lack of any module files. Without a `module.cfg` file, there is no module to build, so ignoring these sub-directories is the right thing to do, whether they are left over from changing branches or for whatever other reason.

---
# Test Description

Hand tested before creating this PR. I don't see a good way to integrate a test for this.
