### PR TITLE
Use `REQUIRE_THROWS` in XIOS tests

### DIFF
--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -1022,6 +1022,11 @@ xios::CFieldGroup* Xios::getFieldGroup()
  */
 xios::CField* Xios::getField(const std::string fieldId)
 {
+    bool exists;
+    cxios_field_valid_id(&exists, fieldId.c_str(), fieldId.length());
+    if (!exists) {
+        throw std::runtime_error("Xios: Undefined field '" + fieldId + "'");
+    }
     xios::CField* field = NULL;
     cxios_field_handle_create(&field, fieldId.c_str(), fieldId.length());
     if (!field) {
@@ -1037,10 +1042,19 @@ xios::CField* Xios::getField(const std::string fieldId)
  */
 void Xios::createField(const std::string fieldId)
 {
+    bool exists;
+    cxios_field_valid_id(&exists, fieldId.c_str(), fieldId.length());
+    if (exists) {
+        throw std::runtime_error("Xios: Field '" + fieldId + "' already exists");
+    }
     xios::CField* field = NULL;
     cxios_xml_tree_add_field(getFieldGroup(), &field, fieldId.c_str(), fieldId.length());
     if (!field) {
         throw std::runtime_error("Xios: Null pointer for field '" + fieldId + "'");
+    }
+    cxios_field_valid_id(&exists, fieldId.c_str(), fieldId.length());
+    if (!exists) {
+        throw std::runtime_error("Xios: Failed to create field '" + fieldId + "'");
     }
 }
 

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -881,6 +881,11 @@ xios::CGridGroup* Xios::getGridGroup()
  */
 xios::CGrid* Xios::getGrid(const std::string gridId)
 {
+    bool exists;
+    cxios_grid_valid_id(&exists, gridId.c_str(), gridId.length());
+    if (!exists) {
+        throw std::runtime_error("Xios: Undefined grid '" + gridId + "'");
+    }
     xios::CGrid* grid = NULL;
     cxios_grid_handle_create(&grid, gridId.c_str(), gridId.length());
     if (!grid) {
@@ -896,10 +901,19 @@ xios::CGrid* Xios::getGrid(const std::string gridId)
  */
 void Xios::createGrid(const std::string gridId)
 {
+    bool exists;
+    cxios_grid_valid_id(&exists, gridId.c_str(), gridId.length());
+    if (exists) {
+        throw std::runtime_error("Xios: Grid '" + gridId + "' already exists");
+    }
     xios::CGrid* grid = NULL;
     cxios_xml_tree_add_grid(getGridGroup(), &grid, gridId.c_str(), gridId.length());
     if (!grid) {
         throw std::runtime_error("Xios: Null pointer for grid '" + gridId + "'");
+    }
+    cxios_grid_valid_id(&exists, gridId.c_str(), gridId.length());
+    if (!exists) {
+        throw std::runtime_error("Xios: Failed to create grid '" + gridId + "'");
     }
 }
 

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -346,6 +346,11 @@ xios::CAxisGroup* Xios::getAxisGroup()
  */
 xios::CAxis* Xios::getAxis(const std::string axisId)
 {
+    bool exists;
+    cxios_axis_valid_id(&exists, axisId.c_str(), axisId.length());
+    if (!exists) {
+        throw std::runtime_error("Xios: Undefined axis '" + axisId + "'");
+    }
     xios::CAxis* axis = NULL;
     cxios_axis_handle_create(&axis, axisId.c_str(), axisId.length());
     if (!axis) {
@@ -361,10 +366,19 @@ xios::CAxis* Xios::getAxis(const std::string axisId)
  */
 void Xios::createAxis(const std::string axisId)
 {
+    bool exists;
+    cxios_axis_valid_id(&exists, axisId.c_str(), axisId.length());
+    if (exists) {
+        throw std::runtime_error("Xios: Axis '" + axisId + "' already exists");
+    }
     xios::CAxis* axis = NULL;
     cxios_xml_tree_add_axis(getAxisGroup(), &axis, axisId.c_str(), axisId.length());
     if (!axis) {
         throw std::runtime_error("Xios: Null pointer for axis '" + axisId + "'");
+    }
+    cxios_axis_valid_id(&exists, axisId.c_str(), axisId.length());
+    if (!exists) {
+        throw std::runtime_error("Xios: Failed to create axis '" + axisId + "'");
     }
 }
 

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -1260,6 +1260,11 @@ xios::CFileGroup* Xios::getFileGroup()
  */
 xios::CFile* Xios::getFile(const std::string fileId)
 {
+    bool exists;
+    cxios_file_valid_id(&exists, fileId.c_str(), fileId.length());
+    if (!exists) {
+        throw std::runtime_error("Xios: Undefined file '" + fileId + "'");
+    }
     xios::CFile* file = NULL;
     cxios_file_handle_create(&file, fileId.c_str(), fileId.length());
     if (!file) {
@@ -1276,18 +1281,18 @@ xios::CFile* Xios::getFile(const std::string fileId)
 void Xios::createFile(const std::string fileId)
 {
     xios::CFile* file = NULL;
-    bool valid;
-    cxios_file_valid_id(&valid, fileId.c_str(), fileId.length());
-    if (valid) {
+    bool exists;
+    cxios_file_valid_id(&exists, fileId.c_str(), fileId.length());
+    if (exists) {
         throw std::runtime_error("Xios: File '" + fileId + "' already exists");
     }
     cxios_xml_tree_add_file(getFileGroup(), &file, fileId.c_str(), fileId.length());
     if (!file) {
         throw std::runtime_error("Xios: Null pointer for file '" + fileId + "'");
     }
-    cxios_file_valid_id(&valid, fileId.c_str(), fileId.length());
-    if (!valid) {
-        throw std::runtime_error("Xios: Failed to create valid file '" + fileId + "'");
+    cxios_file_valid_id(&exists, fileId.c_str(), fileId.length());
+    if (!exists) {
+        throw std::runtime_error("Xios: Failed to create file '" + fileId + "'");
     }
 }
 
@@ -1425,7 +1430,7 @@ std::string Xios::getFileName(const std::string fileId)
 std::string Xios::getFileType(const std::string fileId)
 {
     xios::CFile* file = getFile(fileId);
-    if (!cxios_is_defined_file_name(file)) {
+    if (!cxios_is_defined_file_type(file)) {
         throw std::runtime_error("Xios: Undefined type for file '" + fileId + "'");
     }
     char cStr[cStrLen];
@@ -1443,7 +1448,7 @@ Duration Xios::getFileOutputFreq(const std::string fileId)
 {
     xios::CFile* file = getFile(fileId);
     if (!cxios_is_defined_file_output_freq(file)) {
-        throw std::runtime_error("Xios: Undefined type for file '" + fileId + "'");
+        throw std::runtime_error("Xios: Undefined output frequency for file '" + fileId + "'");
     }
     cxios_duration duration;
     cxios_get_file_output_freq(file, &duration);
@@ -1460,7 +1465,7 @@ Duration Xios::getFileSplitFreq(const std::string fileId)
 {
     xios::CFile* file = getFile(fileId);
     if (!cxios_is_defined_file_split_freq(file)) {
-        throw std::runtime_error("Xios: Undefined values for file '" + fileId + "'");
+        throw std::runtime_error("Xios: Undefined split frequency for file '" + fileId + "'");
     }
     cxios_duration duration;
     cxios_get_file_split_freq(file, &duration);

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -486,6 +486,11 @@ xios::CDomainGroup* Xios::getDomainGroup()
  */
 xios::CDomain* Xios::getDomain(const std::string domainId)
 {
+    bool exists;
+    cxios_domain_valid_id(&exists, domainId.c_str(), domainId.length());
+    if (!exists) {
+        throw std::runtime_error("Xios: Undefined domain '" + domainId + "'");
+    }
     xios::CDomain* domain = NULL;
     cxios_domain_handle_create(&domain, domainId.c_str(), domainId.length());
     if (!domain) {
@@ -501,10 +506,19 @@ xios::CDomain* Xios::getDomain(const std::string domainId)
  */
 void Xios::createDomain(const std::string domainId)
 {
+    bool exists;
+    cxios_domain_valid_id(&exists, domainId.c_str(), domainId.length());
+    if (exists) {
+        throw std::runtime_error("Xios: Domain '" + domainId + "' already exists");
+    }
     xios::CDomain* domain = NULL;
     cxios_xml_tree_add_domain(getDomainGroup(), &domain, domainId.c_str(), domainId.length());
     if (!domain) {
         throw std::runtime_error("Xios: Null pointer for domain '" + domainId + "'");
+    }
+    cxios_domain_valid_id(&exists, domainId.c_str(), domainId.length());
+    if (!exists) {
+        throw std::runtime_error("Xios: Failed to create domain '" + domainId + "'");
     }
 }
 

--- a/core/src/include/xios_c_interface.hpp
+++ b/core/src/include/xios_c_interface.hpp
@@ -126,6 +126,7 @@ void cxios_xml_tree_add_grid(
 
 // grid methods
 void cxios_grid_handle_create(xios::CGrid** _ret, const char* _id, int _id_len);
+void cxios_grid_valid_id(bool* _ret, const char* _id, int _id_len);
 void cxios_set_grid_name(xios::CGrid* _ret, const char* name, int name_size);
 void cxios_get_grid_name(xios::CGrid* _ret, char* name, int name_size);
 bool cxios_is_defined_grid_name(xios::CGrid* file_hdl);

--- a/core/src/include/xios_c_interface.hpp
+++ b/core/src/include/xios_c_interface.hpp
@@ -2,7 +2,7 @@
  * @file    xios_c_interface.hpp
  * @author  Tom Meltzer <tdm39@cam.ac.uk>
  * @author  Joe Wallwork <jw2423@cam.ac.uk>
- * @date    5 August 2024
+ * @date    12 August 2024
  * @brief   C interface for XIOS library
  * @details
  * This interface is based on an earlier version provided by Laurent as part of
@@ -75,6 +75,7 @@ void cxios_xml_tree_add_axis(
 
 // axis methods
 void cxios_axis_handle_create(xios::CAxis** _ret, const char* _id, int _id_len);
+void cxios_axis_valid_id(bool* _ret, const char* _id, int _id_len);
 void cxios_set_axis_n_glo(xios::CAxis* axis_hdl, int n_glo);
 void cxios_set_axis_value(xios::CAxis* axis_hdl, double* value, int* extent);
 void cxios_get_axis_n_glo(xios::CAxis* axis_hdl, int* n_glo);

--- a/core/src/include/xios_c_interface.hpp
+++ b/core/src/include/xios_c_interface.hpp
@@ -90,6 +90,7 @@ void cxios_xml_tree_add_domain(
 
 // domain methods
 void cxios_domain_handle_create(xios::CDomain** _ret, const char* _id, int _id_len);
+void cxios_domain_valid_id(bool* _ret, const char* _id, int _id_len);
 void cxios_set_domain_type(xios::CDomain* domain_hdl, const char* type, int type_size);
 void cxios_set_domain_ni_glo(xios::CDomain* domain_hdl, int ni_glo);
 void cxios_set_domain_nj_glo(xios::CDomain* domain_hdl, int nj_glo);

--- a/core/src/include/xios_c_interface.hpp
+++ b/core/src/include/xios_c_interface.hpp
@@ -142,6 +142,7 @@ void cxios_xml_tree_add_field(
 
 // field methods
 void cxios_field_handle_create(xios::CField** _ret, const char* _id, int _id_len);
+void cxios_field_valid_id(bool* _ret, const char* _id, int _id_len);
 void cxios_set_field_name(xios::CField* _ret, const char* name, int name_size);
 void cxios_set_field_operation(xios::CField* _ret, const char* operation, int operation_size);
 void cxios_set_field_grid_ref(xios::CField* _ret, const char* grid_ref, int grid_ref_size);

--- a/core/test/XiosAxis_test.cpp
+++ b/core/test/XiosAxis_test.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file    XiosAxis_test.cpp
  * @author  Joe Wallwork <jw2423@cam.ac.uk>
- * @date    5 August 2024
+ * @date    12 August 2024
  * @brief   Tests for XIOS axes
  * @details
  * This test is designed to test axis functionality of the C++ interface
@@ -48,17 +48,25 @@ MPI_TEST_CASE("TestXiosAxis", 2)
 
     // --- Tests for axis API
     const std::string axisId = { "axis_A" };
+    REQUIRE_THROWS_WITH(xios_handler.getAxisSize(axisId), "Xios: Undefined axis 'axis_A'");
+    REQUIRE_THROWS_WITH(xios_handler.getAxisValues(axisId), "Xios: Undefined axis 'axis_A'");
     xios_handler.createAxis(axisId);
+    REQUIRE_THROWS_WITH(xios_handler.createAxis(axisId), "Xios: Axis 'axis_A' already exists");
     // Axis size
-    const size_t axis_size { 2 };
-    xios_handler.setAxisSize(axisId, axis_size);
-    REQUIRE(xios_handler.getAxisSize(axisId) == axis_size);
+    REQUIRE_THROWS_WITH(xios_handler.getAxisSize(axisId), "Xios: Undefined size for axis 'axis_A'");
+    const size_t axisSize { 2 };
+    xios_handler.setAxisSize(axisId, axisSize);
+    REQUIRE(xios_handler.getAxisSize(axisId) == axisSize);
     // Axis values
+    REQUIRE_THROWS_WITH(
+        xios_handler.getAxisValues(axisId), "Xios: Undefined values for axis 'axis_A'");
+    REQUIRE_THROWS_WITH(xios_handler.setAxisValues(axisId, { 0.0, 1.0, 2.0 }),
+        "Xios: Size incompatible with values for axis 'axis_A'");
     std::vector<double> axisValues { 0.0, 1.0 };
     xios_handler.setAxisValues(axisId, axisValues);
     std::vector<double> axis_A = xios_handler.getAxisValues(axisId);
-    REQUIRE(axis_A[0] == doctest::Approx(0));
-    REQUIRE(axis_A[1] == doctest::Approx(1));
+    REQUIRE(axis_A[0] == doctest::Approx(0.0));
+    REQUIRE(axis_A[1] == doctest::Approx(1.0));
 
     xios_handler.close_context_definition();
     xios_handler.context_finalize();

--- a/core/test/XiosDomain_test.cpp
+++ b/core/test/XiosDomain_test.cpp
@@ -49,37 +49,57 @@ MPI_TEST_CASE("TestXiosDomain", 2)
     xios_handler.setCalendarTimestep(Duration("P0-0T01:00:00"));
 
     // --- Tests for domain API
-    const std::string domainId = { "domain_A" };
+    const std::string domainId = "domain_A";
+    REQUIRE_THROWS_WITH(xios_handler.getDomainType(domainId), "Xios: Undefined domain 'domain_A'");
     xios_handler.createDomain(domainId);
+    REQUIRE_THROWS_WITH(
+        xios_handler.createDomain(domainId), "Xios: Domain 'domain_A' already exists");
     // Domain type
-    const std::string domainType = { "rectilinear" };
+    REQUIRE_THROWS_WITH(
+        xios_handler.getDomainType(domainId), "Xios: Undefined type for domain 'domain_A'");
+    const std::string domainType = "rectilinear";
     xios_handler.setDomainType(domainId, domainType);
     REQUIRE(xios_handler.getDomainType(domainId) == domainType);
     // Global number of points in x-direction
+    REQUIRE_THROWS_WITH(xios_handler.getDomainGlobalXSize(domainId),
+        "Xios: Undefined global x-size for domain 'domain_A'");
     const size_t nx_glo = 4;
     xios_handler.setDomainGlobalXSize(domainId, nx_glo);
     REQUIRE(xios_handler.getDomainGlobalXSize(domainId) == nx_glo);
     // Global number of points in y-direction
+    REQUIRE_THROWS_WITH(xios_handler.getDomainGlobalYSize(domainId),
+        "Xios: Undefined global y-size for domain 'domain_A'");
     const size_t ny_glo = 2;
     xios_handler.setDomainGlobalYSize(domainId, ny_glo);
     REQUIRE(xios_handler.getDomainGlobalYSize(domainId) == ny_glo);
     // Local number of points in x-direction
+    REQUIRE_THROWS_WITH(xios_handler.getDomainLocalXSize(domainId),
+        "Xios: Undefined local x-size for domain 'domain_A'");
     const size_t nx = nx_glo / size;
     xios_handler.setDomainLocalXSize(domainId, nx);
     REQUIRE(xios_handler.getDomainLocalXSize(domainId) == nx);
     // Local number of points in y-direction
+    REQUIRE_THROWS_WITH(xios_handler.getDomainLocalYSize(domainId),
+        "Xios: Undefined local y-size for domain 'domain_A'");
     const size_t ny = ny_glo;
     xios_handler.setDomainLocalYSize(domainId, ny);
     REQUIRE(xios_handler.getDomainLocalYSize(domainId) == ny);
     // Local starting x-index
+    REQUIRE_THROWS_WITH(xios_handler.getDomainLocalXStart(domainId),
+        "Xios: Undefined local starting x-index for domain 'domain_A'");
     const size_t x0 = nx * rank;
     xios_handler.setDomainLocalXStart(domainId, x0);
     REQUIRE(xios_handler.getDomainLocalXStart(domainId) == x0);
     // Local starting y-index
+    REQUIRE_THROWS_WITH(xios_handler.getDomainLocalYStart(domainId),
+        "Xios: Undefined local starting y-index for domain 'domain_A'");
     const size_t y0 = 0;
     xios_handler.setDomainLocalYStart(domainId, y0);
     REQUIRE(xios_handler.getDomainLocalYStart(domainId) == y0);
     // Local x-values
+    REQUIRE_THROWS_WITH(xios_handler.getDomainLocalXValues(domainId),
+        "Xios: Undefined local x-values for domain 'domain_A'");
+    REQUIRE_THROWS_AS(xios_handler.getDomainLocalXValues(domainId), std::runtime_error);
     std::vector<double> vx { -1.0 + rank, -0.5 + rank };
     xios_handler.setDomainLocalXValues(domainId, vx);
     std::vector<double> vxOut = xios_handler.getDomainLocalXValues(domainId);
@@ -87,6 +107,8 @@ MPI_TEST_CASE("TestXiosDomain", 2)
         REQUIRE(vxOut[i] == doctest::Approx(vx[i]));
     }
     // Local y-values
+    REQUIRE_THROWS_WITH(xios_handler.getDomainLocalYValues(domainId),
+        "Xios: Undefined local y-values for domain 'domain_A'");
     std::vector<double> vy { -1.0, 1.0 };
     xios_handler.setDomainLocalYValues(domainId, vy);
     std::vector<double> vyOut = xios_handler.getDomainLocalYValues(domainId);

--- a/core/test/XiosField_test.cpp
+++ b/core/test/XiosField_test.cpp
@@ -59,16 +59,24 @@ MPI_TEST_CASE("TestXiosField", 2)
 
     // --- Tests for field API
     const std::string fieldId = "field_A";
+    REQUIRE_THROWS_WITH(xios_handler.getFieldName(fieldId), "Xios: Undefined field 'field_A'");
     xios_handler.createField(fieldId);
+    REQUIRE_THROWS_WITH(xios_handler.createField(fieldId), "Xios: Field 'field_A' already exists");
     // Field name
+    REQUIRE_THROWS_WITH(
+        xios_handler.getFieldName(fieldId), "Xios: Undefined name for field 'field_A'");
     const std::string fieldName = "test_field";
     xios_handler.setFieldName(fieldId, fieldName);
     REQUIRE(xios_handler.getFieldName(fieldId) == fieldName);
     // Operation
+    REQUIRE_THROWS_WITH(
+        xios_handler.getFieldOperation(fieldId), "Xios: Undefined operation for field 'field_A'");
     const std::string operation = "instant";
     xios_handler.setFieldOperation(fieldId, operation);
     REQUIRE(xios_handler.getFieldOperation(fieldId) == operation);
     // Grid reference
+    REQUIRE_THROWS_WITH(xios_handler.getFieldGridRef(fieldId),
+        "Xios: Undefined grid reference for field 'field_A'");
     const std::string gridRef = "grid_1D";
     xios_handler.setFieldGridRef(fieldId, gridRef);
     REQUIRE(xios_handler.getFieldGridRef(fieldId) == gridRef);

--- a/core/test/XiosFile_test.cpp
+++ b/core/test/XiosFile_test.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file    XiosFile_test.cpp
  * @author  Joe Wallwork <jw2423@cam.ac.uk>
- * @date    5 August 2024
+ * @date    12 August 2024
  * @brief   Tests for XIOS axes
  * @details
  * This test is designed to test axis functionality of the C++ interface
@@ -66,19 +66,27 @@ MPI_TEST_CASE("TestXiosFile", 2)
 
     // --- Tests for file API
     const std::string fileId = "output";
+    REQUIRE_THROWS_WITH(xios_handler.getFileName(fileId), "Xios: Undefined file 'output'");
     xios_handler.createFile(fileId);
+    REQUIRE_THROWS_WITH(xios_handler.createFile(fileId), "Xios: File 'output' already exists");
     // File name
+    REQUIRE_THROWS_WITH(xios_handler.getFileName(fileId), "Xios: Undefined name for file 'output'");
     const std::string fileName = "diagnostic";
     xios_handler.setFileName(fileId, fileName);
     REQUIRE(xios_handler.getFileName(fileId) == fileName);
     // File type
+    REQUIRE_THROWS_WITH(xios_handler.getFileType(fileId), "Xios: Undefined type for file 'output'");
     const std::string fileType = "one_file";
     xios_handler.setFileType(fileId, fileType);
     REQUIRE(xios_handler.getFileType(fileId) == fileType);
     // Output frequency
+    REQUIRE_THROWS_WITH(xios_handler.getFileOutputFreq(fileId),
+        "Xios: Undefined output frequency for file 'output'");
     xios_handler.setFileOutputFreq(fileId, timestep);
     REQUIRE(xios_handler.getFileOutputFreq(fileId).seconds() == 1.5 * 60 * 60);
     // Split frequency
+    REQUIRE_THROWS_WITH(
+        xios_handler.getFileSplitFreq(fileId), "Xios: Undefined split frequency for file 'output'");
     xios_handler.setFileSplitFreq(fileId, timestep);
     REQUIRE(xios_handler.getFileSplitFreq(fileId).seconds() == 1.5 * 60 * 60);
     // File mode

--- a/core/test/XiosGrid_test.cpp
+++ b/core/test/XiosGrid_test.cpp
@@ -63,9 +63,13 @@ MPI_TEST_CASE("TestXiosGrid", 2)
 
     // --- Tests for grid API
     const std::string gridId = { "grid_2D" };
+    REQUIRE_THROWS_WITH(xios_handler.getGridName(gridId), "Xios: Undefined grid 'grid_2D'");
     xios_handler.createGrid(gridId);
+    REQUIRE_THROWS_WITH(xios_handler.createGrid(gridId), "Xios: Grid 'grid_2D' already exists");
     // Grid name
     const std::string gridName = { "test_grid" };
+    REQUIRE_THROWS_WITH(
+        xios_handler.getGridName(gridId), "Xios: Undefined name for grid 'grid_2D'");
     xios_handler.setGridName(gridId, gridName);
     REQUIRE(xios_handler.getGridName(gridId) == gridName);
     // Add axis


### PR DESCRIPTION
# Use `REQUIRE_THROWS` in XIOS tests
Closes #638

### Task List
- [x] Defined the tests that specify a complete and functioning change (*It may help to create a [design specification & test specification](../../../wiki/Specification-Template)*)
- [x] Implemented the source code change that satisfies the tests
- [x] Documented the feature by providing worked example
- [x] Updated the README or other documentation
- [x] Completed the pre-Request checklist below

---
# Change Description

#576 and other recent PRs made it so that the XIOS interface throws warnings and errors when things aren't as expected. This PR adds tests to check that many of the errors are indeed thrown as expected. Implementing this change helped me find a few typos in comments and error messages.

Currently based off the branch for #635 so this is blocked by that PR for now.

---
### Pre-Request Checklist

- [x] The requirements of this pull request are fully captured in an issue or design specification and are linked and summarised in the description of this PR
- [x] No new warnings are generated
- [x] The documentation has been updated (or an issue has been created to track the corresponding change)
- [x] Methods and Tests are commented such that they can be understood without having to obtain additional context
- [x] This PR/Issue is labelled as a bug/feature/enhancement/breaking change
- [x] File dates have been updated to reflect modification date
- [x] This change conforms to the conventions described in the README