### PR TITLE
Issue648 cmake refactor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,26 @@
 cmake_minimum_required(VERSION 3.12)
 
+# set globally because we have a number of independent targets
 set(CMAKE_CXX_STANDARD 17)
 
 project(nextsim_dg)
 
+# user definable build options
+OPTION(WITH_THREADS "Build with support for openmp" OFF)
+option(ENABLE_MPI "Enable distributed-memory parallelization with MPI" OFF)
+option(ENABLE_XIOS "Enable XIOS library for IO" OFF)
+option(BUILD_TESTS "Build the tests" ON)
+set(DynamicsType "DG2" CACHE STRING "Set the discretization order for the dynamics, either DG1 or DG2")
+
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
+# all nextsim code is collected in a library to allow for reuse in the tests
+# the code is added after processing the subdirectories
+add_library(nextsimlib SHARED)
+# modern way to set the standard is redundant since we also do it globally
+target_compile_features(nextsimlib PUBLIC cxx_std_17)
+
+# NetCDF
 find_package(PkgConfig)
 pkg_search_module(NETCDF_CXX4 netcdf-cxx4)
 if (NETCDF_CXX4_FOUND)
@@ -20,70 +35,30 @@ else()
         set(NSDG_NetCDF_Library "netcdf_c++4")
     endif()
 endif()
+target_include_directories(nextsimlib
+    PUBLIC
+    "${netCDF_INCLUDE_DIR}"
+    )
+target_link_directories(nextsimlib PUBLIC "${netCDF_LIB_DIR}")
+target_link_libraries(nextsimlib PUBLIC "${NSDG_NetCDF_Library}"
+    "${FORTRAN_RUNTIME_LIB}"
+    )
 
-OPTION(WITH_THREADS      "Build with support for openmp" OFF)
-
-find_package(OpenMP)
-if (OPENMP_FOUND)
-    IF(WITH_THREADS)
-        set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
-        set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-        set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
-    endif()
+if(BUILD_TESTS)
+    # Add the doctest header library
+    set(DOCTEST_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/lib)
+    add_library(doctest::doctest IMPORTED INTERFACE)
+    set_property(TARGET doctest::doctest PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${DOCTEST_INCLUDE_DIR}")
 endif()
 
-option(ENABLE_XIOS "Enable XIOS library for IO" OFF)
-if (ENABLE_XIOS)
-    message(STATUS "Building with XIOS library")
-    find_package(xios REQUIRED QUIET)
-    if (XIOS_FOUND)
-        find_package(HDF5 REQUIRED COMPONENTS C HL)
-    endif()
-endif()
-
-# Regarding Boost.Log, if our application consists of more
-# than one modules that use it, we must link to the shared
-# version. If we have a single executable or a single module
-# that works, we may use the static version.
-# By default, it is assumed that the library is built in
-# static mode. Use the following definition to indicate that
-# the code will be linked against dynamically loaded boost
-# libraries.
-add_definitions(-DBOOST_ALL_DYN_LINK)
-find_package(Boost COMPONENTS program_options log REQUIRED)
-
-# Add the doctest header library
-set(DOCTEST_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/lib)
-add_library(doctest::doctest IMPORTED INTERFACE)
-set_property(TARGET doctest::doctest PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${DOCTEST_INCLUDE_DIR}")
-
+# Eigen
 find_package(Eigen3 3.4 REQUIRED)
-
-option(ENABLE_MPI "Enable distributed-memory parallelization with MPI" OFF)
-if(ENABLE_MPI)
-    find_package(MPI REQUIRED COMPONENTS C CXX)
-endif()
-
-# if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-#     set(FORTRAN_RUNTIME_LIB "-lgfortran")
-# elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
-#     set(FORTRAN_RUNTIME_LIB "-lifcore")
-# endif()
+target_link_libraries(nextsimlib PUBLIC
+    Eigen3::Eigen
+    )
 
 set(Python_FIND_VIRTUALENV FIRST)
 find_package (Python COMPONENTS Interpreter)
-
-# To add netCDF to a target:
-# target_include_directories(target PUBLIC ${netCDF_INCLUDE_DIR})
-# target_link_directories(target PUBLIC ${netCDF_LIB_DIR})
-# target_link_libraries(target LINK_PUBLIC "${NSDG_NetCDF_Library}")
-
-# Set the list of components that define modules. Component subdirectories are
-# contained in this directory level and contain src/modules/ and
-# src/modules/include/ subdirectories
-#set(ModularComponents
-#"physics"
-#)
 
 # The location of the module_builder.py scripts
 set(ScriptDirectory "${PROJECT_SOURCE_DIR}/scripts")
@@ -95,12 +70,6 @@ set(ModuleHeaderScript "${ScriptDirectory}/module_header.py")
 # DG1 Discontinuous Galerkin, degree 1 (3 components)
 # DG2 Discontinuous Galerkin, degree 2 (6 components)
 set(isDG FALSE)
-
-# Replace a missing dynamics type with DG1
-if (NOT DynamicsType)
-    set(DynamicsType "DG2")
-    message("Defaulting dynamics to ${DynamicsType}")
-endif()
 
 message("Dynamics is set to ${DynamicsType}")
 
@@ -140,65 +109,93 @@ if (isDG)
 # The exact selection of dimensions and Types available to ModelArray
     set(ModelArrayStructure "discontinuousgalerkin")
 endif()
+# set degree / component parameters
+target_compile_definitions(nextsimlib
+    PRIVATE
+    DGCOMP=${DGComp}
+    DGSTRESSCOMP=${DGStressComp}
+    CGDEGREE=${CGDegree}
+    )
+
+# boost
+find_package(Boost COMPONENTS program_options log REQUIRED)
+target_link_libraries(nextsimlib PUBLIC
+    Boost::program_options Boost::log
+    )
+# Regarding Boost.Log, if our application consists of more
+# than one modules that use it, we must link to the shared
+# version. If we have a single executable or a single module
+# that works, we may use the static version.
+# By default, it is assumed that the library is built in
+# static mode. Use the following definition to indicate that
+# the code will be linked against dynamically loaded boost
+# libraries.
+target_compile_definitions(nextsimlib PUBLIC BOOST_ALL_DYN_LINK)
+
+# MPI
+if(ENABLE_MPI)
+    find_package(MPI REQUIRED COMPONENTS C CXX)
+    target_compile_definitions(nextsimlib
+        PUBLIC
+        USE_MPI)
+    target_link_libraries(nextsimlib PUBLIC MPI::MPI_C MPI::MPI_CXX)
+endif()
+
+# XIOS
+if (ENABLE_XIOS)
+    message(STATUS "Building with XIOS library")
+    find_package(xios REQUIRED)
+    find_package(HDF5 REQUIRED COMPONENTS C HL)
+    target_compile_definitions(nextsimlib
+    PUBLIC
+    USE_XIOS)
+
+    target_link_directories(nextsimlib PUBLIC ${xios_LIBRARIES})
+    target_link_libraries(nextsimlib PUBLIC xios HDF5::HDF5)
+    target_include_directories(nextsimlib
+    PRIVATE
+    ${xios_INCLUDES}
+    ${xios_EXTERNS}/blitz/
+    ${xios_EXTERNS}/rapidxml/include
+    )
+endif()
+
+# OpenMP
+if (WITH_THREADS)
+    find_package(OpenMP REQUIRED)
+    target_link_libraries(nextsimlib PUBLIC OpenMP::OpenMP_CXX)
+endif()
 
 # Set an empty list of sources
 set(NextsimSources "")
-
 # Set an empty list of include directories
 set(NextsimIncludeDirs "")
-
 # At least one test shell script runs the full binary. This variable contains the path to it.
 set(NEXTSIM_BINARY_PATH "${CMAKE_CURRENT_BINARY_DIR}/nextsim")
 
 # Build the core model. Defines the 'parse_modules' target
-add_subdirectory(core)
-
+add_subdirectory("core")
 
 # Build all components
 foreach(compo ${CodeComponents})
     add_subdirectory("${compo}")
 endforeach()
 
-add_library(nextsimlib SHARED ${NextsimSources})
-target_compile_definitions(nextsimlib
-    PRIVATE
-    $<$<BOOL:${ENABLE_MPI}>:USE_MPI>
-    $<$<BOOL:${ENABLE_XIOS}>:USE_XIOS>
-    DGCOMP=${DGComp}
-    DGSTRESSCOMP=${DGStressComp}
-    CGDEGREE=${CGDegree}
-    )
+target_sources(nextsimlib PRIVATE ${NextsimSources})
 target_include_directories(nextsimlib
     PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}"
     "${NextsimIncludeDirs}"
-    $<$<BOOL:${ENABLE_XIOS}>:${xios_INCLUDES}>
-    $<$<BOOL:${ENABLE_XIOS}>:${xios_EXTERNS}/blitz/>
-    $<$<BOOL:${ENABLE_XIOS}>:${xios_EXTERNS}/rapidxml/include>
-    PUBLIC
-    "${netCDF_INCLUDE_DIR}"
     )
 
-target_link_directories(nextsimlib PUBLIC "${netCDF_LIB_DIR}" $<$<BOOL:${ENABLE_MPI}>:${xios_LIBRARIES}>)
-target_link_libraries(nextsimlib PUBLIC
-    $<$<BOOL:${ENABLE_XIOS}>:xios>
-    $<$<BOOL:${ENABLE_XIOS}>:HDF5::HDF5>
-    Boost::program_options Boost::log "${NSDG_NetCDF_Library}" Eigen3::Eigen
-    $<$<BOOL:${ENABLE_MPI}>:MPI::MPI_C> $<$<BOOL:${ENABLE_MPI}>:MPI::MPI_CXX>
-    "${FORTRAN_RUNTIME_LIB}"
-    )
-
-add_executable(nextsim ./core/src/main.cpp)
-target_compile_definitions(nextsim
-    PRIVATE
-    $<$<BOOL:${ENABLE_MPI}>:USE_MPI>
-    $<$<BOOL:${ENABLE_XIOS}>:USE_XIOS>
-    )
+# main executable
+add_executable(nextsim "./core/src/main.cpp")
+target_link_libraries(nextsim PRIVATE nextsimlib)
+# nextsimlib does not expose the needed includes so they need to be set again
 target_include_directories(nextsim PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}"
     "${NextsimIncludeDirs}"
     )
-target_link_libraries(nextsim PUBLIC nextsimlib)
 
 # Generate the restart files that don't require additional data
 add_subdirectory(run)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,11 +6,15 @@ set(CMAKE_CXX_STANDARD 17)
 project(nextsim_dg)
 
 # user definable build options
-OPTION(WITH_THREADS "Build with support for openmp" OFF)
+option(WITH_THREADS "Build with support for openmp" OFF)
 option(ENABLE_MPI "Enable distributed-memory parallelization with MPI" OFF)
 option(ENABLE_XIOS "Enable XIOS library for IO" OFF)
 option(BUILD_TESTS "Build the tests" ON)
-set(DynamicsType "DG2" CACHE STRING "Set the discretization order for the dynamics, either DG1 or DG2")
+set(DynamicsType
+    "DG2"
+    CACHE STRING
+    "Set the discretization order for the dynamics, either DG1 or DG2"
+)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
@@ -23,7 +27,7 @@ target_compile_features(nextsimlib PUBLIC cxx_std_17)
 # NetCDF
 find_package(PkgConfig)
 pkg_search_module(NETCDF_CXX4 netcdf-cxx4)
-if (NETCDF_CXX4_FOUND)
+if(NETCDF_CXX4_FOUND)
     set(NSDG_NetCDF_Library "${NETCDF_CXX4_LIBRARIES}")
     set(netCDF_INCLUDE_DIR "${NETCDF_CXX4_INCLUDE_DIRS}")
     set(netCDF_LIB_DIR "${NETCDF_CXX4_LIBRARY_DIRS}")
@@ -35,30 +39,26 @@ else()
         set(NSDG_NetCDF_Library "netcdf_c++4")
     endif()
 endif()
-target_include_directories(nextsimlib
-    PUBLIC
-    "${netCDF_INCLUDE_DIR}"
-    )
+target_include_directories(nextsimlib PUBLIC "${netCDF_INCLUDE_DIR}")
 target_link_directories(nextsimlib PUBLIC "${netCDF_LIB_DIR}")
-target_link_libraries(nextsimlib PUBLIC "${NSDG_NetCDF_Library}"
-    "${FORTRAN_RUNTIME_LIB}"
-    )
+target_link_libraries(nextsimlib PUBLIC "${NSDG_NetCDF_Library}" "${FORTRAN_RUNTIME_LIB}")
 
 if(BUILD_TESTS)
     # Add the doctest header library
     set(DOCTEST_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/lib)
     add_library(doctest::doctest IMPORTED INTERFACE)
-    set_property(TARGET doctest::doctest PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${DOCTEST_INCLUDE_DIR}")
+    set_property(
+        TARGET doctest::doctest
+        PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${DOCTEST_INCLUDE_DIR}"
+    )
 endif()
 
 # Eigen
 find_package(Eigen3 3.4 REQUIRED)
-target_link_libraries(nextsimlib PUBLIC
-    Eigen3::Eigen
-    )
+target_link_libraries(nextsimlib PUBLIC Eigen3::Eigen)
 
 set(Python_FIND_VIRTUALENV FIRST)
-find_package (Python COMPONENTS Interpreter)
+find_package(Python COMPONENTS Interpreter)
 
 # The location of the module_builder.py scripts
 set(ScriptDirectory "${PROJECT_SOURCE_DIR}/scripts")
@@ -73,32 +73,27 @@ set(isDG FALSE)
 
 message("Dynamics is set to ${DynamicsType}")
 
-if (DynamicsType STREQUAL "DG1")
+if(DynamicsType STREQUAL "DG1")
     set(isDG TRUE)
     set(DGComp 3)
     set(CGDegree 1)
 endif()
 
-if (DynamicsType STREQUAL "DG2")
+if(DynamicsType STREQUAL "DG2")
     set(isDG TRUE)
     set(DGComp 6)
     set(CGDegree 2)
 endif()
 
 # Set the components which provide source or object code to the main model
-set(CodeComponents
-    "physics"
-    )
+set(CodeComponents "physics")
 
-if (isDG)
-# Add the DG dynamics subdirectory to the list of code components
-    set(CodeComponents
-        "${CodeComponents}"
-        "dynamics"
-        )
+if(isDG)
+    # Add the DG dynamics subdirectory to the list of code components
+    set(CodeComponents "${CodeComponents}" "dynamics")
 
-# Set the number of DG stress components given the CG degree
-    if (CGDegree EQUAL 1)
+    # Set the number of DG stress components given the CG degree
+    if(CGDegree EQUAL 1)
         set(DGStressComp 3)
     elseif(CGDegree EQUAL 2)
         set(DGStressComp 8)
@@ -106,22 +101,18 @@ if (isDG)
         message("Invalid value of CGDegree. Valid values are 1–2")
     endif()
 
-# The exact selection of dimensions and Types available to ModelArray
+    # The exact selection of dimensions and Types available to ModelArray
     set(ModelArrayStructure "discontinuousgalerkin")
 endif()
 # set degree / component parameters
-target_compile_definitions(nextsimlib
-    PRIVATE
-    DGCOMP=${DGComp}
-    DGSTRESSCOMP=${DGStressComp}
-    CGDEGREE=${CGDegree}
-    )
+target_compile_definitions(
+    nextsimlib
+    PRIVATE DGCOMP=${DGComp} DGSTRESSCOMP=${DGStressComp} CGDEGREE=${CGDegree}
+)
 
 # boost
 find_package(Boost COMPONENTS program_options log REQUIRED)
-target_link_libraries(nextsimlib PUBLIC
-    Boost::program_options Boost::log
-    )
+target_link_libraries(nextsimlib PUBLIC Boost::program_options Boost::log)
 # Regarding Boost.Log, if our application consists of more
 # than one modules that use it, we must link to the shared
 # version. If we have a single executable or a single module
@@ -135,33 +126,27 @@ target_compile_definitions(nextsimlib PUBLIC BOOST_ALL_DYN_LINK)
 # MPI
 if(ENABLE_MPI)
     find_package(MPI REQUIRED COMPONENTS C CXX)
-    target_compile_definitions(nextsimlib
-        PUBLIC
-        USE_MPI)
+    target_compile_definitions(nextsimlib PUBLIC USE_MPI)
     target_link_libraries(nextsimlib PUBLIC MPI::MPI_C MPI::MPI_CXX)
 endif()
 
 # XIOS
-if (ENABLE_XIOS)
+if(ENABLE_XIOS)
     message(STATUS "Building with XIOS library")
     find_package(xios REQUIRED)
     find_package(HDF5 REQUIRED COMPONENTS C HL)
-    target_compile_definitions(nextsimlib
-    PUBLIC
-    USE_XIOS)
+    target_compile_definitions(nextsimlib PUBLIC USE_XIOS)
 
     target_link_directories(nextsimlib PUBLIC ${xios_LIBRARIES})
     target_link_libraries(nextsimlib PUBLIC xios HDF5::HDF5)
-    target_include_directories(nextsimlib
-    PRIVATE
-    ${xios_INCLUDES}
-    ${xios_EXTERNS}/blitz/
-    ${xios_EXTERNS}/rapidxml/include
+    target_include_directories(
+        nextsimlib
+        PRIVATE ${xios_INCLUDES} ${xios_EXTERNS}/blitz/ ${xios_EXTERNS}/rapidxml/include
     )
 endif()
 
 # OpenMP
-if (WITH_THREADS)
+if(WITH_THREADS)
     find_package(OpenMP REQUIRED)
     target_link_libraries(nextsimlib PUBLIC OpenMP::OpenMP_CXX)
 endif()
@@ -182,20 +167,13 @@ foreach(compo ${CodeComponents})
 endforeach()
 
 target_sources(nextsimlib PRIVATE ${NextsimSources})
-target_include_directories(nextsimlib
-    PRIVATE
-    "${CMAKE_CURRENT_SOURCE_DIR}"
-    "${NextsimIncludeDirs}"
-    )
+target_include_directories(nextsimlib PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}" "${NextsimIncludeDirs}")
 
 # main executable
 add_executable(nextsim "./core/src/main.cpp")
 target_link_libraries(nextsim PRIVATE nextsimlib)
 # nextsimlib does not expose the needed includes so they need to be set again
-target_include_directories(nextsim PRIVATE
-    "${CMAKE_CURRENT_SOURCE_DIR}"
-    "${NextsimIncludeDirs}"
-    )
+target_include_directories(nextsim PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}" "${NextsimIncludeDirs}")
 
 # Generate the restart files that don't require additional data
 add_subdirectory(run)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,12 +1,8 @@
 add_subdirectory(src)
-if (BUILD_TESTS) #(NOT(CMAKE_BUILD_TYPE STREQUAL "Release"))
+if(BUILD_TESTS) #(NOT(CMAKE_BUILD_TYPE STREQUAL "Release"))
     add_subdirectory(test)
 endif()
 
-set(NextsimSources
-    "${NextsimSources}"
-    PARENT_SCOPE)
+set(NextsimSources "${NextsimSources}" PARENT_SCOPE)
 
-set(NextsimIncludeDirs
-    "${NextsimIncludeDirs}"
-    PARENT_SCOPE)
+set(NextsimIncludeDirs "${NextsimIncludeDirs}" PARENT_SCOPE)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_subdirectory(src)
-if (NOT(CMAKE_BUILD_TYPE STREQUAL "Release"))
+if (BUILD_TESTS) #(NOT(CMAKE_BUILD_TYPE STREQUAL "Release"))
     add_subdirectory(test)
 endif()
 

--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -27,11 +27,9 @@ set(BaseSources
     "Time.cpp"
     "${ModelArrayStructure}/ModelArrayDetails.cpp"
     "Xios.cpp"
-    )
+)
 
-set(ParallelNetCDFSources
-    "${CMAKE_CURRENT_SOURCE_DIR}/ParallelNetcdfFile.cpp"
-    )
+set(ParallelNetCDFSources "${CMAKE_CURRENT_SOURCE_DIR}/ParallelNetcdfFile.cpp")
 
 list(TRANSFORM BaseSources PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
 
@@ -41,23 +39,18 @@ add_subdirectory("${ModuleDir}")
 
 list(TRANSFORM ModuleSources PREPEND "${ModuleDir}/")
 
-set(NextsimSourcesTemp
-  "${BaseSources}"
-  "${NextsimSources}"
-  "${ModuleSources}"
-  )
+set(NextsimSourcesTemp "${BaseSources}" "${NextsimSources}" "${ModuleSources}")
 
 if(ENABLE_MPI)
-  list(APPEND NextsimSourcesTemp "${ParallelNetCDFSources}")
+    list(APPEND NextsimSourcesTemp "${ParallelNetCDFSources}")
 endif()
 
-set(NextsimSources
-  "${NextsimSourcesTemp}"
-  PARENT_SCOPE)
+set(NextsimSources "${NextsimSourcesTemp}" PARENT_SCOPE)
 
 set(NextsimIncludeDirs
     "${NextsimIncludeDirs}"
     "${ModuleDir}"
     "${CMAKE_CURRENT_SOURCE_DIR}"
     "${CMAKE_CURRENT_SOURCE_DIR}/${ModelArrayStructure}"
-    PARENT_SCOPE)
+    PARENT_SCOPE
+)

--- a/core/src/modules/CMakeLists.txt
+++ b/core/src/modules/CMakeLists.txt
@@ -6,28 +6,28 @@ file(GLOB ModuleSubDirs LIST_DIRECTORIES TRUE "*Module")
 
 foreach(ModuleSubDir IN LISTS ModuleSubDirs)
     # Ignore directories without a module.cfg file
-    IF (NOT EXISTS "${ModuleSubDir}/module.cfg")
-        CONTINUE()
-    ENDIF()
+    if(NOT EXISTS "${ModuleSubDir}/module.cfg")
+        continue()
+    endif()
 
-    IF (NOT EXISTS("include/${ModuleSubDir}.hpp"))
+    if(NOT EXISTS ("include/${ModuleSubDir}.hpp"))
         # Run the header python script
-        EXECUTE_PROCESS(COMMAND "${Python_EXECUTABLE}" "${ModuleHeaderScript}" WORKING_DIRECTORY "${ModuleSubDir}")
-    ENDIF()
-    
+        execute_process(
+            COMMAND "${Python_EXECUTABLE}" "${ModuleHeaderScript}"
+            WORKING_DIRECTORY "${ModuleSubDir}"
+        )
+    endif()
+
     # Run the source python script
-    EXECUTE_PROCESS(COMMAND "${Python_EXECUTABLE}" "${ModuleBuilderScript}" WORKING_DIRECTORY "${ModuleSubDir}")
-    
+    execute_process(
+        COMMAND "${Python_EXECUTABLE}" "${ModuleBuilderScript}"
+        WORKING_DIRECTORY "${ModuleSubDir}"
+    )
+
     # List all sources in the subdirectory
     file(GLOB ThisModuleSources LIST_DIRECTORIES FALSE "${ModuleSubDir}/*.cpp")
-    
-    set(AllModuleSources
-        "${AllModuleSources}"
-        "${ThisModuleSources}"
-        )
+
+    set(AllModuleSources "${AllModuleSources}" "${ThisModuleSources}")
 endforeach()
 
-set(NextsimSources
-    "${NextsimSources}"
-    "${AllModuleSources}"
-    PARENT_SCOPE)
+set(NextsimSources "${NextsimSources}" "${AllModuleSources}" PARENT_SCOPE)

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -32,7 +32,7 @@ if(ENABLE_MPI)
 
 
   add_executable(testRectGrid_MPI3 "RectGrid_test.cpp" "MainMPI.cpp")
-  target_compile_definitions(testRectGrid_MPI3 PRIVATE USE_MPI TEST_FILES_DIR=\"${CMAKE_CURRENT_BINARY_DIR}\")
+  target_compile_definitions(testRectGrid_MPI3 PRIVATE TEST_FILES_DIR=\"${CMAKE_CURRENT_BINARY_DIR}\")
   target_include_directories(testRectGrid_MPI3 PRIVATE ${MODEL_INCLUDE_DIR} "${ModulesRoot}/StructureModule")
   target_link_libraries(testRectGrid_MPI3 PRIVATE nextsimlib doctest::doctest)
 
@@ -60,37 +60,37 @@ if(ENABLE_MPI)
       )
 
     add_executable(testXiosCalendar_MPI2 "XiosCalendar_test.cpp" "MainMPI.cpp")
-    target_compile_definitions(testXiosCalendar_MPI2 PRIVATE USE_XIOS USE_MPI)
+    target_compile_definitions(testXiosCalendar_MPI2 PRIVATE USE_XIOS)
     target_include_directories(testXiosCalendar_MPI2 PRIVATE "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}" "${ModulesRoot}/StructureModule")
     target_link_libraries(testXiosCalendar_MPI2 PRIVATE nextsimlib doctest::doctest)
 
     add_executable(testXiosAxis_MPI2 "XiosAxis_test.cpp" "MainMPI.cpp")
-    target_compile_definitions(testXiosAxis_MPI2 PRIVATE USE_XIOS USE_MPI)
+    target_compile_definitions(testXiosAxis_MPI2 PRIVATE USE_XIOS)
     target_include_directories(testXiosAxis_MPI2 PRIVATE "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}" "${ModulesRoot}/StructureModule")
     target_link_libraries(testXiosAxis_MPI2 PRIVATE nextsimlib doctest::doctest)
 
     add_executable(testXiosDomain_MPI2 "XiosDomain_test.cpp" "MainMPI.cpp")
-    target_compile_definitions(testXiosDomain_MPI2 PRIVATE USE_XIOS USE_MPI)
+    target_compile_definitions(testXiosDomain_MPI2 PRIVATE USE_XIOS)
     target_include_directories(testXiosDomain_MPI2 PRIVATE "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}" "${ModulesRoot}/StructureModule")
     target_link_libraries(testXiosDomain_MPI2 PRIVATE nextsimlib doctest::doctest)
 
     add_executable(testXiosGrid_MPI2 "XiosGrid_test.cpp" "MainMPI.cpp")
-    target_compile_definitions(testXiosGrid_MPI2 PRIVATE USE_XIOS USE_MPI)
+    target_compile_definitions(testXiosGrid_MPI2 PRIVATE USE_XIOS)
     target_include_directories(testXiosGrid_MPI2 PRIVATE "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}" "${ModulesRoot}/StructureModule")
     target_link_libraries(testXiosGrid_MPI2 PRIVATE nextsimlib doctest::doctest)
 
     add_executable(testXiosField_MPI2 "XiosField_test.cpp" "MainMPI.cpp")
-    target_compile_definitions(testXiosField_MPI2 PRIVATE USE_XIOS USE_MPI)
+    target_compile_definitions(testXiosField_MPI2 PRIVATE USE_XIOS)
     target_include_directories(testXiosField_MPI2 PRIVATE "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}" "${ModulesRoot}/StructureModule")
     target_link_libraries(testXiosField_MPI2 PRIVATE nextsimlib doctest::doctest)
 
     add_executable(testXiosFile_MPI2 "XiosFile_test.cpp" "MainMPI.cpp")
-    target_compile_definitions(testXiosFile_MPI2 PRIVATE USE_XIOS USE_MPI)
+    target_compile_definitions(testXiosFile_MPI2 PRIVATE USE_XIOS)
     target_include_directories(testXiosFile_MPI2 PRIVATE "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}" "${ModulesRoot}/StructureModule")
     target_link_libraries(testXiosFile_MPI2 PRIVATE nextsimlib doctest::doctest)
 
     add_executable(testXiosWrite_MPI2 "XiosWrite_test.cpp" "MainMPI.cpp")
-    target_compile_definitions(testXiosWrite_MPI2 PRIVATE USE_XIOS USE_MPI)
+    target_compile_definitions(testXiosWrite_MPI2 PRIVATE USE_XIOS)
     target_include_directories(testXiosWrite_MPI2 PRIVATE "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}" "${ModulesRoot}/StructureModule")
     target_link_libraries(testXiosWrite_MPI2 PRIVATE nextsimlib doctest::doctest)
 

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -3,176 +3,263 @@ set(COMMON_INCLUDE_DIRS
     "../../core/src"
     "../../core/src/modules"
     "../../core/src/include"
-    )
+)
 
-set(PHYSICS_INCLUDE_DIRS
-    "../../physics/src"
-    "../../physics/src/modules"
-    )
+set(PHYSICS_INCLUDE_DIRS "../../physics/src" "../../physics/src/modules")
 
 set(ModulesRoot "../src/modules")
 
 # Generate netCDF files for tests
-execute_process(COMMAND "${Python_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/old_names.py" WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
+execute_process(
+    COMMAND "${Python_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/old_names.py"
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+)
 
 include_directories(${COMMON_INCLUDE_DIRS})
 set(MODEL_INCLUDE_DIR "../../core/src/discontinuousgalerkin")
 
 if(ENABLE_MPI)
-# Generate partition files needed for MPI test from respective cdl files
-  add_custom_command(OUTPUT partition_metadata_3.nc
-      COMMAND ncgen -b -o partition_metadata_3.nc ${CMAKE_CURRENT_SOURCE_DIR}/partition_metadata_3.cdl
-      DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/partition_metadata_3.cdl
-  )
-  add_custom_command(OUTPUT partition_metadata_2.nc
-      COMMAND ncgen -b -o partition_metadata_2.nc ${CMAKE_CURRENT_SOURCE_DIR}/partition_metadata_2.cdl
-      DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/partition_metadata_2.cdl
-  )
-  add_custom_target(generate_partition_files ALL DEPENDS partition_metadata_3.nc partition_metadata_2.nc)
-
-
-  add_executable(testRectGrid_MPI3 "RectGrid_test.cpp" "MainMPI.cpp")
-  target_compile_definitions(testRectGrid_MPI3 PRIVATE TEST_FILES_DIR=\"${CMAKE_CURRENT_BINARY_DIR}\")
-  target_include_directories(testRectGrid_MPI3 PRIVATE ${MODEL_INCLUDE_DIR} "${ModulesRoot}/StructureModule")
-  target_link_libraries(testRectGrid_MPI3 PRIVATE nextsimlib doctest::doctest)
-
-  add_executable(testParaGrid_MPI2 "ParaGrid_test.cpp" "MainMPI.cpp")
-  target_compile_definitions(testParaGrid_MPI2 PRIVATE USE_MPI TEST_FILES_DIR=\"${CMAKE_CURRENT_BINARY_DIR}\" TEST_FILE_SOURCE=\"${CMAKE_CURRENT_SOURCE_DIR}\")
-  target_include_directories(testParaGrid_MPI2 PRIVATE ${MODEL_INCLUDE_DIR} "${ModulesRoot}/StructureModule")
-  target_link_libraries(testParaGrid_MPI2 PRIVATE nextsimlib doctest::doctest)
-
-  add_executable(testConfigOutput_MPI2 "ConfigOutput_test.cpp" "MainMPI.cpp")
-  target_compile_definitions(testConfigOutput_MPI2 PRIVATE USE_MPI TEST_FILES_DIR=\"${CMAKE_CURRENT_BINARY_DIR}\")
-  target_include_directories(testConfigOutput_MPI2 PRIVATE ${MODEL_INCLUDE_DIR})
-  target_link_libraries(testConfigOutput_MPI2 PRIVATE nextsimlib doctest::doctest)
-
-  if(ENABLE_XIOS)
-    FILE(CREATE_LINK "${CMAKE_SOURCE_DIR}/core/test/iodef.xml" "${CMAKE_CURRENT_BINARY_DIR}/iodef.xml" SYMBOLIC)
-    add_custom_command(OUTPUT xios_test_input.nc
-      COMMAND ncgen -o xios_test_input.nc ${CMAKE_CURRENT_SOURCE_DIR}/xios_test_input.cdl
-      DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/xios_test_input.cdl
+    # Generate partition files needed for MPI test from respective cdl files
+    add_custom_command(
+        OUTPUT partition_metadata_3.nc
+        COMMAND
+            ncgen -b -o partition_metadata_3.nc ${CMAKE_CURRENT_SOURCE_DIR}/partition_metadata_3.cdl
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/partition_metadata_3.cdl
     )
-    add_custom_target(generate_xios_input_file ALL DEPENDS xios_test_input.nc)
-    set(XIOS_INCLUDE_LIST
-      "${xios_INCLUDES}"
-      "${xios_EXTERNS}/blitz/"
-      "${xios_EXTERNS}/rapidxml/include"
-      )
+    add_custom_command(
+        OUTPUT partition_metadata_2.nc
+        COMMAND
+            ncgen -b -o partition_metadata_2.nc ${CMAKE_CURRENT_SOURCE_DIR}/partition_metadata_2.cdl
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/partition_metadata_2.cdl
+    )
+    add_custom_target(
+        generate_partition_files
+        ALL
+        DEPENDS partition_metadata_3.nc partition_metadata_2.nc
+    )
 
-    add_executable(testXiosCalendar_MPI2 "XiosCalendar_test.cpp" "MainMPI.cpp")
-    target_compile_definitions(testXiosCalendar_MPI2 PRIVATE USE_XIOS)
-    target_include_directories(testXiosCalendar_MPI2 PRIVATE "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}" "${ModulesRoot}/StructureModule")
-    target_link_libraries(testXiosCalendar_MPI2 PRIVATE nextsimlib doctest::doctest)
+    add_executable(testRectGrid_MPI3 "RectGrid_test.cpp" "MainMPI.cpp")
+    target_compile_definitions(
+        testRectGrid_MPI3
+        PRIVATE TEST_FILES_DIR=\"${CMAKE_CURRENT_BINARY_DIR}\"
+    )
+    target_include_directories(
+        testRectGrid_MPI3
+        PRIVATE ${MODEL_INCLUDE_DIR} "${ModulesRoot}/StructureModule"
+    )
+    target_link_libraries(testRectGrid_MPI3 PRIVATE nextsimlib doctest::doctest)
 
-    add_executable(testXiosAxis_MPI2 "XiosAxis_test.cpp" "MainMPI.cpp")
-    target_compile_definitions(testXiosAxis_MPI2 PRIVATE USE_XIOS)
-    target_include_directories(testXiosAxis_MPI2 PRIVATE "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}" "${ModulesRoot}/StructureModule")
-    target_link_libraries(testXiosAxis_MPI2 PRIVATE nextsimlib doctest::doctest)
+    add_executable(testParaGrid_MPI2 "ParaGrid_test.cpp" "MainMPI.cpp")
+    target_compile_definitions(
+        testParaGrid_MPI2
+        PRIVATE
+            USE_MPI
+            TEST_FILES_DIR=\"${CMAKE_CURRENT_BINARY_DIR}\"
+            TEST_FILE_SOURCE=\"${CMAKE_CURRENT_SOURCE_DIR}\"
+    )
+    target_include_directories(
+        testParaGrid_MPI2
+        PRIVATE ${MODEL_INCLUDE_DIR} "${ModulesRoot}/StructureModule"
+    )
+    target_link_libraries(testParaGrid_MPI2 PRIVATE nextsimlib doctest::doctest)
 
-    add_executable(testXiosDomain_MPI2 "XiosDomain_test.cpp" "MainMPI.cpp")
-    target_compile_definitions(testXiosDomain_MPI2 PRIVATE USE_XIOS)
-    target_include_directories(testXiosDomain_MPI2 PRIVATE "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}" "${ModulesRoot}/StructureModule")
-    target_link_libraries(testXiosDomain_MPI2 PRIVATE nextsimlib doctest::doctest)
+    add_executable(testConfigOutput_MPI2 "ConfigOutput_test.cpp" "MainMPI.cpp")
+    target_compile_definitions(
+        testConfigOutput_MPI2
+        PRIVATE USE_MPI TEST_FILES_DIR=\"${CMAKE_CURRENT_BINARY_DIR}\"
+    )
+    target_include_directories(testConfigOutput_MPI2 PRIVATE ${MODEL_INCLUDE_DIR})
+    target_link_libraries(testConfigOutput_MPI2 PRIVATE nextsimlib doctest::doctest)
 
-    add_executable(testXiosGrid_MPI2 "XiosGrid_test.cpp" "MainMPI.cpp")
-    target_compile_definitions(testXiosGrid_MPI2 PRIVATE USE_XIOS)
-    target_include_directories(testXiosGrid_MPI2 PRIVATE "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}" "${ModulesRoot}/StructureModule")
-    target_link_libraries(testXiosGrid_MPI2 PRIVATE nextsimlib doctest::doctest)
+    if(ENABLE_XIOS)
+        file(
+            CREATE_LINK
+                "${CMAKE_SOURCE_DIR}/core/test/iodef.xml"
+                "${CMAKE_CURRENT_BINARY_DIR}/iodef.xml"
+            SYMBOLIC
+        )
+        add_custom_command(
+            OUTPUT xios_test_input.nc
+            COMMAND ncgen -o xios_test_input.nc ${CMAKE_CURRENT_SOURCE_DIR}/xios_test_input.cdl
+            DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/xios_test_input.cdl
+        )
+        add_custom_target(generate_xios_input_file ALL DEPENDS xios_test_input.nc)
+        set(XIOS_INCLUDE_LIST
+            "${xios_INCLUDES}"
+            "${xios_EXTERNS}/blitz/"
+            "${xios_EXTERNS}/rapidxml/include"
+        )
 
-    add_executable(testXiosField_MPI2 "XiosField_test.cpp" "MainMPI.cpp")
-    target_compile_definitions(testXiosField_MPI2 PRIVATE USE_XIOS)
-    target_include_directories(testXiosField_MPI2 PRIVATE "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}" "${ModulesRoot}/StructureModule")
-    target_link_libraries(testXiosField_MPI2 PRIVATE nextsimlib doctest::doctest)
+        add_executable(testXiosCalendar_MPI2 "XiosCalendar_test.cpp" "MainMPI.cpp")
+        target_compile_definitions(testXiosCalendar_MPI2 PRIVATE USE_XIOS)
+        target_include_directories(
+            testXiosCalendar_MPI2
+            PRIVATE "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}" "${ModulesRoot}/StructureModule"
+        )
+        target_link_libraries(testXiosCalendar_MPI2 PRIVATE nextsimlib doctest::doctest)
 
-    add_executable(testXiosFile_MPI2 "XiosFile_test.cpp" "MainMPI.cpp")
-    target_compile_definitions(testXiosFile_MPI2 PRIVATE USE_XIOS)
-    target_include_directories(testXiosFile_MPI2 PRIVATE "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}" "${ModulesRoot}/StructureModule")
-    target_link_libraries(testXiosFile_MPI2 PRIVATE nextsimlib doctest::doctest)
+        add_executable(testXiosAxis_MPI2 "XiosAxis_test.cpp" "MainMPI.cpp")
+        target_compile_definitions(testXiosAxis_MPI2 PRIVATE USE_XIOS)
+        target_include_directories(
+            testXiosAxis_MPI2
+            PRIVATE "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}" "${ModulesRoot}/StructureModule"
+        )
+        target_link_libraries(testXiosAxis_MPI2 PRIVATE nextsimlib doctest::doctest)
 
-    add_executable(testXiosWrite_MPI2 "XiosWrite_test.cpp" "MainMPI.cpp")
-    target_compile_definitions(testXiosWrite_MPI2 PRIVATE USE_XIOS)
-    target_include_directories(testXiosWrite_MPI2 PRIVATE "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}" "${ModulesRoot}/StructureModule")
-    target_link_libraries(testXiosWrite_MPI2 PRIVATE nextsimlib doctest::doctest)
+        add_executable(testXiosDomain_MPI2 "XiosDomain_test.cpp" "MainMPI.cpp")
+        target_compile_definitions(testXiosDomain_MPI2 PRIVATE USE_XIOS)
+        target_include_directories(
+            testXiosDomain_MPI2
+            PRIVATE "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}" "${ModulesRoot}/StructureModule"
+        )
+        target_link_libraries(testXiosDomain_MPI2 PRIVATE nextsimlib doctest::doctest)
 
-    add_executable(testXiosRead_MPI2 "XiosRead_test.cpp" "MainMPI.cpp")
-    target_compile_definitions(testXiosRead_MPI2 PRIVATE USE_XIOS USE_MPI)
-    target_include_directories(testXiosRead_MPI2 PRIVATE "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}" "${ModulesRoot}/StructureModule")
-    target_link_libraries(testXiosRead_MPI2 PRIVATE nextsimlib doctest::doctest)
-  endif()
+        add_executable(testXiosGrid_MPI2 "XiosGrid_test.cpp" "MainMPI.cpp")
+        target_compile_definitions(testXiosGrid_MPI2 PRIVATE USE_XIOS)
+        target_include_directories(
+            testXiosGrid_MPI2
+            PRIVATE "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}" "${ModulesRoot}/StructureModule"
+        )
+        target_link_libraries(testXiosGrid_MPI2 PRIVATE nextsimlib doctest::doctest)
+
+        add_executable(testXiosField_MPI2 "XiosField_test.cpp" "MainMPI.cpp")
+        target_compile_definitions(testXiosField_MPI2 PRIVATE USE_XIOS)
+        target_include_directories(
+            testXiosField_MPI2
+            PRIVATE "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}" "${ModulesRoot}/StructureModule"
+        )
+        target_link_libraries(testXiosField_MPI2 PRIVATE nextsimlib doctest::doctest)
+
+        add_executable(testXiosFile_MPI2 "XiosFile_test.cpp" "MainMPI.cpp")
+        target_compile_definitions(testXiosFile_MPI2 PRIVATE USE_XIOS)
+        target_include_directories(
+            testXiosFile_MPI2
+            PRIVATE "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}" "${ModulesRoot}/StructureModule"
+        )
+        target_link_libraries(testXiosFile_MPI2 PRIVATE nextsimlib doctest::doctest)
+
+        add_executable(testXiosWrite_MPI2 "XiosWrite_test.cpp" "MainMPI.cpp")
+        target_compile_definitions(testXiosWrite_MPI2 PRIVATE USE_XIOS)
+        target_include_directories(
+            testXiosWrite_MPI2
+            PRIVATE "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}" "${ModulesRoot}/StructureModule"
+        )
+        target_link_libraries(testXiosWrite_MPI2 PRIVATE nextsimlib doctest::doctest)
+
+        add_executable(testXiosRead_MPI2 "XiosRead_test.cpp" "MainMPI.cpp")
+        target_compile_definitions(testXiosRead_MPI2 PRIVATE USE_XIOS USE_MPI)
+        target_include_directories(
+            testXiosRead_MPI2
+            PRIVATE "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}" "${ModulesRoot}/StructureModule"
+        )
+        target_link_libraries(testXiosRead_MPI2 PRIVATE nextsimlib doctest::doctest)
+    endif()
 else()
+    add_executable(testRectGrid "RectGrid_test.cpp")
+    target_compile_definitions(testRectGrid PRIVATE TEST_FILES_DIR=\"${CMAKE_CURRENT_BINARY_DIR}\")
+    target_include_directories(
+        testRectGrid
+        PRIVATE ${MODEL_INCLUDE_DIR} "${ModulesRoot}/StructureModule"
+    )
+    target_link_libraries(testRectGrid PRIVATE nextsimlib doctest::doctest)
 
-  add_executable(testRectGrid "RectGrid_test.cpp")
-  target_compile_definitions(testRectGrid PRIVATE TEST_FILES_DIR=\"${CMAKE_CURRENT_BINARY_DIR}\")
-  target_include_directories(testRectGrid PRIVATE ${MODEL_INCLUDE_DIR} "${ModulesRoot}/StructureModule")
-  target_link_libraries(testRectGrid PRIVATE nextsimlib doctest::doctest)
+    add_executable(testParaGrid "ParaGrid_test.cpp")
+    target_compile_definitions(
+        testParaGrid
+        PRIVATE
+            TEST_FILES_DIR=\"${CMAKE_CURRENT_BINARY_DIR}\"
+            TEST_FILE_SOURCE=\"${CMAKE_CURRENT_SOURCE_DIR}\"
+    )
+    target_include_directories(
+        testParaGrid
+        PRIVATE ${MODEL_INCLUDE_DIR} "${ModulesRoot}/StructureModule"
+    )
+    target_link_libraries(testParaGrid PRIVATE nextsimlib doctest::doctest)
 
-  add_executable(testParaGrid "ParaGrid_test.cpp")
-  target_compile_definitions(testParaGrid PRIVATE TEST_FILES_DIR=\"${CMAKE_CURRENT_BINARY_DIR}\" TEST_FILE_SOURCE=\"${CMAKE_CURRENT_SOURCE_DIR}\")
-  target_include_directories(testParaGrid PRIVATE ${MODEL_INCLUDE_DIR} "${ModulesRoot}/StructureModule")
-  target_link_libraries(testParaGrid PRIVATE nextsimlib doctest::doctest)
+    add_executable(testConfigOutput "ConfigOutput_test.cpp")
+    target_compile_definitions(
+        testConfigOutput
+        PRIVATE TEST_FILES_DIR=\"${CMAKE_CURRENT_BINARY_DIR}\"
+    )
+    target_include_directories(testConfigOutput PRIVATE ${MODEL_INCLUDE_DIR})
+    target_link_libraries(testConfigOutput PRIVATE nextsimlib doctest::doctest)
 
-  add_executable(testConfigOutput "ConfigOutput_test.cpp")
-  target_compile_definitions(testConfigOutput PRIVATE TEST_FILES_DIR=\"${CMAKE_CURRENT_BINARY_DIR}\")
-  target_include_directories(testConfigOutput PRIVATE ${MODEL_INCLUDE_DIR})
-  target_link_libraries(testConfigOutput PRIVATE nextsimlib doctest::doctest)
+    add_executable(testIterator "Iterator_test.cpp")
+    target_link_libraries(testIterator PRIVATE nextsimlib doctest::doctest)
 
-  add_executable(testIterator "Iterator_test.cpp")
-  target_link_libraries(testIterator PRIVATE nextsimlib doctest::doctest)
+    add_executable(testCommandLineParser "CommandLineParser_test.cpp" "ArgV.cpp")
+    target_link_libraries(testCommandLineParser PRIVATE nextsimlib doctest::doctest)
 
-  add_executable(testCommandLineParser "CommandLineParser_test.cpp" "ArgV.cpp")
-  target_link_libraries(testCommandLineParser PRIVATE nextsimlib doctest::doctest)
+    add_executable(testConfigurator "Configurator_test.cpp" "ArgV.cpp")
+    target_link_libraries(testConfigurator PRIVATE nextsimlib doctest::doctest)
 
-  add_executable(testConfigurator "Configurator_test.cpp" "ArgV.cpp")
-  target_link_libraries(testConfigurator PRIVATE nextsimlib doctest::doctest)
+    add_executable(testConfiguredModule "ConfiguredModule_test.cpp" "ArgV.cpp")
+    target_link_libraries(testConfiguredModule PRIVATE nextsimlib doctest::doctest)
 
-  add_executable(testConfiguredModule "ConfiguredModule_test.cpp" "ArgV.cpp")
-  target_link_libraries(testConfiguredModule PRIVATE nextsimlib doctest::doctest)
+    add_executable(testTimer "Timer_test.cpp")
+    target_link_libraries(testTimer PRIVATE nextsimlib doctest::doctest)
 
-  add_executable(testTimer "Timer_test.cpp")
-  target_link_libraries(testTimer PRIVATE nextsimlib doctest::doctest)
+    add_executable(testScopedTimer "ScopedTimer_test.cpp" "../src/ScopedTimer.cpp")
+    target_link_libraries(testScopedTimer PRIVATE nextsimlib doctest::doctest)
 
-  add_executable(testScopedTimer "ScopedTimer_test.cpp" "../src/ScopedTimer.cpp")
-  target_link_libraries(testScopedTimer PRIVATE nextsimlib doctest::doctest)
+    add_executable(testTimeClasses "Time_test.cpp")
+    target_link_libraries(testTimeClasses PRIVATE nextsimlib doctest::doctest)
 
-  add_executable(testTimeClasses "Time_test.cpp")
-  target_link_libraries(testTimeClasses PRIVATE nextsimlib doctest::doctest)
+    add_executable(testModelComponent "ModelComponent_test.cpp")
+    target_include_directories(testModelComponent PRIVATE ${MODEL_INCLUDE_DIR})
+    target_link_libraries(testModelComponent PRIVATE nextsimlib doctest::doctest)
 
-  add_executable(testModelComponent "ModelComponent_test.cpp")
-  target_include_directories(testModelComponent PRIVATE ${MODEL_INCLUDE_DIR})
-  target_link_libraries(testModelComponent PRIVATE nextsimlib doctest::doctest)
+    add_executable(testModelArrayRef "ModelArrayRef_test.cpp")
+    target_include_directories(testModelArrayRef PRIVATE ${MODEL_INCLUDE_DIR})
+    target_link_libraries(testModelArrayRef PRIVATE nextsimlib doctest::doctest)
 
-  add_executable(testModelArrayRef "ModelArrayRef_test.cpp")
-  target_include_directories(testModelArrayRef PRIVATE ${MODEL_INCLUDE_DIR})
-  target_link_libraries(testModelArrayRef PRIVATE nextsimlib doctest::doctest)
+    # PrognosticData (and hopefully that alone) requires code from the physics tree
+    add_executable(testPrognosticData "PrognosticData_test.cpp" "DynamicsModuleForPDtest.cpp")
+    target_include_directories(
+        testPrognosticData
+        PRIVATE
+            ${PHYSICS_INCLUDE_DIRS}
+            ${MODEL_INCLUDE_DIR}
+            "${ModulesRoot}/FreezingPointModule"
+            "${ModulesRoot}/DynamicsModule"
+    )
+    target_link_libraries(testPrognosticData PRIVATE nextsimlib doctest::doctest)
 
-  # PrognosticData (and hopefully that alone) requires code from the physics tree
-  add_executable(testPrognosticData "PrognosticData_test.cpp" "DynamicsModuleForPDtest.cpp")
-  target_include_directories(testPrognosticData PRIVATE ${PHYSICS_INCLUDE_DIRS} ${MODEL_INCLUDE_DIR} "${ModulesRoot}/FreezingPointModule" "${ModulesRoot}/DynamicsModule")
-  target_link_libraries(testPrognosticData PRIVATE nextsimlib doctest::doctest)
+    # TODO: itegrate with the above test.
+    add_executable(testPrognosticDataIO "PrognosticDataIO_test.cpp" "DynamicsModuleForPDtest.cpp")
+    target_compile_definitions(testPrognosticDataIO PRIVATE ISDG=${isDG})
+    target_include_directories(
+        testPrognosticDataIO
+        PRIVATE
+            ${PHYSICS_INCLUDE_DIRS}
+            ${MODEL_INCLUDE_DIR}
+            "${ModulesRoot}/FreezingPointModule"
+            "${ModulesRoot}/DynamicsModule"
+            "${ModulesRoot}/StructureModule"
+    )
+    target_link_libraries(testPrognosticDataIO PRIVATE nextsimlib doctest::doctest)
 
-  # TODO: itegrate with the above test.
-  add_executable(testPrognosticDataIO "PrognosticDataIO_test.cpp" "DynamicsModuleForPDtest.cpp")
-  target_compile_definitions(testPrognosticDataIO PRIVATE ISDG=${isDG})
-  target_include_directories(testPrognosticDataIO PRIVATE ${PHYSICS_INCLUDE_DIRS} ${MODEL_INCLUDE_DIR} "${ModulesRoot}/FreezingPointModule" "${ModulesRoot}/DynamicsModule" "${ModulesRoot}/StructureModule")
-  target_link_libraries(testPrognosticDataIO PRIVATE nextsimlib doctest::doctest)
+    add_executable(testMonthlyCubicBSpline "MonthlyCubicBSpline_test.cpp")
+    target_link_libraries(testMonthlyCubicBSpline LINK_PUBLIC Boost::boost doctest::doctest)
 
-  add_executable(testMonthlyCubicBSpline
-      "MonthlyCubicBSpline_test.cpp"
-      )
-  target_link_libraries(testMonthlyCubicBSpline LINK_PUBLIC Boost::boost doctest::doctest)
+    add_executable(
+        testFileCallbackCloser
+        "FileCallbackCloser_test.cpp"
+        "../../core/src/FileCallbackCloser.cpp"
+    )
+    target_link_libraries(testFileCallbackCloser PRIVATE doctest::doctest)
 
-  add_executable(testFileCallbackCloser
-      "FileCallbackCloser_test.cpp"
-      "../../core/src/FileCallbackCloser.cpp"
-      )
-  target_link_libraries(testFileCallbackCloser PRIVATE doctest::doctest)
+    set(MODEL_INCLUDE_DIR "./testmodelarraydetails")
 
-  set(MODEL_INCLUDE_DIR "./testmodelarraydetails")
+    add_executable(
+        testModelArray
+        "ModelArray_test.cpp"
+        "../src/ModelArray.cpp"
+        "${MODEL_INCLUDE_DIR}/ModelArrayDetails.cpp"
+    )
+    target_include_directories(testModelArray PRIVATE "../src" "${MODEL_INCLUDE_DIR}")
+    target_link_libraries(testModelArray PRIVATE doctest::doctest Eigen3::Eigen)
 
-  add_executable(testModelArray "ModelArray_test.cpp" "../src/ModelArray.cpp" "${MODEL_INCLUDE_DIR}/ModelArrayDetails.cpp")
-  target_include_directories(testModelArray PRIVATE "../src" "${MODEL_INCLUDE_DIR}")
-  target_link_libraries(testModelArray PRIVATE doctest::doctest Eigen3::Eigen)
-
-  # The help config test needs access to the full binary
-  FILE(CREATE_LINK ${NEXTSIM_BINARY_PATH} ${CMAKE_CURRENT_BINARY_DIR}/nextsim SYMBOLIC)
+    # The help config test needs access to the full binary
+    file(CREATE_LINK ${NEXTSIM_BINARY_PATH} ${CMAKE_CURRENT_BINARY_DIR}/nextsim SYMBOLIC)
 endif()

--- a/dynamics/CMakeLists.txt
+++ b/dynamics/CMakeLists.txt
@@ -1,9 +1,8 @@
 add_subdirectory(src)
-#if (NOT(CMAKE_BUILD_TYPE STREQUAL "Release"))
-#    add_subdirectory(test)
-#endif()
 
-add_subdirectory(test)
+if (BUILD_TESTS)
+    add_subdirectory(test)
+endif()
 
 set(NextsimSources
     "${NextsimSources}"

--- a/dynamics/CMakeLists.txt
+++ b/dynamics/CMakeLists.txt
@@ -1,13 +1,9 @@
 add_subdirectory(src)
 
-if (BUILD_TESTS)
+if(BUILD_TESTS)
     add_subdirectory(test)
 endif()
 
-set(NextsimSources
-    "${NextsimSources}"
-    PARENT_SCOPE)
+set(NextsimSources "${NextsimSources}" PARENT_SCOPE)
 
-set(NextsimIncludeDirs
-    "${NextsimIncludeDirs}"
-    PARENT_SCOPE)
+set(NextsimIncludeDirs "${NextsimIncludeDirs}" PARENT_SCOPE)

--- a/dynamics/src/CMakeLists.txt
+++ b/dynamics/src/CMakeLists.txt
@@ -2,22 +2,21 @@ set(ModuleDir "${CMAKE_CURRENT_SOURCE_DIR}/modules")
 
 set(IncludeDir "${CMAKE_CURRENT_SOURCE_DIR}/include")
 
-
 ### Set the list of all cpp files
-FILE(GLOB DynamicsSources *.cpp)
+file(GLOB DynamicsSources *.cpp)
 
 set(NextsimSources
     "${NextsimSources}"
     "${Sources}"
     "${ModuleSources}"
     "${DynamicsSources}"
-    PARENT_SCOPE)
-
-
+    PARENT_SCOPE
+)
 
 set(NextsimIncludeDirs
     "${NextsimIncludeDirs}"
     "${ModuleDir}"
     "${IncludeDir}"
     "${CMAKE_CURRENT_SOURCE_DIR}"
-    PARENT_SCOPE)
+    PARENT_SCOPE
+)

--- a/dynamics/test/CMakeLists.txt
+++ b/dynamics/test/CMakeLists.txt
@@ -7,48 +7,69 @@ set(CoreDir "../../core/src/")
 include_directories(${INCLUDE_DIR})
 
 if(NOT ENABLE_MPI)
-  add_executable(testDGModelArray
-    "DGModelArray_test.cpp"
-    "${CoreDir}/ModelArray.cpp"
-    "${CoreDir}/${ModelArrayStructure}/ModelArrayDetails.cpp"
+    add_executable(
+        testDGModelArray
+        "DGModelArray_test.cpp"
+        "${CoreDir}/ModelArray.cpp"
+        "${CoreDir}/${ModelArrayStructure}/ModelArrayDetails.cpp"
     )
-  target_include_directories(testDGModelArray PRIVATE "${CoreDir}" "${SRC_DIR}" "${CoreDir}/${ModelArrayStructure}")
-  target_link_libraries(testDGModelArray LINK_PUBLIC doctest::doctest Eigen3::Eigen)
-
-  add_executable(testCGModelArray
-    "CGModelArray_test.cpp"
-    "${CoreDir}/ModelArray.cpp"
-    "${CoreDir}/${ModelArrayStructure}/ModelArrayDetails.cpp"
+    target_include_directories(
+        testDGModelArray
+        PRIVATE "${CoreDir}" "${SRC_DIR}" "${CoreDir}/${ModelArrayStructure}"
     )
-  target_include_directories(testCGModelArray PRIVATE "${CoreDir}" "${SRC_DIR}" "${CoreDir}/${ModelArrayStructure}")
-  target_link_libraries(testCGModelArray LINK_PUBLIC doctest::doctest Eigen3::Eigen)
+    target_link_libraries(testDGModelArray LINK_PUBLIC doctest::doctest Eigen3::Eigen)
 
-  file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/25km_NH.smesh" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
-
-  add_executable(testParametricMesh
-    "ParametricMesh_test.cpp"
-    "FakeSmeshData.cpp"
-    "${SRC_DIR}/ParametricMesh.cpp"
-    "${CoreDir}/ModelArray.cpp"
-    "${CoreDir}/${ModelArrayStructure}/ModelArrayDetails.cpp"
+    add_executable(
+        testCGModelArray
+        "CGModelArray_test.cpp"
+        "${CoreDir}/ModelArray.cpp"
+        "${CoreDir}/${ModelArrayStructure}/ModelArrayDetails.cpp"
     )
-  target_include_directories(testParametricMesh PRIVATE "${CoreDir}" "${SRC_DIR}" "${CoreDir}/${ModelArrayStructure}")
-  target_link_libraries(testParametricMesh LINK_PUBLIC doctest::doctest Eigen3::Eigen)
-
-
-  add_executable(testAdvection Advection_test.cpp
-    "${SRC_DIR}/Interpolations.cpp"
-    "${SRC_DIR}/DGTransport.cpp"
-    "${SRC_DIR}/ParametricMap.cpp"
+    target_include_directories(
+        testCGModelArray
+        PRIVATE "${CoreDir}" "${SRC_DIR}" "${CoreDir}/${ModelArrayStructure}"
     )
-  target_include_directories(testAdvection PRIVATE "${CoreDir}" "${SRC_DIR}" "${CoreDir}/${ModelArrayStructure}")
-  target_link_libraries(testAdvection LINK_PUBLIC doctest::doctest Eigen3::Eigen)
+    target_link_libraries(testCGModelArray LINK_PUBLIC doctest::doctest Eigen3::Eigen)
 
-  add_executable(testAdvectionPeriodicBC AdvectionPeriodicBC_test.cpp
-    "${SRC_DIR}/DGTransport.cpp"
-    "${SRC_DIR}/ParametricMap.cpp"
-    "${SRC_DIR}/Interpolations.cpp"
+    file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/25km_NH.smesh" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
+
+    add_executable(
+        testParametricMesh
+        "ParametricMesh_test.cpp"
+        "FakeSmeshData.cpp"
+        "${SRC_DIR}/ParametricMesh.cpp"
+        "${CoreDir}/ModelArray.cpp"
+        "${CoreDir}/${ModelArrayStructure}/ModelArrayDetails.cpp"
     )
-  target_include_directories(testAdvectionPeriodicBC PRIVATE "${CoreDir}" "${SRC_DIR}" "${CoreDir}/${ModelArrayStructure}")
-  target_link_libraries(testAdvectionPeriodicBC LINK_PUBLIC doctest::doctest Eigen3::Eigen)
+    target_include_directories(
+        testParametricMesh
+        PRIVATE "${CoreDir}" "${SRC_DIR}" "${CoreDir}/${ModelArrayStructure}"
+    )
+    target_link_libraries(testParametricMesh LINK_PUBLIC doctest::doctest Eigen3::Eigen)
+
+    add_executable(
+        testAdvection
+        Advection_test.cpp
+        "${SRC_DIR}/Interpolations.cpp"
+        "${SRC_DIR}/DGTransport.cpp"
+        "${SRC_DIR}/ParametricMap.cpp"
+    )
+    target_include_directories(
+        testAdvection
+        PRIVATE "${CoreDir}" "${SRC_DIR}" "${CoreDir}/${ModelArrayStructure}"
+    )
+    target_link_libraries(testAdvection LINK_PUBLIC doctest::doctest Eigen3::Eigen)
+
+    add_executable(
+        testAdvectionPeriodicBC
+        AdvectionPeriodicBC_test.cpp
+        "${SRC_DIR}/DGTransport.cpp"
+        "${SRC_DIR}/ParametricMap.cpp"
+        "${SRC_DIR}/Interpolations.cpp"
+    )
+    target_include_directories(
+        testAdvectionPeriodicBC
+        PRIVATE "${CoreDir}" "${SRC_DIR}" "${CoreDir}/${ModelArrayStructure}"
+    )
+    target_link_libraries(testAdvectionPeriodicBC LINK_PUBLIC doctest::doctest Eigen3::Eigen)
 endif()

--- a/physics/CMakeLists.txt
+++ b/physics/CMakeLists.txt
@@ -1,12 +1,8 @@
 add_subdirectory(src)
-if (BUILD_TESTS)
+if(BUILD_TESTS)
     add_subdirectory(test)
 endif()
 
-set(NextsimSources
-    "${NextsimSources}"
-    PARENT_SCOPE)
+set(NextsimSources "${NextsimSources}" PARENT_SCOPE)
 
-set(NextsimIncludeDirs
-    "${NextsimIncludeDirs}"
-    PARENT_SCOPE)
+set(NextsimIncludeDirs "${NextsimIncludeDirs}" PARENT_SCOPE)

--- a/physics/CMakeLists.txt
+++ b/physics/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_subdirectory(src)
-if (NOT(CMAKE_BUILD_TYPE STREQUAL "Release"))
+if (BUILD_TESTS)
     add_subdirectory(test)
 endif()
 

--- a/physics/src/CMakeLists.txt
+++ b/physics/src/CMakeLists.txt
@@ -2,22 +2,15 @@ set(ModuleDir "${CMAKE_CURRENT_SOURCE_DIR}/modules")
 
 add_subdirectory("${ModuleDir}")
 
-set(Sources
-    "IceGrowth.cpp"
-    "IceMinima.cpp"
-    "SlabOcean.cpp"
-    "BenchmarkCoordinates.cpp"
-    )
+set(Sources "IceGrowth.cpp" "IceMinima.cpp" "SlabOcean.cpp" "BenchmarkCoordinates.cpp")
 
 list(TRANSFORM Sources PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
 
-set(NextsimSources
-    "${NextsimSources}"
-    "${Sources}"
-    PARENT_SCOPE)
+set(NextsimSources "${NextsimSources}" "${Sources}" PARENT_SCOPE)
 
 set(NextsimIncludeDirs
     "${NextsimIncludeDirs}"
     "${ModuleDir}"
     "${CMAKE_CURRENT_SOURCE_DIR}"
-    PARENT_SCOPE)
+    PARENT_SCOPE
+)

--- a/physics/src/modules/CMakeLists.txt
+++ b/physics/src/modules/CMakeLists.txt
@@ -6,28 +6,28 @@ file(GLOB ModuleSubDirs LIST_DIRECTORIES TRUE "*Module")
 
 foreach(ModuleSubDir IN LISTS ModuleSubDirs)
     # Ignore directories without a module.cfg file
-    IF (NOT EXISTS "${ModuleSubDir}/module.cfg")
-        CONTINUE()
-    ENDIF()
+    if(NOT EXISTS "${ModuleSubDir}/module.cfg")
+        continue()
+    endif()
 
-    IF (NOT EXISTS("include/${ModuleSubDir}.hpp"))
+    if(NOT EXISTS ("include/${ModuleSubDir}.hpp"))
         # Run the header python script
-        EXECUTE_PROCESS(COMMAND "${Python_EXECUTABLE}" "${ModuleHeaderScript}" WORKING_DIRECTORY "${ModuleSubDir}")
-    ENDIF()
-    
+        execute_process(
+            COMMAND "${Python_EXECUTABLE}" "${ModuleHeaderScript}"
+            WORKING_DIRECTORY "${ModuleSubDir}"
+        )
+    endif()
+
     # Run the source python script
-    EXECUTE_PROCESS(COMMAND "${Python_EXECUTABLE}" "${ModuleBuilderScript}" WORKING_DIRECTORY "${ModuleSubDir}")
-    
+    execute_process(
+        COMMAND "${Python_EXECUTABLE}" "${ModuleBuilderScript}"
+        WORKING_DIRECTORY "${ModuleSubDir}"
+    )
+
     # List all sources in the subdirectory
     file(GLOB ThisModuleSources LIST_DIRECTORIES FALSE "${ModuleSubDir}/*.cpp")
-    
-    set(AllModuleSources
-        "${AllModuleSources}"
-        "${ThisModuleSources}"
-        )
+
+    set(AllModuleSources "${AllModuleSources}" "${ThisModuleSources}")
 endforeach()
 
-set(NextsimSources
-    "${NextsimSources}"
-    "${AllModuleSources}"
-    PARENT_SCOPE)
+set(NextsimSources "${NextsimSources}" "${AllModuleSources}" PARENT_SCOPE)

--- a/physics/test/CMakeLists.txt
+++ b/physics/test/CMakeLists.txt
@@ -4,82 +4,118 @@ set(COMMON_INCLUDE_DIRS
     "../../core/src/modules"
     "../src"
     "../src/modules"
-    )
+)
 
 set(ModulesRoot "../src/modules")
 set(CoreModulesRoot "../../core/src/modules")
 
 # Generate the boundary test data files
-execute_process(COMMAND "${Python_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/era5_test_data.py" WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
-execute_process(COMMAND "${Python_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/topaz_test_data.py" WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
+execute_process(
+    COMMAND "${Python_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/era5_test_data.py"
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+)
+execute_process(
+    COMMAND "${Python_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/topaz_test_data.py"
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+)
 
 include_directories(${COMMON_INCLUDE_DIRS})
 
 if(ENABLE_MPI)
-  add_executable(testERA5Atm_MPI1 "ERA5Atm_test.cpp" "../../core/test/MainMPI.cpp")
-  target_compile_definitions(testERA5Atm_MPI1 PRIVATE USE_MPI TEST_FILES_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}\")
-  target_include_directories(testERA5Atm_MPI1 PRIVATE "${ModulesRoot}/AtmosphereBoundaryModule")
-  target_link_libraries(testERA5Atm_MPI1 PRIVATE nextsimlib doctest::doctest)
+    add_executable(testERA5Atm_MPI1 "ERA5Atm_test.cpp" "../../core/test/MainMPI.cpp")
+    target_compile_definitions(
+        testERA5Atm_MPI1
+        PRIVATE USE_MPI TEST_FILES_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}\"
+    )
+    target_include_directories(testERA5Atm_MPI1 PRIVATE "${ModulesRoot}/AtmosphereBoundaryModule")
+    target_link_libraries(testERA5Atm_MPI1 PRIVATE nextsimlib doctest::doctest)
 
-  add_executable(testTOPAZOcn_MPI1 "TOPAZOcn_test.cpp" "../../core/test/MainMPI.cpp")
-  target_include_directories(testTOPAZOcn_MPI1 PRIVATE "${ModulesRoot}/OceanBoundaryModule")
-  target_compile_definitions(testTOPAZOcn_MPI1 PRIVATE USE_MPI TEST_FILES_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}\")
-  target_link_libraries(testTOPAZOcn_MPI1 PRIVATE nextsimlib doctest::doctest)
+    add_executable(testTOPAZOcn_MPI1 "TOPAZOcn_test.cpp" "../../core/test/MainMPI.cpp")
+    target_include_directories(testTOPAZOcn_MPI1 PRIVATE "${ModulesRoot}/OceanBoundaryModule")
+    target_compile_definitions(
+        testTOPAZOcn_MPI1
+        PRIVATE USE_MPI TEST_FILES_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}\"
+    )
+    target_link_libraries(testTOPAZOcn_MPI1 PRIVATE nextsimlib doctest::doctest)
 else()
-  add_executable(testERA5Atm "ERA5Atm_test.cpp")
-  target_compile_definitions(testERA5Atm PRIVATE TEST_FILES_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}\")
-  target_include_directories(testERA5Atm PRIVATE "${ModulesRoot}/AtmosphereBoundaryModule")
-  target_link_libraries(testERA5Atm PRIVATE nextsimlib doctest::doctest)
+    add_executable(testERA5Atm "ERA5Atm_test.cpp")
+    target_compile_definitions(testERA5Atm PRIVATE TEST_FILES_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}\")
+    target_include_directories(testERA5Atm PRIVATE "${ModulesRoot}/AtmosphereBoundaryModule")
+    target_link_libraries(testERA5Atm PRIVATE nextsimlib doctest::doctest)
 
-  add_executable(testTOPAZOcn "TOPAZOcn_test.cpp")
-  target_include_directories(testTOPAZOcn PRIVATE "${ModulesRoot}/OceanBoundaryModule")
-  target_compile_definitions(testTOPAZOcn PRIVATE TEST_FILES_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}\")
-  target_link_libraries(testTOPAZOcn PRIVATE nextsimlib doctest::doctest)
+    add_executable(testTOPAZOcn "TOPAZOcn_test.cpp")
+    target_include_directories(testTOPAZOcn PRIVATE "${ModulesRoot}/OceanBoundaryModule")
+    target_compile_definitions(testTOPAZOcn PRIVATE TEST_FILES_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}\")
+    target_link_libraries(testTOPAZOcn PRIVATE nextsimlib doctest::doctest)
 
-  add_executable(testIceGrowth "IceGrowth_test.cpp")
-  target_include_directories(testIceGrowth PRIVATE "${ModulesRoot}/OceanBoundaryModule" "${CoreModulesRoot}/FreezingPointModule")
-  target_link_libraries(testIceGrowth PRIVATE nextsimlib doctest::doctest)
+    add_executable(testIceGrowth "IceGrowth_test.cpp")
+    target_include_directories(
+        testIceGrowth
+        PRIVATE "${ModulesRoot}/OceanBoundaryModule" "${CoreModulesRoot}/FreezingPointModule"
+    )
+    target_link_libraries(testIceGrowth PRIVATE nextsimlib doctest::doctest)
 
-  add_executable(testThermoWinton "ThermoWintonTemperature_test.cpp")
-  target_include_directories(testThermoWinton PRIVATE "${ModulesRoot}/IceThermodynamicsModule" "${ModulesRoot}/OceanBoundaryModule")
-  target_link_libraries(testThermoWinton PRIVATE nextsimlib doctest::doctest)
+    add_executable(testThermoWinton "ThermoWintonTemperature_test.cpp")
+    target_include_directories(
+        testThermoWinton
+        PRIVATE "${ModulesRoot}/IceThermodynamicsModule" "${ModulesRoot}/OceanBoundaryModule"
+    )
+    target_link_libraries(testThermoWinton PRIVATE nextsimlib doctest::doctest)
 
-  add_executable(testFEFluxes "FiniteElementFluxes_test.cpp")
-  target_include_directories(testFEFluxes PRIVATE "${ModulesRoot}/FluxCalculationModule" "${ModulesRoot}/OceanBoundaryModule" "${CoreModulesRoot}/FreezingPointModule")
-  target_link_libraries(testFEFluxes PRIVATE nextsimlib doctest::doctest)
+    add_executable(testFEFluxes "FiniteElementFluxes_test.cpp")
+    target_include_directories(
+        testFEFluxes
+        PRIVATE
+            "${ModulesRoot}/FluxCalculationModule"
+            "${ModulesRoot}/OceanBoundaryModule"
+            "${CoreModulesRoot}/FreezingPointModule"
+    )
+    target_link_libraries(testFEFluxes PRIVATE nextsimlib doctest::doctest)
 
-  add_executable(testBIOHFluxes "BasicIceOceanFlux_test.cpp")
-  target_include_directories(testBIOHFluxes PRIVATE "${ModulesRoot}/IceOceanHeatFluxModule" "${ModulesRoot}/OceanBoundaryModule" "${CoreModulesRoot}/FreezingPointModule")
-  target_link_libraries(testBIOHFluxes PRIVATE nextsimlib doctest::doctest)
+    add_executable(testBIOHFluxes "BasicIceOceanFlux_test.cpp")
+    target_include_directories(
+        testBIOHFluxes
+        PRIVATE
+            "${ModulesRoot}/IceOceanHeatFluxModule"
+            "${ModulesRoot}/OceanBoundaryModule"
+            "${CoreModulesRoot}/FreezingPointModule"
+    )
+    target_link_libraries(testBIOHFluxes PRIVATE nextsimlib doctest::doctest)
 
-  add_executable(testSpecHum "SpecificHumidity_test.cpp")
-  target_include_directories(testSpecHum PRIVATE "${ModulesRoot}/FluxCalculationModule")
-  target_link_libraries(testSpecHum PRIVATE nextsimlib doctest::doctest)
+    add_executable(testSpecHum "SpecificHumidity_test.cpp")
+    target_include_directories(testSpecHum PRIVATE "${ModulesRoot}/FluxCalculationModule")
+    target_link_libraries(testSpecHum PRIVATE nextsimlib doctest::doctest)
 
-  add_executable(testThermoIce0 "ThermoIce0_test.cpp")
-  target_include_directories(testThermoIce0 PRIVATE "${ModulesRoot}/IceThermodynamicsModule")
-  target_link_libraries(testThermoIce0 PRIVATE nextsimlib doctest::doctest)
+    add_executable(testThermoIce0 "ThermoIce0_test.cpp")
+    target_include_directories(testThermoIce0 PRIVATE "${ModulesRoot}/IceThermodynamicsModule")
+    target_link_libraries(testThermoIce0 PRIVATE nextsimlib doctest::doctest)
 
-  add_executable(testIceMinima "IceMinima_test.cpp")
-  target_link_libraries(testIceMinima PRIVATE nextsimlib doctest::doctest)
+    add_executable(testIceMinima "IceMinima_test.cpp")
+    target_link_libraries(testIceMinima PRIVATE nextsimlib doctest::doctest)
 
-  add_executable(testConstantOcn "ConstantOceanBoundary_test.cpp")
-  target_include_directories(testConstantOcn PRIVATE "${ModulesRoot}/OceanBoundaryModule")
-  target_link_libraries(testConstantOcn PRIVATE nextsimlib doctest::doctest)
+    add_executable(testConstantOcn "ConstantOceanBoundary_test.cpp")
+    target_include_directories(testConstantOcn PRIVATE "${ModulesRoot}/OceanBoundaryModule")
+    target_link_libraries(testConstantOcn PRIVATE nextsimlib doctest::doctest)
 
-  add_executable(testSlabOcn "SlabOcean_test.cpp")
-  target_include_directories(testSlabOcn PRIVATE "${CoreModulesRoot}/FreezingPointModule")
-  target_link_libraries(testSlabOcn PRIVATE nextsimlib doctest::doctest)
+    add_executable(testSlabOcn "SlabOcean_test.cpp")
+    target_include_directories(testSlabOcn PRIVATE "${CoreModulesRoot}/FreezingPointModule")
+    target_link_libraries(testSlabOcn PRIVATE nextsimlib doctest::doctest)
 
-  add_executable(testUniformOcean "UniformOcean_test.cpp")
-  target_include_directories(testUniformOcean PRIVATE "${ModulesRoot}/OceanBoundaryModule")
-  target_link_libraries(testUniformOcean PRIVATE nextsimlib doctest::doctest)
+    add_executable(testUniformOcean "UniformOcean_test.cpp")
+    target_include_directories(testUniformOcean PRIVATE "${ModulesRoot}/OceanBoundaryModule")
+    target_link_libraries(testUniformOcean PRIVATE nextsimlib doctest::doctest)
 
-  add_executable(testBenchmarkBoundaries "BenchmarkBoundaries_test.cpp")
-  target_include_directories(testBenchmarkBoundaries PRIVATE "${ModulesRoot}/AtmosphereBoundaryModule" "${ModulesRoot}/OceanBoundaryModule")
-  target_link_libraries(testBenchmarkBoundaries PRIVATE nextsimlib doctest::doctest)
+    add_executable(testBenchmarkBoundaries "BenchmarkBoundaries_test.cpp")
+    target_include_directories(
+        testBenchmarkBoundaries
+        PRIVATE "${ModulesRoot}/AtmosphereBoundaryModule" "${ModulesRoot}/OceanBoundaryModule"
+    )
+    target_link_libraries(testBenchmarkBoundaries PRIVATE nextsimlib doctest::doctest)
 
-  add_executable(testDamageHealing "DamageHealing_test.cpp")
-  target_include_directories(testDamageHealing PRIVATE "${ModulesRoot}/DamageHealingModule" "${ModulesRoot}/DamageHealingModule")
-  target_link_libraries(testDamageHealing PRIVATE nextsimlib doctest::doctest)
+    add_executable(testDamageHealing "DamageHealing_test.cpp")
+    target_include_directories(
+        testDamageHealing
+        PRIVATE "${ModulesRoot}/DamageHealingModule" "${ModulesRoot}/DamageHealingModule"
+    )
+    target_link_libraries(testDamageHealing PRIVATE nextsimlib doctest::doctest)
 endif()

--- a/run/CMakeLists.txt
+++ b/run/CMakeLists.txt
@@ -1,6 +1,21 @@
 # Generate the example restart files that don't depend on external data
-execute_process(COMMAND "${Python_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/make_init_rect20x30.py" WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
-execute_process(COMMAND "${Python_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/make_init.py" WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
-execute_process(COMMAND "${Python_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/make_init_column.py" WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
-execute_process(COMMAND "${Python_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/make_init_para24x30.py" WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
-execute_process(COMMAND "${Python_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/make_init_benchmark.py" WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
+execute_process(
+    COMMAND "${Python_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/make_init_rect20x30.py"
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+)
+execute_process(
+    COMMAND "${Python_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/make_init.py"
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+)
+execute_process(
+    COMMAND "${Python_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/make_init_column.py"
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+)
+execute_process(
+    COMMAND "${Python_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/make_init_para24x30.py"
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+)
+execute_process(
+    COMMAND "${Python_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/make_init_benchmark.py"
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+)


### PR DESCRIPTION
# Issue648 cmake refactor
## Fixes #648

---
# Change Description

This pull request tidies up the CMakeLists.txt. The changes primarly concern the root CMakeLists.txt. It should now be easier to read and to update. Additionally, there is now a switch to disable test building which speeds up builds. The formatting was done with [gersemi](https://github.com/BlankSpruce/gersemi) and the following options:
```
gersemi -i --indent 4 --list-expansion favour-inlining -l 100 CMakeLists.txt
```
