### PR TITLE
XIOS duration handling

### DIFF
--- a/core/src/Time.cpp
+++ b/core/src/Time.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file Time.cpp
  *
- * @date Jun 7, 2022
+ * @date 5 August, 2024
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 
@@ -66,15 +66,19 @@ int julianGregorianShiftDays(int year)
     return -leaps;
 }
 
-bool isDOYFormat(const std::string& iso)
+bool isYMDFormat(const std::string& iso)
 {
     const std::regex ymd("^\\d+-\\d+-\\d+($|T)"); // Search for the month
+    return std::regex_search(iso, ymd);
+}
+
+bool isDOYFormat(const std::string& iso)
+{
     const std::regex doy("^\\d+-\\d+($|T)"); // Search for the day of year
 
-    bool isYMD = std::regex_search(iso, ymd);
     bool isDOY = std::regex_search(iso, doy);
 
-    if (!isYMD && !isDOY)
+    if (!isYMDFormat(iso) && !isDOY)
         throw std::invalid_argument("Unrecognized date format: " + iso);
 
     if (TimeOptions::useDOY() && !isDOY)
@@ -157,6 +161,10 @@ std::time_t timeFromISO(std::istream& is)
 
 Duration durationFromISO(const std::string& iso, int sign = +1)
 {
+    if (isYMDFormat(iso)) {
+        throw std::invalid_argument(
+            "Duration does not accept months as they have arbitrary length");
+    }
     bool isDOY = isDOYFormat(iso);
     std::tm tm = getTimTime(iso, isDOY);
     // Make up the time duration, analogously to mkgmtime()

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file    Xios.cpp
- * @author  Joe Wallwork <jw2423@cam.ac.uk
- * @date    31 July 2024
+ * @author  Joe Wallwork <jw2423@cam.ac.uk>
+ * @date    5 August 2024
  * @brief   XIOS interface implementation
  * @details
  *

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -204,6 +204,17 @@ Duration Xios::convertDurationFromXios(const cxios_duration duration)
 }
 
 /*!
+ * Convert a nextSIM-DG duration object into an XIOS one.
+ *
+ * @param nextSIM-DG duration object
+ * @return XIOS version
+ */
+cxios_duration Xios::convertDurationToXios(const Duration duration)
+{
+    return cxios_duration({ 0.0, 0.0, 0.0, 0.0, 0.0, duration.seconds() });
+}
+
+/*!
  * Set calendar origin
  *
  * @param origin
@@ -232,8 +243,7 @@ void Xios::setCalendarStart(const TimePoint start)
  */
 void Xios::setCalendarTimestep(const Duration timestep)
 {
-    cxios_duration duration { 0.0, 0.0, 0.0, 0.0, 0.0, timestep.seconds() };
-    cxios_set_calendar_wrapper_timestep(clientCalendar, duration);
+    cxios_set_calendar_wrapper_timestep(clientCalendar, convertDurationToXios(timestep));
     cxios_update_calendar_timestep(clientCalendar);
 }
 
@@ -1193,8 +1203,7 @@ void Xios::setFileOutputFreq(const std::string fileId, Duration freq)
     if (cxios_is_defined_file_output_freq(file)) {
         Logged::warning("Xios: Overwriting output frequency for file '" + fileId + "'");
     }
-    cxios_duration duration { 0.0, 0.0, 0.0, 0.0, 0.0, freq.seconds() };
-    cxios_set_file_output_freq(file, duration);
+    cxios_set_file_output_freq(file, convertDurationToXios(freq));
     if (!cxios_is_defined_file_output_freq(file)) {
         throw std::runtime_error("Xios: Failed to set output frequency for file '" + fileId + "'");
     }
@@ -1212,8 +1221,7 @@ void Xios::setFileSplitFreq(const std::string fileId, Duration freq)
     if (cxios_is_defined_file_split_freq(file)) {
         Logged::warning("Xios: Split frequency already set for file '" + fileId + "'");
     }
-    cxios_duration duration { 0.0, 0.0, 0.0, 0.0, 0.0, freq.seconds() };
-    cxios_set_file_split_freq(file, duration);
+    cxios_set_file_split_freq(file, convertDurationToXios(freq));
     if (!cxios_is_defined_file_split_freq(file)) {
         throw std::runtime_error("Xios: Failed to set split frequency for file '" + fileId + "'");
     }

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -175,6 +175,20 @@ cxios_date Xios::convertStringToXiosDatetime(const std::string datetimeStr, cons
 }
 
 /*!
+ * Convert a C-string to a C++ `std::string`.
+ *
+ * @param C-string
+ * @param length of C-string
+ * @return C++ string version
+ */
+std::string Xios::convertCStrToCppStr(const char* cStr, int cStrLen)
+{
+    std::string cppStr(cStr, cStrLen);
+    boost::algorithm::trim_right(cppStr);
+    return cppStr;
+}
+
+/*!
  * Set calendar origin
  *
  * @param origin
@@ -217,9 +231,7 @@ std::string Xios::getCalendarType()
 {
     char cStr[cStrLen];
     cxios_get_calendar_wrapper_type(clientCalendar, cStr, cStrLen);
-    std::string calendarType(cStr, cStrLen);
-    boost::algorithm::trim_right(calendarType);
-    return calendarType;
+    return convertCStrToCppStr(cStr, cStrLen);
 }
 
 /*!
@@ -257,8 +269,7 @@ Duration Xios::getCalendarTimestep()
     cxios_get_calendar_wrapper_timestep(clientCalendar, &calendar_timestep);
     char cStr[cStrLen];
     cxios_duration_convert_to_string(calendar_timestep, cStr, cStrLen);
-    std::string durationStr(cStr, cStrLen);
-    boost::algorithm::trim_right(durationStr);
+    std::string durationStr = convertCStrToCppStr(cStr, cStrLen);
     boost::erase_all(durationStr, "s");
     return Duration(std::stod(durationStr));
 }
@@ -643,9 +654,7 @@ std::string Xios::getDomainType(const std::string domainId)
     }
     char cStr[cStrLen];
     cxios_get_domain_type(domain, cStr, cStrLen);
-    std::string domainType(cStr, cStrLen);
-    boost::algorithm::trim_right(domainType);
-    return domainType;
+    return convertCStrToCppStr(cStr, cStrLen);
 }
 
 /*!
@@ -852,9 +861,7 @@ std::string Xios::getGridName(const std::string gridId)
     }
     char cStr[cStrLen];
     cxios_get_grid_name(grid, cStr, cStrLen);
-    std::string gridName(cStr, cStrLen);
-    boost::algorithm::trim_right(gridName);
-    return gridName;
+    return convertCStrToCppStr(cStr, cStrLen);
 }
 
 /*!
@@ -1035,9 +1042,7 @@ std::string Xios::getFieldName(const std::string fieldId)
     }
     char cStr[cStrLen];
     cxios_get_field_name(field, cStr, cStrLen);
-    std::string fieldName(cStr, cStrLen);
-    boost::algorithm::trim_right(fieldName);
-    return fieldName;
+    return convertCStrToCppStr(cStr, cStrLen);
 }
 
 /*!
@@ -1054,9 +1059,7 @@ std::string Xios::getFieldOperation(const std::string fieldId)
     }
     char cStr[cStrLen];
     cxios_get_field_operation(field, cStr, cStrLen);
-    std::string operation(cStr, cStrLen);
-    boost::algorithm::trim_right(operation);
-    return operation;
+    return convertCStrToCppStr(cStr, cStrLen);
 }
 
 /*!
@@ -1073,9 +1076,7 @@ std::string Xios::getFieldGridRef(const std::string fieldId)
     }
     char cStr[cStrLen];
     cxios_get_field_grid_ref(field, cStr, cStrLen);
-    std::string gridRef(cStr, cStrLen);
-    boost::algorithm::trim_right(gridRef);
-    return gridRef;
+    return convertCStrToCppStr(cStr, cStrLen);
 }
 
 /*!
@@ -1221,9 +1222,7 @@ std::string Xios::getFileName(const std::string fileId)
     }
     char cStr[cStrLen];
     cxios_get_file_name(file, cStr, cStrLen);
-    std::string fileName(cStr, cStrLen);
-    boost::algorithm::trim_right(fileName);
-    return fileName;
+    return convertCStrToCppStr(cStr, cStrLen);
 }
 
 /*!
@@ -1240,9 +1239,7 @@ std::string Xios::getFileType(const std::string fileId)
     }
     char cStr[cStrLen];
     cxios_get_file_type(file, cStr, cStrLen);
-    std::string fileType(cStr, cStrLen);
-    boost::algorithm::trim_right(fileType);
-    return fileType;
+    return convertCStrToCppStr(cStr, cStrLen);
 }
 
 /*!
@@ -1261,8 +1258,7 @@ Duration Xios::getFileOutputFreq(const std::string fileId)
     cxios_get_file_output_freq(file, &duration);
     char cStr[cStrLen];
     cxios_duration_convert_to_string(duration, cStr, cStrLen);
-    std::string freq(cStr, cStrLen);
-    boost::algorithm::trim_right(freq);
+    std::string freq = convertCStrToCppStr(cStr, cStrLen);
     boost::erase_all(freq, "s");
     return Duration(std::stod(freq));
 }
@@ -1283,8 +1279,7 @@ Duration Xios::getFileSplitFreq(const std::string fileId)
     cxios_get_file_split_freq(file, &duration);
     char cStr[cStrLen];
     cxios_duration_convert_to_string(duration, cStr, cStrLen);
-    std::string freq(cStr, cStrLen);
-    boost::algorithm::trim_right(freq);
+    std::string freq = convertCStrToCppStr(cStr, cStrLen);
     boost::erase_all(freq, "s");
     return Duration(std::stod(freq));
 }

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -189,6 +189,21 @@ std::string Xios::convertCStrToCppStr(const char* cStr, int cStrLen)
 }
 
 /*!
+ * Convert an XIOS duration object into a nextSIM-DG one.
+ *
+ * @param XIOS duration object
+ * @return nextSIM-DG version
+ */
+Duration Xios::convertDurationFromXios(const cxios_duration duration)
+{
+    char cStr[cStrLen];
+    cxios_duration_convert_to_string(duration, cStr, cStrLen);
+    std::string durationStr = convertCStrToCppStr(cStr, cStrLen);
+    boost::erase_all(durationStr, "s");
+    return Duration(std::stod(durationStr));
+}
+
+/*!
  * Set calendar origin
  *
  * @param origin
@@ -267,11 +282,7 @@ Duration Xios::getCalendarTimestep()
 {
     cxios_duration calendar_timestep;
     cxios_get_calendar_wrapper_timestep(clientCalendar, &calendar_timestep);
-    char cStr[cStrLen];
-    cxios_duration_convert_to_string(calendar_timestep, cStr, cStrLen);
-    std::string durationStr = convertCStrToCppStr(cStr, cStrLen);
-    boost::erase_all(durationStr, "s");
-    return Duration(std::stod(durationStr));
+    return convertDurationFromXios(calendar_timestep);
 }
 
 /*!
@@ -1256,11 +1267,7 @@ Duration Xios::getFileOutputFreq(const std::string fileId)
     }
     cxios_duration duration;
     cxios_get_file_output_freq(file, &duration);
-    char cStr[cStrLen];
-    cxios_duration_convert_to_string(duration, cStr, cStrLen);
-    std::string freq = convertCStrToCppStr(cStr, cStrLen);
-    boost::erase_all(freq, "s");
-    return Duration(std::stod(freq));
+    return convertDurationFromXios(duration);
 }
 
 /*!
@@ -1277,11 +1284,7 @@ Duration Xios::getFileSplitFreq(const std::string fileId)
     }
     cxios_duration duration;
     cxios_get_file_split_freq(file, &duration);
-    char cStr[cStrLen];
-    cxios_duration_convert_to_string(duration, cStr, cStrLen);
-    std::string freq = convertCStrToCppStr(cStr, cStrLen);
-    boost::erase_all(freq, "s");
-    return Duration(std::stod(freq));
+    return convertDurationFromXios(duration);
 }
 
 /*!

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -1175,14 +1175,14 @@ void Xios::setFileType(const std::string fileId, const std::string fileType)
  * @param the file ID
  * @param output frequency to set
  */
-void Xios::setFileOutputFreq(const std::string fileId, const std::string freq)
+void Xios::setFileOutputFreq(const std::string fileId, Duration freq)
 {
     xios::CFile* file = getFile(fileId);
     if (cxios_is_defined_file_output_freq(file)) {
         Logged::warning("Xios: Overwriting output frequency for file '" + fileId + "'");
     }
-    cxios_set_file_output_freq(
-        file, cxios_duration_convert_from_string(freq.c_str(), freq.length()));
+    cxios_duration duration { 0.0, 0.0, 0.0, 0.0, 0.0, freq.seconds() };
+    cxios_set_file_output_freq(file, duration);
     if (!cxios_is_defined_file_output_freq(file)) {
         throw std::runtime_error("Xios: Failed to set output frequency for file '" + fileId + "'");
     }
@@ -1194,14 +1194,14 @@ void Xios::setFileOutputFreq(const std::string fileId, const std::string freq)
  * @param the file ID
  * @param split frequency to set
  */
-void Xios::setFileSplitFreq(const std::string fileId, const std::string freq)
+void Xios::setFileSplitFreq(const std::string fileId, Duration freq)
 {
     xios::CFile* file = getFile(fileId);
     if (cxios_is_defined_file_split_freq(file)) {
         Logged::warning("Xios: Split frequency already set for file '" + fileId + "'");
     }
-    cxios_set_file_split_freq(
-        file, cxios_duration_convert_from_string(freq.c_str(), freq.length()));
+    cxios_duration duration { 0.0, 0.0, 0.0, 0.0, 0.0, freq.seconds() };
+    cxios_set_file_split_freq(file, duration);
     if (!cxios_is_defined_file_split_freq(file)) {
         throw std::runtime_error("Xios: Failed to set split frequency for file '" + fileId + "'");
     }
@@ -1251,7 +1251,7 @@ std::string Xios::getFileType(const std::string fileId)
  * @param the file ID
  * @return the corresponding output frequency
  */
-std::string Xios::getFileOutputFreq(const std::string fileId)
+Duration Xios::getFileOutputFreq(const std::string fileId)
 {
     xios::CFile* file = getFile(fileId);
     if (!cxios_is_defined_file_output_freq(file)) {
@@ -1261,9 +1261,10 @@ std::string Xios::getFileOutputFreq(const std::string fileId)
     cxios_get_file_output_freq(file, &duration);
     char cStr[cStrLen];
     cxios_duration_convert_to_string(duration, cStr, cStrLen);
-    std::string outputFreq(cStr, cStrLen);
-    boost::algorithm::trim_right(outputFreq);
-    return outputFreq;
+    std::string freq(cStr, cStrLen);
+    boost::algorithm::trim_right(freq);
+    boost::erase_all(freq, "s");
+    return Duration(std::stod(freq));
 }
 
 /*!
@@ -1272,7 +1273,7 @@ std::string Xios::getFileOutputFreq(const std::string fileId)
  * @param the file ID
  * @return split frequency of the corresponding file
  */
-std::string Xios::getFileSplitFreq(const std::string fileId)
+Duration Xios::getFileSplitFreq(const std::string fileId)
 {
     xios::CFile* file = getFile(fileId);
     if (!cxios_is_defined_file_split_freq(file)) {
@@ -1284,7 +1285,8 @@ std::string Xios::getFileSplitFreq(const std::string fileId)
     cxios_duration_convert_to_string(duration, cStr, cStrLen);
     std::string freq(cStr, cStrLen);
     boost::algorithm::trim_right(freq);
-    return freq;
+    boost::erase_all(freq, "s");
+    return Duration(std::stod(freq));
 }
 
 /*!

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -1,7 +1,7 @@
 /*!
  * @file    Xios.hpp
- * @author  Joe Wallwork <jw2423@cam.ac.uk
- * @date    31 July 2024
+ * @author  Joe Wallwork <jw2423@cam.ac.uk>
+ * @date    5 August 2024
  * @brief   XIOS interface header
  * @details
  *

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -144,6 +144,7 @@ private:
     xios::CCalendarWrapper* clientCalendar;
     std::string convertXiosDatetimeToString(const cxios_date datetime, const bool isoFormat = true);
     cxios_date convertStringToXiosDatetime(const std::string datetime, const bool isoFormat = true);
+    std::string convertCStrToCppStr(const char* cStr, int cStrLen);
 
     xios::CAxisGroup* getAxisGroup();
     xios::CDomainGroup* getDomainGroup();

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -145,6 +145,7 @@ private:
     std::string convertXiosDatetimeToString(const cxios_date datetime, const bool isoFormat = true);
     cxios_date convertStringToXiosDatetime(const std::string datetime, const bool isoFormat = true);
     std::string convertCStrToCppStr(const char* cStr, int cStrLen);
+    Duration convertDurationFromXios(const cxios_duration duration);
 
     xios::CAxisGroup* getAxisGroup();
     xios::CDomainGroup* getDomainGroup();

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -146,6 +146,7 @@ private:
     cxios_date convertStringToXiosDatetime(const std::string datetime, const bool isoFormat = true);
     std::string convertCStrToCppStr(const char* cStr, int cStrLen);
     Duration convertDurationFromXios(const cxios_duration duration);
+    cxios_duration convertDurationToXios(const Duration duration);
 
     xios::CAxisGroup* getAxisGroup();
     xios::CDomainGroup* getDomainGroup();

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -108,12 +108,12 @@ public:
     void createFile(const std::string fileId);
     void setFileName(const std::string fileId, const std::string fileName);
     void setFileType(const std::string fileId, const std::string fileType);
-    void setFileOutputFreq(const std::string fileId, const std::string outputFreq);
-    void setFileSplitFreq(const std::string fileId, const std::string splitFreq);
+    void setFileOutputFreq(const std::string fileId, Duration outputFreq);
+    void setFileSplitFreq(const std::string fileId, Duration splitFreq);
     std::string getFileName(const std::string fileId);
     std::string getFileType(const std::string fileId);
-    std::string getFileOutputFreq(const std::string fileId);
-    std::string getFileSplitFreq(const std::string fileId);
+    Duration getFileOutputFreq(const std::string fileId);
+    Duration getFileSplitFreq(const std::string fileId);
     void fileAddField(const std::string fileId, const std::string fieldId);
     std::vector<std::string> fileGetFieldIds(const std::string fileId);
 

--- a/core/test/Time_test.cpp
+++ b/core/test/Time_test.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file Time_test.cpp
  *
- * @date Jun 7, 2022
+ * @date 5 August, 2024
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 
@@ -164,6 +164,7 @@ TEST_CASE("Durations")
     Duration dur;
     // Basic values
     REQUIRE_THROWS(dur.parse("0-0-0T0:0:1"));
+    REQUIRE_THROWS(dur.parse("P0-1-0T0:0:0"));
     REQUIRE_THROWS(dur.parse(""));
     REQUIRE(dur.parse("P0-1").seconds() == 1 * days);
     REQUIRE(dur.parse("P0-0T0:0:1").seconds() == 1);

--- a/core/test/XiosFile_test.cpp
+++ b/core/test/XiosFile_test.cpp
@@ -77,10 +77,10 @@ MPI_TEST_CASE("TestXiosFile", 2)
     REQUIRE(xios_handler.getFileType(fileId) == fileType);
     // Output frequency
     xios_handler.setFileOutputFreq(fileId, timestep);
-    REQUIRE(xios_handler.getFileOutputFreq(fileId).seconds() == Approx(1.5 * 60 * 60));
+    REQUIRE(xios_handler.getFileOutputFreq(fileId).seconds() == 1.5 * 60 * 60);
     // Split frequency
     xios_handler.setFileSplitFreq(fileId, timestep);
-    REQUIRE(xios_handler.getFileSplitFreq(fileId).seconds() == Approx(1.5 * 60 * 60));
+    REQUIRE(xios_handler.getFileSplitFreq(fileId).seconds() == 1.5 * 60 * 60);
     // Add field
     xios_handler.fileAddField(fileId, "field_A");
     std::vector<std::string> fieldIds = xios_handler.fileGetFieldIds(fileId);
@@ -93,28 +93,28 @@ MPI_TEST_CASE("TestXiosFile", 2)
     xios_handler.createFile("year");
     xios_handler.setFileOutputFreq("year", Duration("P1-0T00:00:00"));
     xios_handler.setFileSplitFreq("year", Duration("P2-0T00:00:00"));
-    REQUIRE(xios_handler.getFileOutputFreq("year").seconds() == Approx(365 * 24 * 60 * 60));
-    REQUIRE(xios_handler.getFileSplitFreq("year").seconds() == Approx(2 * 365 * 24 * 60 * 60));
+    REQUIRE(xios_handler.getFileOutputFreq("year").seconds() == 365 * 24 * 60 * 60);
+    REQUIRE(xios_handler.getFileSplitFreq("year").seconds() == 2 * 365 * 24 * 60 * 60);
     xios_handler.createFile("day");
     xios_handler.setFileOutputFreq("day", Duration("P0-1T00:00:00"));
     xios_handler.setFileSplitFreq("day", Duration("P0-2T00:00:00"));
-    REQUIRE(xios_handler.getFileOutputFreq("day").seconds() == Approx(24 * 60 * 60));
-    REQUIRE(xios_handler.getFileSplitFreq("day").seconds() == Approx(2 * 24 * 60 * 60));
+    REQUIRE(xios_handler.getFileOutputFreq("day").seconds() == 24 * 60 * 60);
+    REQUIRE(xios_handler.getFileSplitFreq("day").seconds() == 2 * 24 * 60 * 60);
     xios_handler.createFile("hour");
     xios_handler.setFileOutputFreq("hour", Duration("P0-0T01:00:00"));
     xios_handler.setFileSplitFreq("hour", Duration("P0-0T02:00:00"));
-    REQUIRE(xios_handler.getFileOutputFreq("hour").seconds() == Approx(60 * 60));
-    REQUIRE(xios_handler.getFileSplitFreq("hour").seconds() == Approx(2 * 60 * 60));
+    REQUIRE(xios_handler.getFileOutputFreq("hour").seconds() == 60 * 60);
+    REQUIRE(xios_handler.getFileSplitFreq("hour").seconds() == 2 * 60 * 60);
     xios_handler.createFile("minute");
     xios_handler.setFileOutputFreq("minute", Duration("P0-0T00:01:00"));
     xios_handler.setFileSplitFreq("minute", Duration("P0-0T00:02:00"));
-    REQUIRE(xios_handler.getFileOutputFreq("minute").seconds() == Approx(60));
-    REQUIRE(xios_handler.getFileSplitFreq("minute").seconds() == Approx(2 * 60));
+    REQUIRE(xios_handler.getFileOutputFreq("minute").seconds() == 60);
+    REQUIRE(xios_handler.getFileSplitFreq("minute").seconds() == 2 * 60);
     xios_handler.createFile("second");
     xios_handler.setFileOutputFreq("second", Duration("P0-0T00:00:01"));
     xios_handler.setFileSplitFreq("second", Duration("P0-0T00:00:02"));
-    REQUIRE(xios_handler.getFileOutputFreq("second").seconds() == Approx(1));
-    REQUIRE(xios_handler.getFileSplitFreq("second").seconds() == Approx(2));
+    REQUIRE(xios_handler.getFileOutputFreq("second").seconds() == 1);
+    REQUIRE(xios_handler.getFileSplitFreq("second").seconds() == 2);
 
     xios_handler.close_context_definition();
     xios_handler.context_finalize();

--- a/core/test/XiosFile_test.cpp
+++ b/core/test/XiosFile_test.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file    XiosFile_test.cpp
- * @author  Joe Wallwork <jw2423@cam.ac.uk
- * @date    31 July 2024
+ * @author  Joe Wallwork <jw2423@cam.ac.uk>
+ * @date    5 August 2024
  * @brief   Tests for XIOS axes
  * @details
  * This test is designed to test axis functionality of the C++ interface

--- a/core/test/XiosFile_test.cpp
+++ b/core/test/XiosFile_test.cpp
@@ -73,13 +73,11 @@ MPI_TEST_CASE("TestXiosFile", 2)
     xios_handler.setFileType(fileId, fileType);
     REQUIRE(xios_handler.getFileType(fileId) == fileType);
     // Output frequency
-    const std::string outputFreq { "1ts" };
-    xios_handler.setFileOutputFreq(fileId, outputFreq);
-    REQUIRE(xios_handler.getFileOutputFreq(fileId) == outputFreq);
+    xios_handler.setFileOutputFreq(fileId, Duration("P0-0T01:00:00"));
+    REQUIRE(xios_handler.getFileOutputFreq(fileId).seconds() == doctest::Approx(3600.0));
     // Split frequency
-    const std::string splitFreq { "1ts" };
-    xios_handler.setFileSplitFreq(fileId, splitFreq);
-    REQUIRE(xios_handler.getFileSplitFreq(fileId) == splitFreq);
+    xios_handler.setFileSplitFreq(fileId, Duration("P0-0T02:00:00"));
+    REQUIRE(xios_handler.getFileSplitFreq(fileId).seconds() == doctest::Approx(7200.0));
     // Add field
     xios_handler.fileAddField(fileId, "field_A");
     std::vector<std::string> fieldIds = xios_handler.fileGetFieldIds(fileId);

--- a/core/test/XiosFile_test.cpp
+++ b/core/test/XiosFile_test.cpp
@@ -73,9 +73,9 @@ MPI_TEST_CASE("TestXiosFile", 2)
     xios_handler.setFileType(fileId, fileType);
     REQUIRE(xios_handler.getFileType(fileId) == fileType);
     // Output frequency
-    const std::string freq { "1ts" };
-    xios_handler.setFileOutputFreq(fileId, freq);
-    REQUIRE(xios_handler.getFileOutputFreq(fileId) == freq);
+    const std::string outputFreq { "1ts" };
+    xios_handler.setFileOutputFreq(fileId, outputFreq);
+    REQUIRE(xios_handler.getFileOutputFreq(fileId) == outputFreq);
     // Split frequency
     const std::string splitFreq { "1ts" };
     xios_handler.setFileSplitFreq(fileId, splitFreq);

--- a/core/test/XiosWrite_test.cpp
+++ b/core/test/XiosWrite_test.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file    XiosWrite_test.cpp
- * @author  Joe Wallwork <jw2423@cam.ac.uk
- * @date    31 July 2024
+ * @author  Joe Wallwork <jw2423@cam.ac.uk>
+ * @date    5 August 2024
  * @brief   Tests for XIOS write method
  * @details
  * This test is designed to test the write method of the C++ interface

--- a/core/test/XiosWrite_test.cpp
+++ b/core/test/XiosWrite_test.cpp
@@ -98,8 +98,8 @@ MPI_TEST_CASE("TestXiosWrite", 2)
     // File setup
     xios_handler.createFile("xios_test_output");
     xios_handler.setFileType("xios_test_output", "one_file");
-    xios_handler.setFileOutputFreq("xios_test_output", "1ts");
-    xios_handler.setFileSplitFreq("xios_test_output", "2ts");
+    xios_handler.setFileOutputFreq("xios_test_output", Duration("P0-0T01:30:00"));
+    xios_handler.setFileSplitFreq("xios_test_output", Duration("P0-0T03:00:00"));
     xios_handler.fileAddField("xios_test_output", "field_2D");
     xios_handler.fileAddField("xios_test_output", "field_3D");
     xios_handler.fileAddField("xios_test_output", "field_4D");


### PR DESCRIPTION
# XIOS duration handling

Closes #628
Closes #636

### Task List
- [x] Defined the tests that specify a complete and functioning change (*It may help to create a [design specification & test specification](../../../wiki/Specification-Template)*)
- [x] Implemented the source code change that satisfies the tests
- [x] Documented the feature by providing worked example
- [x] Updated the README or other documentation
- [x] Completed the pre-Request checklist below

---
# Change Description

This PR addresses a few minor concerns:
* XIOS interface methods related to output frequency and split frequency now work with nextSIM-DG's `Duration` objects, rather than accepting XIOS' duration strings, which differ in confusing ways.
* Implement private methods for converting between XIOS and nextSIM-DG's time duration formats.
* Implement a private method for converting between C and C++ string formats, since this is done repeatedly in the XIOS interface.
* Disallow `"PY-M-DTH:M:S"`-style input to `Duration`. Namely, do not allow months to be specified because they have arbitrary length and the convention does not align with XIOS, which could cause confusion.

---
# Test Description

Unit tests are updated accordingly. I also thought it would be a good idea to test more rigorously that durations with different units are treated appropriately.

---
### Pre-Request Checklist

- [x] The requirements of this pull request are fully captured in an issue or design specification and are linked and summarised in the description of this PR
- [x] No new warnings are generated
- [x] The documentation has been updated (or an issue has been created to track the corresponding change)
- [x] Methods and Tests are commented such that they can be understood without having to obtain additional context
- [x] This PR/Issue is labelled as a bug/feature/enhancement/breaking change
- [x] File dates have been updated to reflect modification date
- [x] This change conforms to the conventions described in the README