### PR TITLE
XIOS: use Domain for xy-plane and Axis for z

### DIFF
--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -615,6 +615,9 @@ void Xios::setDomainLocalXValues(const std::string domainId, std::vector<double>
     if (cxios_is_defined_domain_lonvalue_1d(domain)) {
         Logged::warning("Xios: Overwriting local x-values for domain '" + domainId + "'");
     }
+    if (!cxios_is_defined_domain_ni(domain)) {
+        setDomainLocalXSize(domainId, values.size());
+    }
     int size = getDomainLocalXSize(domainId);
     cxios_set_domain_lonvalue_1d(domain, values.data(), &size);
     if (!cxios_is_defined_domain_lonvalue_1d(domain)) {
@@ -634,6 +637,9 @@ void Xios::setDomainLocalYValues(const std::string domainId, std::vector<double>
     xios::CDomain* domain = getDomain(domainId);
     if (cxios_is_defined_domain_latvalue_1d(domain)) {
         Logged::warning("Xios: Overwriting local y-values for domain '" + domainId + "'");
+    }
+    if (!cxios_is_defined_domain_nj(domain)) {
+        setDomainLocalYSize(domainId, values.size());
     }
     int size = getDomainLocalYSize(domainId);
     cxios_set_domain_latvalue_1d(domain, values.data(), &size);

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -1,5 +1,6 @@
 /*!
  * @file    Xios.cpp
+ * @author  Tom Meltzer <tdm39@cam.ac.uk>
  * @author  Joe Wallwork <jw2423@cam.ac.uk>
  * @date    21 August 2024
  * @brief   XIOS interface implementation

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -1,5 +1,6 @@
 /*!
  * @file    Xios.hpp
+ * @author  Tom Meltzer <tdm39@cam.ac.uk>
  * @author  Joe Wallwork <jw2423@cam.ac.uk>
  * @date    21 August 2024
  * @brief   XIOS interface header

--- a/core/src/include/xios_c_interface.hpp
+++ b/core/src/include/xios_c_interface.hpp
@@ -1,7 +1,8 @@
 /*!
  * @file    xios_c_interface.hpp
- * @author  Joe Wallwork <jw2423@cam.ac.uk
- * @date    31 July 2024
+ * @author  Tom Meltzer <tdm39@cam.ac.uk>
+ * @author  Joe Wallwork <jw2423@cam.ac.uk>
+ * @date    5 August 2024
  * @brief   C interface for XIOS library
  * @details
  * This interface is based on an earlier version provided by Laurent as part of

--- a/core/test/XiosAxis_test.cpp
+++ b/core/test/XiosAxis_test.cpp
@@ -54,7 +54,7 @@ MPI_TEST_CASE("TestXiosAxis", 2)
     xios_handler.setAxisSize(axisId, axis_size);
     REQUIRE(xios_handler.getAxisSize(axisId) == axis_size);
     // Axis values
-    std::vector<double> axisValues { 0, 1 };
+    std::vector<double> axisValues { 0.0, 1.0 };
     xios_handler.setAxisValues(axisId, axisValues);
     std::vector<double> axis_A = xios_handler.getAxisValues(axisId);
     REQUIRE(axis_A[0] == doctest::Approx(0));

--- a/core/test/XiosAxis_test.cpp
+++ b/core/test/XiosAxis_test.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file    XiosAxis_test.cpp
- * @author  Joe Wallwork <jw2423@cam.ac.uk
- * @date    26 July 2024
+ * @author  Joe Wallwork <jw2423@cam.ac.uk>
+ * @date    5 August 2024
  * @brief   Tests for XIOS axes
  * @details
  * This test is designed to test axis functionality of the C++ interface

--- a/core/test/XiosCalendar_test.cpp
+++ b/core/test/XiosCalendar_test.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file    XiosCalendar_test.cpp
- * @author  Joe Wallwork <jw2423@cam.ac.uk
- * @date    31 July 2024
+ * @author  Joe Wallwork <jw2423@cam.ac.uk>
+ * @date    5 August 2024
  * @brief   Tests for XIOS calandars
  * @details
  * This test is designed to test calendar functionality of the C++ interface

--- a/core/test/XiosDomain_test.cpp
+++ b/core/test/XiosDomain_test.cpp
@@ -55,48 +55,42 @@ MPI_TEST_CASE("TestXiosDomain", 2)
     const std::string domainType = { "rectilinear" };
     xios_handler.setDomainType(domainId, domainType);
     REQUIRE(xios_handler.getDomainType(domainId) == domainType);
-    // Global longitude size
-    const size_t ni_glo = 60;
-    xios_handler.setDomainGlobalXSize(domainId, ni_glo);
-    REQUIRE(xios_handler.getDomainGlobalXSize(domainId) == ni_glo);
-    // Global latitude size
-    const size_t nj_glo = 20;
-    xios_handler.setDomainGlobalYSize(domainId, nj_glo);
-    REQUIRE(xios_handler.getDomainGlobalYSize(domainId) == nj_glo);
-    // Local longitude size
-    const size_t ni = ni_glo / size;
-    xios_handler.setDomainLocalXSize(domainId, ni);
-    REQUIRE(xios_handler.getDomainLocalXSize(domainId) == ni);
-    // Local latitude size
-    const size_t nj = nj_glo;
-    xios_handler.setDomainLocalYSize(domainId, nj);
-    REQUIRE(xios_handler.getDomainLocalYSize(domainId) == nj);
-    // Local longitude start
-    const size_t startLon = ni * rank;
-    xios_handler.setDomainLocalXStart(domainId, startLon);
-    REQUIRE(xios_handler.getDomainLocalXStart(domainId) == startLon);
-    // Local latitude start
-    const size_t startLat = 0;
-    xios_handler.setDomainLocalYStart(domainId, startLat);
-    REQUIRE(xios_handler.getDomainLocalYStart(domainId) == startLat);
-    // Local longitude values
-    std::vector<double> vx(ni);
-    for (size_t i {}; i < ni; i++) {
-        vx[i] = -180 + (rank * ni * i) * 360 / ni_glo;
-    }
+    // Global number of points in x-direction
+    const size_t nx_glo = 4;
+    xios_handler.setDomainGlobalXSize(domainId, nx_glo);
+    REQUIRE(xios_handler.getDomainGlobalXSize(domainId) == nx_glo);
+    // Global number of points in y-direction
+    const size_t ny_glo = 2;
+    xios_handler.setDomainGlobalYSize(domainId, ny_glo);
+    REQUIRE(xios_handler.getDomainGlobalYSize(domainId) == ny_glo);
+    // Local number of points in x-direction
+    const size_t nx = nx_glo / size;
+    xios_handler.setDomainLocalXSize(domainId, nx);
+    REQUIRE(xios_handler.getDomainLocalXSize(domainId) == nx);
+    // Local number of points in y-direction
+    const size_t ny = ny_glo;
+    xios_handler.setDomainLocalYSize(domainId, ny);
+    REQUIRE(xios_handler.getDomainLocalYSize(domainId) == ny);
+    // Local starting y-index
+    const size_t x0 = nx * rank;
+    xios_handler.setDomainLocalXStart(domainId, x0);
+    REQUIRE(xios_handler.getDomainLocalXStart(domainId) == x0);
+    // Local starting x-index
+    const size_t y0 = 0;
+    xios_handler.setDomainLocalYStart(domainId, y0);
+    REQUIRE(xios_handler.getDomainLocalYStart(domainId) == y0);
+    // Local x-values
+    std::vector<double> vx { -1.0 + rank, -0.5 + rank };
     xios_handler.setDomainLocalXValues(domainId, vx);
     std::vector<double> vxOut = xios_handler.getDomainLocalXValues(domainId);
-    for (size_t i {}; i < ni; i++) {
+    for (size_t i {}; i < nx; i++) {
         REQUIRE(vxOut[i] == doctest::Approx(vx[i]));
     }
-    // Local latitude values
-    std::vector<double> vy(nj);
-    for (size_t j {}; j < nj; j++) {
-        vy[j] = -90 + j * 180 / nj_glo;
-    }
+    // Local y-values
+    std::vector<double> vy { -1, 1 };
     xios_handler.setDomainLocalYValues(domainId, vy);
     std::vector<double> vyOut = xios_handler.getDomainLocalYValues(domainId);
-    for (size_t j {}; j < nj; j++) {
+    for (size_t j {}; j < ny; j++) {
         REQUIRE(vyOut[j] == doctest::Approx(vy[j]));
     }
 

--- a/core/test/XiosDomain_test.cpp
+++ b/core/test/XiosDomain_test.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file    XiosDomain_test.cpp
- * @author  Joe Wallwork <jw2423@cam.ac.uk
- * @date    26 July 2024
+ * @author  Joe Wallwork <jw2423@cam.ac.uk>
+ * @date    5 August 2024
  * @brief   Tests for XIOS domains
  * @details
  * This test is designed to test domain functionality of the C++ interface

--- a/core/test/XiosDomain_test.cpp
+++ b/core/test/XiosDomain_test.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file    XiosDomain_test.cpp
  * @author  Joe Wallwork <jw2423@cam.ac.uk>
- * @date    12 August 2024
+ * @date    21 August 2024
  * @brief   Tests for XIOS domains
  * @details
  * This test is designed to test domain functionality of the C++ interface
@@ -83,14 +83,14 @@ MPI_TEST_CASE("TestXiosDomain", 2)
     std::vector<double> vx { -1.0 + rank, -0.5 + rank };
     xios_handler.setDomainLocalXValues(domainId, vx);
     std::vector<double> vxOut = xios_handler.getDomainLocalXValues(domainId);
-    for (size_t i {}; i < nx; i++) {
+    for (size_t i = 0; i < nx; i++) {
         REQUIRE(vxOut[i] == doctest::Approx(vx[i]));
     }
     // Local y-values
     std::vector<double> vy { -1.0, 1.0 };
     xios_handler.setDomainLocalYValues(domainId, vy);
     std::vector<double> vyOut = xios_handler.getDomainLocalYValues(domainId);
-    for (size_t j {}; j < ny; j++) {
+    for (size_t j = 0; j < ny; j++) {
         REQUIRE(vyOut[j] == doctest::Approx(vy[j]));
     }
 

--- a/core/test/XiosDomain_test.cpp
+++ b/core/test/XiosDomain_test.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file    XiosDomain_test.cpp
  * @author  Joe Wallwork <jw2423@cam.ac.uk>
- * @date    5 August 2024
+ * @date    12 August 2024
  * @brief   Tests for XIOS domains
  * @details
  * This test is designed to test domain functionality of the C++ interface
@@ -20,7 +20,7 @@
 namespace Nextsim {
 
 /*!
- * TestXiosDomin
+ * TestXiosDomain
  *
  * This function tests the domain functionality of the C++ interface for XIOS. It
  * needs to be run with 2 ranks i.e.,
@@ -71,11 +71,11 @@ MPI_TEST_CASE("TestXiosDomain", 2)
     const size_t ny = ny_glo;
     xios_handler.setDomainLocalYSize(domainId, ny);
     REQUIRE(xios_handler.getDomainLocalYSize(domainId) == ny);
-    // Local starting y-index
+    // Local starting x-index
     const size_t x0 = nx * rank;
     xios_handler.setDomainLocalXStart(domainId, x0);
     REQUIRE(xios_handler.getDomainLocalXStart(domainId) == x0);
-    // Local starting x-index
+    // Local starting y-index
     const size_t y0 = 0;
     xios_handler.setDomainLocalYStart(domainId, y0);
     REQUIRE(xios_handler.getDomainLocalYStart(domainId) == y0);

--- a/core/test/XiosDomain_test.cpp
+++ b/core/test/XiosDomain_test.cpp
@@ -80,24 +80,24 @@ MPI_TEST_CASE("TestXiosDomain", 2)
     xios_handler.setDomainLocalYStart(domainId, startLat);
     REQUIRE(xios_handler.getDomainLocalYStart(domainId) == startLat);
     // Local longitude values
-    std::vector<double> vecLon(ni);
-    for (size_t i = 0; i < ni; i++) {
-        vecLon[i] = -180 + (rank * ni * i) * 360 / ni_glo;
+    std::vector<double> vx(ni);
+    for (size_t i {}; i < ni; i++) {
+        vx[i] = -180 + (rank * ni * i) * 360 / ni_glo;
     }
-    xios_handler.setDomainLocalXValues(domainId, vecLon);
-    std::vector<double> vecLonOut = xios_handler.getDomainLocalXValues(domainId);
-    for (size_t i = 0; i < ni; i++) {
-        REQUIRE(vecLonOut[i] == doctest::Approx(vecLon[i]));
+    xios_handler.setDomainLocalXValues(domainId, vx);
+    std::vector<double> vxOut = xios_handler.getDomainLocalXValues(domainId);
+    for (size_t i {}; i < ni; i++) {
+        REQUIRE(vxOut[i] == doctest::Approx(vx[i]));
     }
     // Local latitude values
-    std::vector<double> vecLat(nj);
-    for (size_t j = 0; j < nj; j++) {
-        vecLat[j] = -90 + j * 180 / nj_glo;
+    std::vector<double> vy(nj);
+    for (size_t j {}; j < nj; j++) {
+        vy[j] = -90 + j * 180 / nj_glo;
     }
-    xios_handler.setDomainLocalYValues(domainId, vecLat);
-    std::vector<double> vecLatOut = xios_handler.getDomainLocalYValues(domainId);
-    for (size_t j = 0; j < nj; j++) {
-        REQUIRE(vecLatOut[j] == doctest::Approx(vecLat[j]));
+    xios_handler.setDomainLocalYValues(domainId, vy);
+    std::vector<double> vyOut = xios_handler.getDomainLocalYValues(domainId);
+    for (size_t j {}; j < nj; j++) {
+        REQUIRE(vyOut[j] == doctest::Approx(vy[j]));
     }
 
     xios_handler.close_context_definition();

--- a/core/test/XiosDomain_test.cpp
+++ b/core/test/XiosDomain_test.cpp
@@ -87,7 +87,7 @@ MPI_TEST_CASE("TestXiosDomain", 2)
         REQUIRE(vxOut[i] == doctest::Approx(vx[i]));
     }
     // Local y-values
-    std::vector<double> vy { -1, 1 };
+    std::vector<double> vy { -1.0, 1.0 };
     xios_handler.setDomainLocalYValues(domainId, vy);
     std::vector<double> vyOut = xios_handler.getDomainLocalYValues(domainId);
     for (size_t j {}; j < ny; j++) {

--- a/core/test/XiosField_test.cpp
+++ b/core/test/XiosField_test.cpp
@@ -49,11 +49,11 @@ MPI_TEST_CASE("TestXiosField", 2)
     Duration timestep("P0-0T01:00:00");
     xios_handler.setCalendarTimestep(timestep);
 
-    // Axis setup
+    // Create an axis with two points
     xios_handler.createAxis("axis_A");
     xios_handler.setAxisValues("axis_A", { 0.0, 1.0 });
 
-    // Grid setup
+    // Create a 1D grid comprised of the single axis
     xios_handler.createGrid("grid_1D");
     xios_handler.gridAddAxis("grid_1D", "axis_A");
 

--- a/core/test/XiosField_test.cpp
+++ b/core/test/XiosField_test.cpp
@@ -1,6 +1,6 @@
 /*!
  * @file    XiosField_test.cpp
- * @author  Joe Wallwork <jw2423@cam.ac.uk
+ * @author  Joe Wallwork <jw2423@cam.ac.uk>
  * @date    21 August 2024
  * @brief   Tests for XIOS axes
  * @details

--- a/core/test/XiosField_test.cpp
+++ b/core/test/XiosField_test.cpp
@@ -51,7 +51,7 @@ MPI_TEST_CASE("TestXiosField", 2)
 
     // Axis setup
     xios_handler.createAxis("axis_A");
-    xios_handler.setAxisValues("axis_A", { 0, 1 });
+    xios_handler.setAxisValues("axis_A", { 0.0, 1.0 });
 
     // Grid setup
     xios_handler.createGrid("grid_1D");

--- a/core/test/XiosFile_test.cpp
+++ b/core/test/XiosFile_test.cpp
@@ -53,7 +53,7 @@ MPI_TEST_CASE("TestXiosFile", 2)
 
     // Axis setup
     xios_handler.createAxis("axis_A");
-    xios_handler.setAxisValues("axis_A", { 0, 1 });
+    xios_handler.setAxisValues("axis_A", { 0.0, 1.0 });
 
     // Grid setup
     xios_handler.createGrid("grid_1D");

--- a/core/test/XiosFile_test.cpp
+++ b/core/test/XiosFile_test.cpp
@@ -51,15 +51,15 @@ MPI_TEST_CASE("TestXiosFile", 2)
     Duration timestep("P0-0T01:30:00");
     xios_handler.setCalendarTimestep(timestep);
 
-    // Axis setup
+    // Create a simple axis with two points
     xios_handler.createAxis("axis_A");
     xios_handler.setAxisValues("axis_A", { 0.0, 1.0 });
 
-    // Grid setup
+    // Create a 1D grid comprised of the single axis
     xios_handler.createGrid("grid_1D");
     xios_handler.gridAddAxis("grid_1D", "axis_A");
 
-    // Field setup
+    // Create a field on the 1D grid
     xios_handler.createField("field_A");
     xios_handler.setFieldOperation("field_A", "instant");
     xios_handler.setFieldGridRef("field_A", "grid_1D");

--- a/core/test/XiosGrid_test.cpp
+++ b/core/test/XiosGrid_test.cpp
@@ -66,7 +66,7 @@ MPI_TEST_CASE("TestXiosGrid", 2)
     xios_handler.setDomainLocalYStart("domain_A", 0);
     std::vector<double> vx { -1.0 + rank, -0.5 + rank };
     xios_handler.setDomainLocalXValues("domain_A", vx);
-    std::vector<double> vy { -1, 1 };
+    std::vector<double> vy { -1.0, 1.0 };
     xios_handler.setDomainLocalYValues("domain_A", vy);
 
     // --- Tests for grid API

--- a/core/test/XiosGrid_test.cpp
+++ b/core/test/XiosGrid_test.cpp
@@ -64,16 +64,16 @@ MPI_TEST_CASE("TestXiosGrid", 2)
     xios_handler.setDomainLocalYSize("domain_A", nj);
     xios_handler.setDomainLocalXStart("domain_A", ni * rank);
     xios_handler.setDomainLocalYStart("domain_A", 0);
-    std::vector<double> vecLon(ni);
-    for (size_t i = 0; i < ni; i++) {
-        vecLon[i] = -180 + (rank * ni * i) * 360 / ni_glo;
+    std::vector<double> vx(ni);
+    for (size_t i {}; i < ni; i++) {
+        vx[i] = -180 + (rank * ni * i) * 360 / ni_glo;
     }
-    xios_handler.setDomainLocalXValues("domain_A", vecLon);
-    std::vector<double> vecLat(nj);
-    for (size_t j = 0; j < nj; j++) {
-        vecLat[j] = -90 + j * 180 / nj_glo;
+    xios_handler.setDomainLocalXValues("domain_A", vx);
+    std::vector<double> vy(nj);
+    for (size_t j {}; j < nj; j++) {
+        vy[j] = -90 + j * 180 / nj_glo;
     }
-    xios_handler.setDomainLocalYValues("domain_A", vecLat);
+    xios_handler.setDomainLocalYValues("domain_A", vy);
 
     // --- Tests for grid API
     const std::string gridId = { "grid_2D" };

--- a/core/test/XiosGrid_test.cpp
+++ b/core/test/XiosGrid_test.cpp
@@ -54,20 +54,12 @@ MPI_TEST_CASE("TestXiosGrid", 2)
     // Domain setup
     xios_handler.createDomain("domain_A");
     xios_handler.setDomainType("domain_A", "rectilinear");
-    const size_t nx_glo = 4;
-    xios_handler.setDomainGlobalXSize("domain_A", nx_glo);
-    const size_t ny_glo = 2;
-    xios_handler.setDomainGlobalYSize("domain_A", ny_glo);
-    const size_t nx = nx_glo / size;
-    xios_handler.setDomainLocalXSize("domain_A", nx);
-    const size_t ny = ny_glo;
-    xios_handler.setDomainLocalYSize("domain_A", ny);
-    xios_handler.setDomainLocalXStart("domain_A", nx * rank);
+    xios_handler.setDomainGlobalXSize("domain_A", 4);
+    xios_handler.setDomainGlobalYSize("domain_A", 2);
+    xios_handler.setDomainLocalXStart("domain_A", 2 * rank);
     xios_handler.setDomainLocalYStart("domain_A", 0);
-    std::vector<double> vx { -1.0 + rank, -0.5 + rank };
-    xios_handler.setDomainLocalXValues("domain_A", vx);
-    std::vector<double> vy { -1.0, 1.0 };
-    xios_handler.setDomainLocalYValues("domain_A", vy);
+    xios_handler.setDomainLocalXValues("domain_A", { -1.0 + rank, -0.5 + rank });
+    xios_handler.setDomainLocalYValues("domain_A", { -1.0, 1.0 });
 
     // --- Tests for grid API
     const std::string gridId = { "grid_2D" };

--- a/core/test/XiosGrid_test.cpp
+++ b/core/test/XiosGrid_test.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file    XiosGrid_test.cpp
- * @author  Joe Wallwork <jw2423@cam.ac.uk
- * @date    26 July 2024
+ * @author  Joe Wallwork <jw2423@cam.ac.uk>
+ * @date    5 August 2024
  * @brief   Tests for XIOS axes
  * @details
  * This test is designed to test axis functionality of the C++ interface

--- a/core/test/XiosGrid_test.cpp
+++ b/core/test/XiosGrid_test.cpp
@@ -47,19 +47,19 @@ MPI_TEST_CASE("TestXiosGrid", 2)
     // Set timestep as a minimum
     xios_handler.setCalendarTimestep(Duration("P0-0T01:30:00"));
 
-    // Axis setup
-    xios_handler.createAxis("axis_A");
-    xios_handler.setAxisValues("axis_A", { 0, 1 });
+    // Create a 4x2 horizontal domain with a partition halving the x-extent
+    xios_handler.createDomain("xy_domain");
+    xios_handler.setDomainType("xy_domain", "rectilinear");
+    xios_handler.setDomainGlobalXSize("xy_domain", 4);
+    xios_handler.setDomainGlobalYSize("xy_domain", 2);
+    xios_handler.setDomainLocalXStart("xy_domain", 2 * rank);
+    xios_handler.setDomainLocalYStart("xy_domain", 0);
+    xios_handler.setDomainLocalXValues("xy_domain", { -1.0 + rank, -0.5 + rank });
+    xios_handler.setDomainLocalYValues("xy_domain", { -1.0, 1.0 });
 
-    // Domain setup
-    xios_handler.createDomain("domain_A");
-    xios_handler.setDomainType("domain_A", "rectilinear");
-    xios_handler.setDomainGlobalXSize("domain_A", 4);
-    xios_handler.setDomainGlobalYSize("domain_A", 2);
-    xios_handler.setDomainLocalXStart("domain_A", 2 * rank);
-    xios_handler.setDomainLocalYStart("domain_A", 0);
-    xios_handler.setDomainLocalXValues("domain_A", { -1.0 + rank, -0.5 + rank });
-    xios_handler.setDomainLocalYValues("domain_A", { -1.0, 1.0 });
+    // Create a vertical axis with 2 points
+    xios_handler.createAxis("z_axis");
+    xios_handler.setAxisValues("z_axis", { 0.0, 1.0 });
 
     // --- Tests for grid API
     const std::string gridId = { "grid_2D" };
@@ -69,15 +69,15 @@ MPI_TEST_CASE("TestXiosGrid", 2)
     xios_handler.setGridName(gridId, gridName);
     REQUIRE(xios_handler.getGridName(gridId) == gridName);
     // Add axis
-    xios_handler.gridAddAxis("grid_2D", "axis_A");
+    xios_handler.gridAddAxis("grid_2D", "z_axis");
     std::vector<std::string> axisIds = xios_handler.gridGetAxisIds(gridId);
     REQUIRE(axisIds.size() == 1);
-    REQUIRE(axisIds[0] == "axis_A");
+    REQUIRE(axisIds[0] == "z_axis");
     // Add domain
-    xios_handler.gridAddDomain("grid_2D", "domain_A");
+    xios_handler.gridAddDomain("grid_2D", "xy_domain");
     std::vector<std::string> domainIds = xios_handler.gridGetDomainIds(gridId);
     REQUIRE(domainIds.size() == 1);
-    REQUIRE(domainIds[0] == "domain_A");
+    REQUIRE(domainIds[0] == "xy_domain");
 
     xios_handler.close_context_definition();
     xios_handler.context_finalize();

--- a/core/test/XiosGrid_test.cpp
+++ b/core/test/XiosGrid_test.cpp
@@ -54,25 +54,19 @@ MPI_TEST_CASE("TestXiosGrid", 2)
     // Domain setup
     xios_handler.createDomain("domain_A");
     xios_handler.setDomainType("domain_A", "rectilinear");
-    const size_t ni_glo = 60;
-    xios_handler.setDomainGlobalXSize("domain_A", ni_glo);
-    const size_t nj_glo = 20;
-    xios_handler.setDomainGlobalYSize("domain_A", nj_glo);
-    const size_t ni = ni_glo / size;
-    xios_handler.setDomainLocalXSize("domain_A", ni);
-    const size_t nj = nj_glo;
-    xios_handler.setDomainLocalYSize("domain_A", nj);
-    xios_handler.setDomainLocalXStart("domain_A", ni * rank);
+    const size_t nx_glo = 4;
+    xios_handler.setDomainGlobalXSize("domain_A", nx_glo);
+    const size_t ny_glo = 2;
+    xios_handler.setDomainGlobalYSize("domain_A", ny_glo);
+    const size_t nx = nx_glo / size;
+    xios_handler.setDomainLocalXSize("domain_A", nx);
+    const size_t ny = ny_glo;
+    xios_handler.setDomainLocalYSize("domain_A", ny);
+    xios_handler.setDomainLocalXStart("domain_A", nx * rank);
     xios_handler.setDomainLocalYStart("domain_A", 0);
-    std::vector<double> vx(ni);
-    for (size_t i {}; i < ni; i++) {
-        vx[i] = -180 + (rank * ni * i) * 360 / ni_glo;
-    }
+    std::vector<double> vx { -1.0 + rank, -0.5 + rank };
     xios_handler.setDomainLocalXValues("domain_A", vx);
-    std::vector<double> vy(nj);
-    for (size_t j {}; j < nj; j++) {
-        vy[j] = -90 + j * 180 / nj_glo;
-    }
+    std::vector<double> vy { -1, 1 };
     xios_handler.setDomainLocalYValues("domain_A", vy);
 
     // --- Tests for grid API

--- a/core/test/XiosWrite_test.cpp
+++ b/core/test/XiosWrite_test.cpp
@@ -52,7 +52,7 @@ MPI_TEST_CASE("TestXiosWrite", 2)
     xios_handler.setCalendarStart(TimePoint("2023-03-17T17:11:00Z"));
     xios_handler.setCalendarTimestep(Duration("P0-0T01:30:00"));
 
-    // Domain setup
+    // Create a 4x2 horizontal domain with a partition halving the x-extent
     xios_handler.createDomain("xy_domain");
     xios_handler.setDomainType("xy_domain", "rectilinear");
     xios_handler.setDomainGlobalXSize("xy_domain", 4);
@@ -62,18 +62,18 @@ MPI_TEST_CASE("TestXiosWrite", 2)
     xios_handler.setDomainLocalXValues("xy_domain", { -1.0 + rank, -0.5 + rank });
     xios_handler.setDomainLocalYValues("xy_domain", { -1.0, 1.0 });
 
-    // Axis setup
+    // Create a vertical axis with 2 points
     xios_handler.createAxis("z_axis");
     xios_handler.setAxisValues("z_axis", { 0.0, 1.0 });
 
-    // Grid setup
+    // Create a 2D grid comprised of the xy-domain and a 3D grid which also includes the z-axis
     xios_handler.createGrid("grid_2D");
     xios_handler.gridAddDomain("grid_2D", "xy_domain");
     xios_handler.createGrid("grid_3D");
     xios_handler.gridAddDomain("grid_3D", "xy_domain");
     xios_handler.gridAddAxis("grid_3D", "z_axis");
 
-    // Field setup
+    // Create fields on the two grids
     xios_handler.createField("field_2D");
     xios_handler.setFieldOperation("field_2D", "instant");
     xios_handler.setFieldGridRef("field_2D", "grid_2D");
@@ -83,7 +83,7 @@ MPI_TEST_CASE("TestXiosWrite", 2)
     xios_handler.setFieldGridRef("field_3D", "grid_3D");
     xios_handler.setFieldReadAccess("field_3D", false);
 
-    // File setup
+    // Create an output file to hold data from both fields
     xios_handler.createFile("xios_test_output");
     xios_handler.setFileType("xios_test_output", "one_file");
     xios_handler.setFileOutputFreq("xios_test_output", Duration("P0-0T01:30:00"));

--- a/core/test/XiosWrite_test.cpp
+++ b/core/test/XiosWrite_test.cpp
@@ -55,25 +55,15 @@ MPI_TEST_CASE("TestXiosWrite", 2)
     // Domain setup
     xios_handler.createDomain("xy_domain");
     xios_handler.setDomainType("xy_domain", "rectilinear");
-    const size_t nx_glo { 4 };
-    xios_handler.setDomainGlobalXSize("xy_domain", nx_glo);
-    const size_t ny_glo { 2 };
-    xios_handler.setDomainGlobalYSize("xy_domain", ny_glo);
-    const size_t nx { nx_glo / size };
-    xios_handler.setDomainLocalXSize("xy_domain", nx);
-    const size_t ny { ny_glo };
-    xios_handler.setDomainLocalYSize("xy_domain", ny);
-    xios_handler.setDomainLocalXStart("xy_domain", nx * rank);
+    xios_handler.setDomainGlobalXSize("xy_domain", 4);
+    xios_handler.setDomainGlobalYSize("xy_domain", 2);
+    xios_handler.setDomainLocalXStart("xy_domain", 2 * rank);
     xios_handler.setDomainLocalYStart("xy_domain", 0);
-    std::vector<double> vx { -1.0 + rank, -0.5 + rank };
-    xios_handler.setDomainLocalXValues("xy_domain", vx);
-    std::vector<double> vy { -1.0, 1.0 };
-    xios_handler.setDomainLocalYValues("xy_domain", vy);
+    xios_handler.setDomainLocalXValues("xy_domain", { -1.0 + rank, -0.5 + rank });
+    xios_handler.setDomainLocalYValues("xy_domain", { -1.0, 1.0 });
 
     // Axis setup
-    const int nz = 2;
     xios_handler.createAxis("z_axis");
-    xios_handler.setAxisSize("z_axis", nz);
     xios_handler.setAxisValues("z_axis", { 0.0, 1.0 });
 
     // Grid setup
@@ -106,8 +96,11 @@ MPI_TEST_CASE("TestXiosWrite", 2)
 
     // --- Tests for writing to file
     Module::setImplementation<IStructure>("Nextsim::ParametricGrid");
-    ModelArray::setDimension(ModelArray::Dimension::X, nx, nx, 0);
-    ModelArray::setDimension(ModelArray::Dimension::Y, ny, ny, 0);
+    const size_t nx = xios_handler.getDomainLocalXSize("xy_domain");
+    const size_t ny = xios_handler.getDomainLocalYSize("xy_domain");
+    const size_t nz = xios_handler.getAxisSize("z_axis");
+    ModelArray::setDimension(ModelArray::Dimension::X, xios_handler.getDomainGlobalXSize("xy_domain"), nx, 0);
+    ModelArray::setDimension(ModelArray::Dimension::Y, xios_handler.getDomainGlobalYSize("xy_domain"), ny, 0);
     ModelArray::setDimension(ModelArray::Dimension::Z, nz, nz, 0);
     // Create some fake data to test writing methods
     HField field_2D(ModelArray::Type::H);

--- a/core/test/XiosWrite_test.cpp
+++ b/core/test/XiosWrite_test.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file    XiosWrite_test.cpp
  * @author  Joe Wallwork <jw2423@cam.ac.uk>
- * @date    5 August 2024
+ * @date    21 August 2024
  * @brief   Tests for XIOS write method
  * @details
  * This test is designed to test the write method of the C++ interface
@@ -52,37 +52,36 @@ MPI_TEST_CASE("TestXiosWrite", 2)
     xios_handler.setCalendarStart(TimePoint("2023-03-17T17:11:00Z"));
     xios_handler.setCalendarTimestep(Duration("P0-0T01:30:00"));
 
+    // Domain setup
+    xios_handler.createDomain("xy_domain");
+    xios_handler.setDomainType("xy_domain", "rectilinear");
+    const size_t nx_glo { 4 };
+    xios_handler.setDomainGlobalXSize("xy_domain", nx_glo);
+    const size_t ny_glo { 2 };
+    xios_handler.setDomainGlobalYSize("xy_domain", ny_glo);
+    const size_t nx { nx_glo / size };
+    xios_handler.setDomainLocalXSize("xy_domain", nx);
+    const size_t ny { ny_glo };
+    xios_handler.setDomainLocalYSize("xy_domain", ny);
+    xios_handler.setDomainLocalXStart("xy_domain", nx * rank);
+    xios_handler.setDomainLocalYStart("xy_domain", 0);
+    std::vector<double> vx { -1.0 + rank, -0.5 + rank };
+    xios_handler.setDomainLocalXValues("xy_domain", vx);
+    std::vector<double> vy { -1.0, 1.0 };
+    xios_handler.setDomainLocalYValues("xy_domain", vy);
+
     // Axis setup
-    const int n1 = 2;
-    const int n2 = 3;
-    const int n3 = 4;
-    const int n4 = 5;
-    xios_handler.createAxis("axis_A");
-    xios_handler.setAxisSize("axis_A", n1);
-    xios_handler.setAxisValues("axis_A", { 0, 1 });
-    xios_handler.createAxis("axis_B");
-    xios_handler.setAxisSize("axis_B", n2);
-    xios_handler.setAxisValues("axis_B", { 0, 1, 2 });
-    xios_handler.createAxis("axis_C");
-    xios_handler.setAxisSize("axis_C", n3);
-    xios_handler.setAxisValues("axis_C", { 0, 1, 2, 3 });
-    xios_handler.createAxis("axis_D");
-    xios_handler.setAxisSize("axis_D", n4);
-    xios_handler.setAxisValues("axis_D", { 0, 1, 2, 3, 4 });
+    const int nz = 2;
+    xios_handler.createAxis("z_axis");
+    xios_handler.setAxisSize("z_axis", nz);
+    xios_handler.setAxisValues("z_axis", { 0.0, 1.0 });
 
     // Grid setup
     xios_handler.createGrid("grid_2D");
-    xios_handler.gridAddAxis("grid_2D", "axis_A");
-    xios_handler.gridAddAxis("grid_2D", "axis_B");
+    xios_handler.gridAddDomain("grid_2D", "xy_domain");
     xios_handler.createGrid("grid_3D");
-    xios_handler.gridAddAxis("grid_3D", "axis_A");
-    xios_handler.gridAddAxis("grid_3D", "axis_B");
-    xios_handler.gridAddAxis("grid_3D", "axis_C");
-    xios_handler.createGrid("grid_4D");
-    xios_handler.gridAddAxis("grid_4D", "axis_A");
-    xios_handler.gridAddAxis("grid_4D", "axis_B");
-    xios_handler.gridAddAxis("grid_4D", "axis_C");
-    xios_handler.gridAddAxis("grid_4D", "axis_D");
+    xios_handler.gridAddDomain("grid_3D", "xy_domain");
+    xios_handler.gridAddAxis("grid_3D", "z_axis");
 
     // Field setup
     xios_handler.createField("field_2D");
@@ -93,10 +92,6 @@ MPI_TEST_CASE("TestXiosWrite", 2)
     xios_handler.setFieldOperation("field_3D", "instant");
     xios_handler.setFieldGridRef("field_3D", "grid_3D");
     xios_handler.setFieldReadAccess("field_3D", false);
-    xios_handler.createField("field_4D");
-    xios_handler.setFieldOperation("field_4D", "instant");
-    xios_handler.setFieldGridRef("field_4D", "grid_4D");
-    xios_handler.setFieldReadAccess("field_4D", false);
 
     // File setup
     xios_handler.createFile("xios_test_output");
@@ -106,33 +101,31 @@ MPI_TEST_CASE("TestXiosWrite", 2)
     xios_handler.setFileMode("xios_test_output", "write");
     xios_handler.fileAddField("xios_test_output", "field_2D");
     xios_handler.fileAddField("xios_test_output", "field_3D");
-    xios_handler.fileAddField("xios_test_output", "field_4D");
 
     xios_handler.close_context_definition();
 
     // --- Tests for writing to file
     Module::setImplementation<IStructure>("Nextsim::ParametricGrid");
-    ModelArray::setDimension(ModelArray::Dimension::X, n1, n1, 0);
-    ModelArray::setDimension(ModelArray::Dimension::Y, n2, n2, 0);
-    ModelArray::setDimension(ModelArray::Dimension::Z, n3, n3, 0);
+    ModelArray::setDimension(ModelArray::Dimension::X, nx, nx, 0);
+    ModelArray::setDimension(ModelArray::Dimension::Y, ny, ny, 0);
+    ModelArray::setDimension(ModelArray::Dimension::Z, nz, nz, 0);
     // Create some fake data to test writing methods
     HField field_2D(ModelArray::Type::H);
     field_2D.resize();
-    for (size_t j = 0; j < n2; ++j) {
-        for (size_t i = 0; i < n1; ++i) {
-            field_2D(i, j) = 1.0 * (i + n1 * j);
+    for (size_t j = 0; j < ny; ++j) {
+        for (size_t i = 0; i < nx; ++i) {
+            field_2D(i, j) = 1.0 * (i + nx * j);
         }
     }
     HField field_3D(ModelArray::Type::Z);
     field_3D.resize();
-    for (size_t k = 0; k < n3; ++k) {
-        for (size_t j = 0; j < n2; ++j) {
-            for (size_t i = 0; i < n1; ++i) {
-                field_3D(i, j, k) = 1.0 * (i + n1 * (j + n2 * k));
+    for (size_t k = 0; k < nz; ++k) {
+        for (size_t j = 0; j < ny; ++j) {
+            for (size_t i = 0; i < nx; ++i) {
+                field_3D(i, j, k) = 1.0 * (i + nx * (j + ny * k));
             }
         }
     }
-    // TODO: Implement 4D case
     // Verify calendar step is starting from zero
     REQUIRE(xios_handler.getCalendarStep() == 0);
     // Check a file with the expected name doesn't exist yet
@@ -144,7 +137,6 @@ MPI_TEST_CASE("TestXiosWrite", 2)
         // Send data to XIOS to be written to disk
         xios_handler.write("field_2D", field_2D);
         xios_handler.write("field_3D", field_3D);
-        // TODO: Implement 4D case
         // Verify timestep
         REQUIRE(xios_handler.getCalendarStep() == ts);
     }
@@ -156,5 +148,7 @@ MPI_TEST_CASE("TestXiosWrite", 2)
         std::filesystem::remove("xios_test_output_20230317201100-20230317231059.nc");
     }
     xios_handler.context_finalize();
+
+    // TODO: Consider adding a 4D test case
 }
 }


### PR DESCRIPTION
# XIOS: use Domain for xy-plane and Axis for z
## Fixes #634

### Task List
- [x] Defined the tests that specify a complete and functioning change (*It may help to create a [design specification & test specification](../../../wiki/Specification-Template)*)
- [x] Implemented the source code change that satisfies the tests
- [x] Documented the feature by providing worked example
- [x] Updated the README or other documentation
- [x] Completed the pre-Request checklist below

---
# Change Description

I gather the intention is to parallelise nextSIM-DG in the horizontal domain. As such, it makes sense to set the XIOS tests up such that they use a Domain in the horizontal (which supports MPI parallelisation) and an Axis in the vertical ~~(which does not)~~ (see discussion below).

A minor piece of new functionality is that it's now possible to deduce the local sizes of a domain when setting the values i.e., you can call `setDomainLocalXValues` without having set `setDomainLocalXSize` (and similarly for Y).

---
# Test Description

Tests are updated as above, along with some other minor improvements:
* Use `{}` initialisation, as discussed in #554.
* Simplified domains.
* Purged all mention of latitude and longitude.
* More concise notation.
* Clearer comments on what's actually being set up in the tests.

---
### Pre-Request Checklist

- [x] The requirements of this pull request are fully captured in an issue or design specification and are linked and summarised in the description of this PR
- [x] No new warnings are generated
- [x] The documentation has been updated (or an issue has been created to track the corresponding change)
- [x] Methods and Tests are commented such that they can be understood without having to obtain additional context
- [x] This PR/Issue is labelled as a bug/feature/enhancement/breaking change
- [x] File dates have been updated to reflect modification date
- [x] This change conforms to the conventions described in the README
