### PR TITLE
Use doctest in advection test cases

### DIFF
--- a/dynamics/test/AdvectionPeriodicBC_test.cpp
+++ b/dynamics/test/AdvectionPeriodicBC_test.cpp
@@ -1,6 +1,6 @@
 /*!
  * @file AdvectionPeriodicBC_test.cpp
- * @date 10 Jul 2022
+ * @date 19 August 2024
  * @author Thomas Richter <thomas.richter@ovgu.de>
  */
 

--- a/dynamics/test/AdvectionPeriodicBC_test.cpp
+++ b/dynamics/test/AdvectionPeriodicBC_test.cpp
@@ -14,11 +14,10 @@
 #include "dgLimit.hpp"
 #include "dgVisu.hpp"
 
-#include <cassert>
-#include <chrono>
 #include <filesystem> // only for automatic creation of output directory
 #include <iostream>
-#include <vector>
+
+using namespace doctest;
 
 /*!
  * Advection test case on a ring:
@@ -255,13 +254,11 @@ void create_rectanglemesh(Nextsim::ParametricMesh& smesh)
     }
 }
 
-template <int DG> bool run(const std::array<std::array<double, 6>, 3>& exact)
+template <int DG> void run(const std::array<std::array<double, 6>, 3>& exact)
 {
     Nextsim::ParametricMesh smesh(Nextsim::CARTESIAN);
 
 #define DG2DEG(DG) (DG == 1 ? 0 : (DG == 3 ? 1 : DG == 6 ? 2 : -1))
-
-    bool success = true;
 
     for (int it = 0; it < 2; ++it) {
 
@@ -273,23 +270,14 @@ template <int DG> bool run(const std::array<std::array<double, 6>, 3>& exact)
 
         Test<DG> test(smesh);
         double error = test.run();
-        std::cout << error << "\t" << exact[DG2DEG(DG)][it];
-        if (fabs(error - exact[DG2DEG(DG)][it]) / exact[DG2DEG(DG)][it] < TOL) {
-            std::cout << "\ttest passed" << std::endl;
-        } else {
-            std::cout << "\ttest failed" << std::endl;
-            success = false;
-        }
+        std::cout << error << "\t" << exact[DG2DEG(DG)][it] << std::endl;
+        CHECK(error == Approx(exact[DG2DEG(DG)][it]).epsilon(TOL));
     }
-    return success;
 }
 
 TEST_SUITE_BEGIN("Advection Periodic Boundary Conditions");
 TEST_CASE("Advection Periodic Boundary Conditions")
 {
-    std::cout << "DG\tNT\tNX\tmass\t\terror\t\texact\t\tpassed" << std::endl;
-    std::cout << std::setprecision(4) << std::scientific;
-
     std::array<std::array<double, 6>, 3> exact = // Exact values taken 26/06/2024
         { std::array<double, 6>(
               { 1.0338503986019776e+00, 1.1451366598186583e+00, 1.0681593193338459e+00,
@@ -300,7 +288,10 @@ TEST_CASE("Advection Periodic Boundary Conditions")
             std::array<double, 6>(
                 { 7.1704413076190610e-01, 4.6135258391583606e-01, 3.2770311091970727e-01,
                     2.3424633076579465e-01, 1.7038068017215552e-01, 1.2486932724366147e-01 }) };
-    REQUIRE(run<1>(exact) == true);
-    REQUIRE(run<3>(exact) == true);
-    REQUIRE(run<6>(exact) == true);
+
+    std::cout << "DG\tNT\tNX\tmass\t\terror\t\texact" << std::endl;
+    std::cout << std::setprecision(4) << std::scientific;
+    run<1>(exact);
+    run<3>(exact);
+    run<6>(exact);
 }

--- a/dynamics/test/AdvectionPeriodicBC_test.cpp
+++ b/dynamics/test/AdvectionPeriodicBC_test.cpp
@@ -4,8 +4,8 @@
  * @author Thomas Richter <thomas.richter@ovgu.de>
  */
 
- #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
- #include <doctest/doctest.h>
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest/doctest.h>
 
 #include "DGTransport.hpp"
 #include "Interpolations.hpp"
@@ -165,8 +165,8 @@ public:
 
         // initial density
         Nextsim::Interpolations::Function2DG(smesh, phi, Packman());
-	Nextsim::LimitMax(phi, 1.0);
-	//	Nextsim::LimitMin(phi, 0.0);
+        Nextsim::LimitMax(phi, 1.0);
+        //	Nextsim::LimitMin(phi, 0.0);
 
         double initialmass = Nextsim::Tools::MeanValue(smesh, phi);
         // velocity field
@@ -274,13 +274,12 @@ template <int DG> bool run(const std::array<std::array<double, 6>, 3>& exact)
         Test<DG> test(smesh);
         double error = test.run();
         std::cout << error << "\t" << exact[DG2DEG(DG)][it];
-        if (fabs(error - exact[DG2DEG(DG)][it]) / exact[DG2DEG(DG)][it] < TOL){
+        if (fabs(error - exact[DG2DEG(DG)][it]) / exact[DG2DEG(DG)][it] < TOL) {
             std::cout << "\ttest passed" << std::endl;
-          }
-        else{
+        } else {
             std::cout << "\ttest failed" << std::endl;
             success = false;
-          }
+        }
     }
     return success;
 }
@@ -292,11 +291,16 @@ TEST_CASE("Advection Periodic Boundary Conditions")
     std::cout << std::setprecision(4) << std::scientific;
 
     std::array<std::array<double, 6>, 3> exact = // Exact values taken 26/06/2024
-      {std::array<double,6>({1.0338503986019776e+00,1.1451366598186583e+00,1.0681593193338459e+00,9.5252231195653603e-01,8.1458581892610615e-01,6.8950068528265651e-01}),
-       std::array<double,6>({1.0949680727313791e+00,8.3851748134278226e-01,5.8501741891364523e-01,4.0006092999256893e-01,2.8493698219799068e-01,2.0801424342840474e-01}),
-       std::array<double,6>({7.1704413076190610e-01,4.6135258391583606e-01,3.2770311091970727e-01,2.3424633076579465e-01,1.7038068017215552e-01,1.2486932724366147e-01})};
+        { std::array<double, 6>(
+              { 1.0338503986019776e+00, 1.1451366598186583e+00, 1.0681593193338459e+00,
+                  9.5252231195653603e-01, 8.1458581892610615e-01, 6.8950068528265651e-01 }),
+            std::array<double, 6>(
+                { 1.0949680727313791e+00, 8.3851748134278226e-01, 5.8501741891364523e-01,
+                    4.0006092999256893e-01, 2.8493698219799068e-01, 2.0801424342840474e-01 }),
+            std::array<double, 6>(
+                { 7.1704413076190610e-01, 4.6135258391583606e-01, 3.2770311091970727e-01,
+                    2.3424633076579465e-01, 1.7038068017215552e-01, 1.2486932724366147e-01 }) };
     REQUIRE(run<1>(exact) == true);
     REQUIRE(run<3>(exact) == true);
     REQUIRE(run<6>(exact) == true);
-     
 }

--- a/dynamics/test/Advection_test.cpp
+++ b/dynamics/test/Advection_test.cpp
@@ -14,7 +14,6 @@
 #include "dgLimiters.hpp"
 #include "dgVisu.hpp"
 
-#include <cassert>
 #include <chrono>
 #include <filesystem> // only for automatic creation of output directory
 #include <iostream>

--- a/dynamics/test/Advection_test.cpp
+++ b/dynamics/test/Advection_test.cpp
@@ -1,6 +1,6 @@
 /*!
  * @file Advection_test.cpp
- * @date 10 Jul 2022
+ * @date 19 August 2024
  * @author Thomas Richter <thomas.richter@ovgu.de>
  */
 

--- a/dynamics/test/Advection_test.cpp
+++ b/dynamics/test/Advection_test.cpp
@@ -261,22 +261,15 @@ template <int DG> bool run(double distort, const std::array<std::array<double, 6
         Test<DG> test(smesh);
         double error = test.run();
         std::cout << error << "\t" << exact[DG2DEG(DG)][it];
-        if (fabs(error - exact[DG2DEG(DG)][it]) / exact[DG2DEG(DG)][it] < TOL){
+        if (fabs(error - exact[DG2DEG(DG)][it]) / exact[DG2DEG(DG)][it] < TOL) {
             std::cout << "\ttest passed" << std::endl;
-            }
-        else{
+        } else {
             std::cout << "\ttest failed" << std::endl;
-            success = false;}
+            success = false;
+        }
     }
     return success;
 }
-
-
-
-
-
-
-
 
 TEST_SUITE_BEGIN("Advection");
 TEST_CASE("Advection")
@@ -285,10 +278,16 @@ TEST_CASE("Advection")
 
     // Exact values taken 25/06/2024 after some plausibility check of the results
     // and by checking the theoretical order of convergence to be expected
-    std::array<std::array<double, 6>, 3> exact = 
-        { std::array<double, 6>({ 5.1256149074257538e-02,4.8288256703303903e-02,4.3105635248809886e-02,3.5793986049422598e-02,2.6937487824223016e-02,1.8456775604583933e-02 }),
-	  std::array<double, 6>({ 2.9450967798560313e-02,1.3427281824939470e-02,5.8574889800512000e-03,2.2756813704797301e-03,7.3564079504566610e-04,1.9177169540867740e-04}),
-	  std::array<double, 6>({ 9.9340386651904228e-03,4.0274889287136816e-03,1.2400186092664943e-03,2.8460130790583933e-04,4.5459555769938981e-05,4.6851425365137733e-06})};
+    std::array<std::array<double, 6>, 3> exact
+        = { std::array<double, 6>(
+                { 5.1256149074257538e-02, 4.8288256703303903e-02, 4.3105635248809886e-02,
+                    3.5793986049422598e-02, 2.6937487824223016e-02, 1.8456775604583933e-02 }),
+              std::array<double, 6>(
+                  { 2.9450967798560313e-02, 1.3427281824939470e-02, 5.8574889800512000e-03,
+                      2.2756813704797301e-03, 7.3564079504566610e-04, 1.9177169540867740e-04 }),
+              std::array<double, 6>(
+                  { 9.9340386651904228e-03, 4.0274889287136816e-03, 1.2400186092664943e-03,
+                      2.8460130790583933e-04, 4.5459555769938981e-05, 4.6851425365137733e-06 }) };
 
     std::cout << std::endl << "DG\tNT\tNX\tmass loss\terror\t\texact\t\tpassed" << std::endl;
     REQUIRE(run<1>(0.0, exact) == true);
@@ -297,10 +296,16 @@ TEST_CASE("Advection")
 }
 TEST_CASE("Distorted Mesh")
 {
-    std::array<std::array<double, 6>, 3> exact =
-      { std::array<double, 6>({5.0958748236875594e-02,4.8461087243594887e-02,4.3918572621094686e-02,3.7038043078562323e-02,2.8334464207979679e-02,1.9666196904181983e-02  }),
-        std::array<double, 6>({3.2033423984965226e-02,1.5639052766007147e-02,6.7926997203524983e-03,2.7369916393700151e-03,9.2109964949992139e-04,2.5128064874203957e-04  }),
-        std::array<double, 6>({1.1830071142946669e-02,4.9207680503709564e-03,1.5831512504162868e-03,3.8869595113351363e-04,6.7162895595772516e-05,7.5853786764529606e-06})};
+    std::array<std::array<double, 6>, 3> exact
+        = { std::array<double, 6>(
+                { 5.0958748236875594e-02, 4.8461087243594887e-02, 4.3918572621094686e-02,
+                    3.7038043078562323e-02, 2.8334464207979679e-02, 1.9666196904181983e-02 }),
+              std::array<double, 6>(
+                  { 3.2033423984965226e-02, 1.5639052766007147e-02, 6.7926997203524983e-03,
+                      2.7369916393700151e-03, 9.2109964949992139e-04, 2.5128064874203957e-04 }),
+              std::array<double, 6>(
+                  { 1.1830071142946669e-02, 4.9207680503709564e-03, 1.5831512504162868e-03,
+                      3.8869595113351363e-04, 6.7162895595772516e-05, 7.5853786764529606e-06 }) };
 
     std::cout << std::endl << "Distorted mesh" << std::endl;
     std::cout << "DG\tNT\tNX\tmass loss\terror\t\texact\t\tpassed" << std::endl;


### PR DESCRIPTION
# Use doctest in advection test cases
## Fixes #587

---
# Change Description

Closes #587.

* Replace hand-coded error checking with the `Approx` class from `doctest`.
  * To get a relative error check, we use its `epsilon` method, passing the desired tolerance as an argument.
* Remove unnecessary includes.
* Apply clang-format.

---
# Test Description

The tests have been implemented with `CHECK` rather than `REQUIRE` so that they continue after a failing case. If the first test fails then the output will now look as follows (I manufactured this failure by changing the sign of one of the expected values):
```
[doctest] doctest version is "2.4.11"
[doctest] run with "--help" for options
DG	NT	NX	mass		error		exact
1	50	32	-1.0473e-15	1.0339e+00	-1.0339e+00
===============================================================================
/home/joe/software/nextSIM-DG/dynamics/test/AdvectionPeriodicBC_test.cpp:281:
TEST SUITE: Advection Periodic Boundary Conditions
TEST CASE:  Advection Periodic Boundary Conditions

/home/joe/software/nextSIM-DG/dynamics/test/AdvectionPeriodicBC_test.cpp:276: ERROR: CHECK( error == Approx(exact[(DG == 1 ? 0 : (DG == 3 ? 1 : DG == 6 ? 2 : -1))][it]).epsilon(TOL) ) is NOT correct!
  values: CHECK( 1.03385 == Approx( -1.03385 ) )

1	100	64	2.2148e-15	1.1451e+00	1.1451e+00
3	200	32	1.6564e-01	1.0950e+00	1.0950e+00
3	400	64	1.9425e-02	8.3852e-01	8.3852e-01
6	450	32	4.2731e-02	7.1704e-01	7.1704e-01
6	900	64	2.3961e-03	4.6135e-01	4.6135e-01
===============================================================================
[doctest] test cases: 1 | 0 passed | 1 failed | 0 skipped
[doctest] assertions: 6 | 5 passed | 1 failed |
[doctest] Status: FAILURE!
```