### PR TITLE
Wrap XIOS frequency splitting and fix timestep bug

### DIFF
--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -203,7 +203,7 @@ void Xios::setCalendarStart(const TimePoint start)
  */
 void Xios::setCalendarTimestep(const Duration timestep)
 {
-    cxios_duration duration { 0.0, 0.0, 0.0, 0.0, timestep.seconds(), 0.0 };
+    cxios_duration duration { 0.0, 0.0, 0.0, 0.0, 0.0, timestep.seconds() };
     cxios_set_calendar_wrapper_timestep(clientCalendar, duration);
     cxios_update_calendar_timestep(clientCalendar);
 }

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file    Xios.cpp
  * @author  Joe Wallwork <jw2423@cam.ac.uk
- * @date    24 July 2024
+ * @date    31 July 2024
  * @brief   XIOS interface implementation
  * @details
  *
@@ -1153,6 +1153,25 @@ void Xios::setFileOutputFreq(const std::string fileId, const std::string freq)
 }
 
 /*!
+ * Set the split frequency of a file with a given ID
+ *
+ * @param the file ID
+ * @param split frequency to set
+ */
+void Xios::setFileSplitFreq(const std::string fileId, const std::string freq)
+{
+    xios::CFile* file = getFile(fileId);
+    if (cxios_is_defined_file_split_freq(file)) {
+        Logged::warning("Xios: Split frequency already set for file '" + fileId + "'");
+    }
+    cxios_set_file_split_freq(
+        file, cxios_duration_convert_from_string(freq.c_str(), freq.length()));
+    if (!cxios_is_defined_file_split_freq(file)) {
+        throw std::runtime_error("Xios: Failed to set split frequency for file '" + fileId + "'");
+    }
+}
+
+/*!
  * Get the name of a file with a given ID
  *
  * @param the file ID
@@ -1197,6 +1216,27 @@ std::string Xios::getFileOutputFreq(const std::string fileId)
     std::string outputFreq(cStr, cStrLen);
     boost::algorithm::trim_right(outputFreq);
     return outputFreq;
+}
+
+/*!
+ * Get the split frequency of a file with a given ID
+ *
+ * @param the file ID
+ * @return split frequency of the corresponding file
+ */
+std::string Xios::getFileSplitFreq(const std::string fileId)
+{
+    xios::CFile* file = getFile(fileId);
+    if (!cxios_is_defined_file_split_freq(file)) {
+        throw std::runtime_error("Xios: Undefined values for file '" + fileId + "'");
+    }
+    cxios_duration duration;
+    cxios_get_file_split_freq(file, &duration);
+    char cStr[cStrLen];
+    cxios_duration_convert_to_string(duration, cStr, cStrLen);
+    std::string freq(cStr, cStrLen);
+    boost::algorithm::trim_right(freq);
+    return freq;
 }
 
 /*!

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -1,7 +1,7 @@
 /*!
  * @file    Xios.hpp
  * @author  Joe Wallwork <jw2423@cam.ac.uk
- * @date    24 July 2024
+ * @date    31 July 2024
  * @brief   XIOS interface header
  * @details
  *
@@ -15,6 +15,7 @@
 #if USE_XIOS
 
 #include "Configured.hpp"
+#include "Logged.hpp"
 #include "ModelArray.hpp"
 #include "Time.hpp"
 #include <boost/date_time/posix_time/posix_time.hpp>
@@ -123,9 +124,11 @@ public:
     void setFileName(const std::string fileId, const std::string fileName);
     void setFileType(const std::string fileId, const std::string fileType);
     void setFileOutputFreq(const std::string fileId, const std::string outputFreq);
+    void setFileSplitFreq(const std::string fileId, const std::string splitFreq);
     std::string getFileName(const std::string fileId);
     std::string getFileType(const std::string fileId);
     std::string getFileOutputFreq(const std::string fileId);
+    std::string getFileSplitFreq(const std::string fileId);
     bool validFileId(const std::string fileId);
     bool isDefinedFileName(const std::string fileId);
     bool isDefinedFileType(const std::string fileId);

--- a/core/src/include/xios_c_interface.hpp
+++ b/core/src/include/xios_c_interface.hpp
@@ -1,7 +1,7 @@
 /*!
  * @file    xios_c_interface.hpp
  * @author  Joe Wallwork <jw2423@cam.ac.uk
- * @date    24 July 2024
+ * @date    31 July 2024
  * @brief   C interface for XIOS library
  * @details
  * This interface is based on an earlier version provided by Laurent as part of
@@ -159,12 +159,15 @@ void cxios_file_valid_id(bool* _ret, const char* _id, int _id_len);
 void cxios_set_file_name(xios::CFile* file_hdl, const char* name, int name_size);
 void cxios_set_file_type(xios::CFile* file_hdl, const char* type, int type_size);
 void cxios_set_file_output_freq(xios::CFile* file_hdl, cxios_duration output_freq_c);
+void cxios_set_file_split_freq(xios::CFile* file_hdl, cxios_duration split_freq_c);
 void cxios_get_file_name(xios::CFile* file_hdl, char* name, int name_size);
 void cxios_get_file_type(xios::CFile* file_hdl, char* type, int type_size);
 void cxios_get_file_output_freq(xios::CFile* file_hdl, cxios_duration* output_freq_c);
+void cxios_get_file_split_freq(xios::CFile* file_hdl, cxios_duration* split_freq_c);
 bool cxios_is_defined_file_name(xios::CFile* file_hdl);
 bool cxios_is_defined_file_type(xios::CFile* file_hdl);
 bool cxios_is_defined_file_output_freq(xios::CFile* file_hdl);
+bool cxios_is_defined_file_split_freq(xios::CFile* file_hdl);
 void cxios_xml_tree_add_fieldtofile(
     xios::CFile* file, xios::CField** field, const char* _id, int _id_len);
 

--- a/core/test/XiosCalendar_test.cpp
+++ b/core/test/XiosCalendar_test.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file    XiosCalendar_test.cpp
  * @author  Joe Wallwork <jw2423@cam.ac.uk
- * @date    24 July 2024
+ * @date    31 July 2024
  * @brief   Tests for XIOS calandars
  * @details
  * This test is designed to test calendar functionality of the C++ interface

--- a/core/test/XiosCalendar_test.cpp
+++ b/core/test/XiosCalendar_test.cpp
@@ -65,8 +65,13 @@ MPI_TEST_CASE("TestXiosInitialization", 2)
     xios_handler.close_context_definition();
 
     // --- Tests for getCurrentDate method
+    REQUIRE(xios_handler.getCalendarStep() == 0);
     REQUIRE(xios_handler.getCurrentDate() == "2023-03-17T17:11:00Z");
     REQUIRE(xios_handler.getCurrentDate(false) == "2023-03-17 17:11:00");
+
+    // -- Tests that the timestep is set up correctly
+    xios_handler.updateCalendar(1);
+    REQUIRE(xios_handler.getCurrentDate() == "2023-03-17T18:41:00Z");
 
     xios_handler.context_finalize();
 }

--- a/core/test/XiosFile_test.cpp
+++ b/core/test/XiosFile_test.cpp
@@ -83,6 +83,10 @@ MPI_TEST_CASE("TestXiosFile", 2)
     xios_handler.setFileOutputFreq(fileId, freq);
     REQUIRE(xios_handler.isDefinedFileOutputFreq(fileId));
     REQUIRE(xios_handler.getFileOutputFreq(fileId) == freq);
+    // Split frequency
+    const std::string splitFreq { "1ts" };
+    xios_handler.setFileSplitFreq(fileId, splitFreq);
+    REQUIRE(xios_handler.getFileSplitFreq(fileId) == splitFreq);
     // Add field
     xios_handler.fileAddField(fileId, "field_A");
     std::vector<std::string> fieldIds = xios_handler.fileGetFieldIds(fileId);

--- a/core/test/XiosFile_test.cpp
+++ b/core/test/XiosFile_test.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file    XiosFile_test.cpp
  * @author  Joe Wallwork <jw2423@cam.ac.uk
- * @date    24 July 2024
+ * @date    31 July 2024
  * @brief   Tests for XIOS axes
  * @details
  * This test is designed to test axis functionality of the C++ interface

--- a/core/test/XiosWrite_test.cpp
+++ b/core/test/XiosWrite_test.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file    XiosWrite_test.cpp
  * @author  Joe Wallwork <jw2423@cam.ac.uk
- * @date    24 July 2024
+ * @date    31 July 2024
  * @brief   Tests for XIOS write method
  * @details
  * This test is designed to test the write method of the C++ interface
@@ -96,12 +96,13 @@ MPI_TEST_CASE("TestXiosWrite", 2)
     xios_handler.setFieldGridRef("field_4D", "grid_4D");
 
     // File setup
-    xios_handler.createFile("output");
-    xios_handler.setFileType("output", "one_file");
-    xios_handler.setFileOutputFreq("output", "1ts");
-    xios_handler.fileAddField("output", "field_2D");
-    xios_handler.fileAddField("output", "field_3D");
-    xios_handler.fileAddField("output", "field_4D");
+    xios_handler.createFile("xios_test_output");
+    xios_handler.setFileType("xios_test_output", "one_file");
+    xios_handler.setFileOutputFreq("xios_test_output", "1ts");
+    xios_handler.setFileSplitFreq("xios_test_output", "2ts");
+    xios_handler.fileAddField("xios_test_output", "field_2D");
+    xios_handler.fileAddField("xios_test_output", "field_3D");
+    xios_handler.fileAddField("xios_test_output", "field_4D");
 
     xios_handler.close_context_definition();
 
@@ -130,6 +131,8 @@ MPI_TEST_CASE("TestXiosWrite", 2)
     // TODO: field_4D?
     // Verify calendar step is starting from zero
     REQUIRE(xios_handler.getCalendarStep() == 0);
+    // Check a file with the expected name doesn't exist yet
+    REQUIRE_FALSE(std::filesystem::exists("xios_test_output*.nc"));
     // Simulate 4 iterations (timesteps)
     for (int ts = 1; ts <= 4; ts++) {
         // Update the current timestep
@@ -141,12 +144,14 @@ MPI_TEST_CASE("TestXiosWrite", 2)
         // Verify timestep
         REQUIRE(xios_handler.getCalendarStep() == ts);
     }
-    // Check the file exists then remove it
-    REQUIRE(filesystem::exists("output.nc"));
+    // Check the files have indeed been created then remove it
+    // FIXME: These aren't the datetimes that come out - seems to be using 54hr timestep
+    REQUIRE(std::filesystem::exists("xios_test_output_20230317171100-20230317201059.nc"));
+    REQUIRE(std::filesystem::exists("xios_test_output_20230317201100-20230317231059.nc"));
     if (rank == 0) {
-        filesystem::remove("output.nc");
+        std::filesystem::remove("xios_test_output_20230317171100-20230317201059.nc");
+        std::filesystem::remove("xios_test_output_20230317201100-20230317231059.nc");
     }
-
     xios_handler.context_finalize();
 }
 }

--- a/core/test/XiosWrite_test.cpp
+++ b/core/test/XiosWrite_test.cpp
@@ -145,7 +145,6 @@ MPI_TEST_CASE("TestXiosWrite", 2)
         REQUIRE(xios_handler.getCalendarStep() == ts);
     }
     // Check the files have indeed been created then remove it
-    // FIXME: These aren't the datetimes that come out - seems to be using 54hr timestep
     REQUIRE(std::filesystem::exists("xios_test_output_20230317171100-20230317201059.nc"));
     REQUIRE(std::filesystem::exists("xios_test_output_20230317201100-20230317231059.nc"));
     if (rank == 0) {


### PR DESCRIPTION
# Wrap XIOS frequency splitting and fix timestep bug
## Fixes #554

### Task List
- [x] Defined the tests that specify a complete and functioning change (*It may help to create a [design specification & test specification](../../../wiki/Specification-Template)*)
- [x] Implemented the source code change that satisfies the tests
- [x] Documented the feature by providing worked example
- [x] Updated the README or other documentation
- [x] Completed the pre-Request checklist below

---
# Change Description

Closes #554. Wraps the `split_freq` option for XIOS Files, so that output files can be separated according to some frequency.

While working on this, I spotted a bug: the timestep is interpreted as minutes rather than seconds. This is now fixed.

---
# Test Description

A test for the frequency splitting option is added, which checks a frequency of 2 timesteps works.

Another test is added to verify that the timestep is set up correctly.

---
### Pre-Request Checklist

- [x] The requirements of this pull request are fully captured in an issue or design specification and are linked and summarised in the description of this PR
- [x] No new warnings are generated
- [x] The documentation has been updated (or an issue has been created to track the corresponding change)
- [x] Methods and Tests are commented such that they can be understood without having to obtain additional context
- [x] This PR/Issue is labelled as a bug/feature/enhancement/breaking change
- [x] File dates have been updated to reflect modification date
- [x] This change conforms to the conventions described in the README