### PR TITLE
Get the ice-ocean stress into the ModelArrayRef system

### DIFF
--- a/core/src/include/ModelComponent.hpp
+++ b/core/src/include/ModelComponent.hpp
@@ -1,7 +1,7 @@
 /*!
  * @file ModelComponent.hpp
  *
- * @date 1 Jul 2024
+ * @date 22 Aug 2024
  * @author Tim Spain <timothy.spain@nersc.no>
  * @author Einar Ólason <einar.olason@nersc.no>
  */

--- a/core/src/include/ModelComponent.hpp
+++ b/core/src/include/ModelComponent.hpp
@@ -64,6 +64,8 @@ namespace Protected {
     inline constexpr TextTag WIND_V = "WIND_V"; // y(north)-ward component of wind, m s⁻¹
     inline constexpr TextTag ICE_U = "ICE_U"; // x(east)-ward ice velocity, m s⁻¹
     inline constexpr TextTag ICE_V = "ICE_V"; // y(north)-ward ice velocity, m s⁻¹
+    inline constexpr TextTag IO_STRESS_U = "IO_STRESS_U"; // x(east)-ward ice-ocean stress, Pa
+    inline constexpr TextTag IO_STRESS_V = "IO_STRESS_V"; // y(north)-ward ice-ocean stress, Pa
     // Slab ocean fields
     inline constexpr TextTag SLAB_SST = "SLAB_SST"; // Slab ocean sea surface temperature, ˚C
     inline constexpr TextTag SLAB_SSS = "SLAB_SSS"; // Slab ocean sea surface salinity, ˚C

--- a/core/src/include/gridNames.hpp
+++ b/core/src/include/gridNames.hpp
@@ -1,8 +1,9 @@
 /*!
  * @file gridNames.hpp
  *
- * @date Oct 24, 2022
+ * @date Aug 22, 2024
  * @author Tim Spain <timothy.spain@nersc.no>
+ * @author Einar Ólason <einar.olason@nersc.no>
  */
 
 #ifndef GRIDNAMES_HPP

--- a/core/src/include/gridNames.hpp
+++ b/core/src/include/gridNames.hpp
@@ -29,6 +29,9 @@ static const std::string vWindName = "vwind";
 static const std::string uOceanName = "uocean";
 static const std::string vOceanName = "vocean";
 
+static const std::string uIOStressName = "uiostress";
+static const std::string vIOStressName = "viostress";
+
 static const std::string coordsName = "coords";
 static const std::string latitudeName = "latitude";
 static const std::string longitudeName = "longitude";

--- a/core/src/modules/DynamicsModule/BBMDynamics.cpp
+++ b/core/src/modules/DynamicsModule/BBMDynamics.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file BBMDynamics.cpp
  *
- * @date Jul 1, 2024
+ * @date Agu 22, 2024
  * @author Tim Spain <timothy.spain@nersc.no>
  * @author Einar Ólason <einar.olason@nersc.no>
  */

--- a/core/src/modules/DynamicsModule/BBMDynamics.cpp
+++ b/core/src/modules/DynamicsModule/BBMDynamics.cpp
@@ -94,6 +94,9 @@ void BBMDynamics::update(const TimestepTime& tst)
 
     uice = kernel.getDG0Data(uName);
     vice = kernel.getDG0Data(vName);
+
+    taux = kernel.getDG0Data(uIOStressName);
+    tauy = kernel.getDG0Data(vIOStressName);
 }
 
 // All data for prognostic output

--- a/core/src/modules/DynamicsModule/MEVPDynamics.cpp
+++ b/core/src/modules/DynamicsModule/MEVPDynamics.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file MEVPDynamics.cpp
  *
- * @date 18 Jul 2024
+ * @date 22 Aug 2024
  * @author Tim Spain <timothy.spain@nersc.no>
  * @author Piotr Minakowski <piotr.minakowski@ovgu.de>
  * @author Einar Ólason <einar.olason@nersc.no>

--- a/core/src/modules/DynamicsModule/MEVPDynamics.cpp
+++ b/core/src/modules/DynamicsModule/MEVPDynamics.cpp
@@ -80,6 +80,9 @@ void MEVPDynamics::update(const TimestepTime& tst)
 
     uice = kernel.getDG0Data(uName);
     vice = kernel.getDG0Data(vName);
+
+    taux = kernel.getDG0Data(uIOStressName);
+    tauy = kernel.getDG0Data(vIOStressName);
 }
 
 ModelState MEVPDynamics::getStateRecursive(const OutputSpec& os) const

--- a/core/src/modules/include/IDynamics.hpp
+++ b/core/src/modules/include/IDynamics.hpp
@@ -1,8 +1,9 @@
 /*!
  * @file IDynamics.hpp
  *
- * @date 7 Sep 2023
+ * @date 22 Aug 2024
  * @author Tim Spain <timothy.spain@nersc.no>
+ * @author Einar Ólason <einar.olason@nersc.no>
  */
 
 #ifndef IDYNAMICS_HPP

--- a/core/src/modules/include/IDynamics.hpp
+++ b/core/src/modules/include/IDynamics.hpp
@@ -23,6 +23,8 @@ public:
         : uice(ModelArray::Type::H)
         , vice(ModelArray::Type::H)
         , damage(ModelArray::Type::H)
+        , taux(ModelArray::Type::H)
+        , tauy(ModelArray::Type::H)
         , hice(getStore())
         , cice(getStore())
         , hsnow(getStore())
@@ -76,12 +78,14 @@ protected:
     HField vice;
     // Updated damage array
     HField damage;
+    // Ice-ocean stress (for the coupler, mostly)
+    HField taux;
+    HField tauy;
     // References to the DG0 finite volume data arrays
     ModelArrayRef<Shared::H_ICE, RW> hice;
     ModelArrayRef<Shared::C_ICE, RW> cice;
     ModelArrayRef<Shared::H_SNOW, RW> hsnow;
     ModelArrayRef<Protected::DAMAGE, RO> damage0;
-    // ModelArrayRef<ModelComponent::SharedArray::D, MARBackingStore, RW> damage;
 
     // References to the forcing velocity arrays
     ModelArrayRef<Protected::WIND_U> uwind;

--- a/core/src/modules/include/IDynamics.hpp
+++ b/core/src/modules/include/IDynamics.hpp
@@ -37,6 +37,8 @@ public:
         , m_usesDamage(usesDamageIn)
     {
         getStore().registerArray(Shared::DAMAGE, &damage, RW);
+        getStore().registerArray(Protected::IO_STRESS_U, &taux, RO);
+        getStore().registerArray(Protected::IO_STRESS_V, &tauy, RO);
     }
     virtual ~IDynamics() = default;
 

--- a/core/src/modules/include/ProtectedArrayNames.ipp
+++ b/core/src/modules/include/ProtectedArrayNames.ipp
@@ -40,4 +40,6 @@
 { "sss_slab", "SLAB_SSS" }, // Slab ocean surface salinity PSU
 { "qdw", "SLAB_QDW" }, // Slab ocean temperature nudging heat flux, W m⁻²
 { "fdw", "SLAB_FDW" }, // Slab ocean salinity nudging water flux, kg s⁻¹ m⁻²
+{ "taux", "IO_STRESS_U" }, // Ice-ocean stress x(east) direction, Pa
+{ "tauy", "IO_STRESS_V" }, // Ice-ocean stress x(east) direction, Pa
 

--- a/dynamics/src/CGDynamicsKernel.cpp
+++ b/dynamics/src/CGDynamicsKernel.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file CGDynamicsKernel.cpp
  *
- * @date Aug 22, 2024
+ * @date 27 Aug 2024
  * @author Tim Spain <timothy.spain@nersc.no>
  * @author Einar ÓLason <einar.olason@nersc.no>
  */
@@ -298,7 +298,8 @@ template <int DGadvection> void CGDynamicsKernel<DGadvection>::applyBoundaries()
 }
 
 template <int DGadvection>
-std::pair<CGVector<CGdegree>, CGVector<CGdegree>> CGDynamicsKernel<DGadvection>::getIceOceanStress() const
+std::pair<CGVector<CGdegree>, CGVector<CGdegree>>
+CGDynamicsKernel<DGadvection>::getIceOceanStress() const
 {
     CGVector<CGdegree> taux, tauy;
     taux.resizeLike(uStress);
@@ -308,7 +309,8 @@ std::pair<CGVector<CGdegree>, CGVector<CGdegree>> CGDynamicsKernel<DGadvection>:
     for (int i = 0; i < taux.rows(); ++i) {
         const double uOceanRel = uOcean(i) - uStress(i);
         const double vOceanRel = vOcean(i) - vStress(i);
-        const double cPrime = DynamicsKernel<DGadvection, DGstressComp>::getParams().F_ocean * std::hypot(uOceanRel, vOceanRel);
+        const double cPrime = DynamicsKernel<DGadvection, DGstressComp>::getParams().F_ocean
+            * std::hypot(uOceanRel, vOceanRel);
 
         taux(i) = cPrime * (uOceanRel * cosOceanAngle - vOceanRel * sinOceanAngle);
         tauy(i) = cPrime * (vOceanRel * cosOceanAngle + uOceanRel * sinOceanAngle);
@@ -316,7 +318,6 @@ std::pair<CGVector<CGdegree>, CGVector<CGdegree>> CGDynamicsKernel<DGadvection>:
 
     return { taux, tauy };
 }
-
 
 // Instantiate the templates for all (1, 3, 6) degrees of DGadvection
 template class CGDynamicsKernel<1>;

--- a/dynamics/src/CGDynamicsKernel.cpp
+++ b/dynamics/src/CGDynamicsKernel.cpp
@@ -94,6 +94,16 @@ ModelArray CGDynamicsKernel<DGadvection>::getDG0Data(const std::string& name) co
         DGVector<DGadvection> vtmp(*smesh);
         Nextsim::Interpolations::CG2DG(*smesh, vtmp, v);
         return DGModelArray::dg2ma(vtmp, data);
+    } else if (name == uIOStressName) {
+        ModelArray data(ModelArray::Type::U);
+        DGVector<DGadvection> utmp(*smesh);
+        Nextsim::Interpolations::CG2DG(*smesh, utmp, getIceOceanStress(name));
+        return DGModelArray::dg2ma(utmp, data);
+    } else if (name == vIOStressName) {
+        ModelArray data(ModelArray::Type::V);
+        DGVector<DGadvection> vtmp(*smesh);
+        Nextsim::Interpolations::CG2DG(*smesh, vtmp, getIceOceanStress(name));
+        return DGModelArray::dg2ma(vtmp, data);
     } else {
         return DynamicsKernel<DGadvection, DGstressComp>::getDG0Data(name);
     }

--- a/dynamics/src/CGDynamicsKernel.cpp
+++ b/dynamics/src/CGDynamicsKernel.cpp
@@ -1,8 +1,9 @@
 /*!
  * @file CGDynamicsKernel.cpp
  *
- * @date Jan 26, 2024
+ * @date Aug 22, 2024
  * @author Tim Spain <timothy.spain@nersc.no>
+ * @author Einar ÓLason <einar.olason@nersc.no>
  */
 
 /*

--- a/dynamics/src/include/BrittleCGDynamicsKernel.hpp
+++ b/dynamics/src/include/BrittleCGDynamicsKernel.hpp
@@ -1,7 +1,8 @@
 /*!
  * @file BrittleCGDynamicsKernel.hpp
  *
- * @date Jul 1, 2024
+ * @date Aug 22, 2024
+ * @author Tim Spain <timothy.spain@nersc.no>
  * @author Einar Ólason <einar.olason@nersc.no>
  */
 

--- a/dynamics/src/include/BrittleCGDynamicsKernel.hpp
+++ b/dynamics/src/include/BrittleCGDynamicsKernel.hpp
@@ -162,6 +162,32 @@ public:
         }
     }
 
+    CGVector<CGdegree> getIceOceanStress(const std::string& name) const override
+    {
+        CGVector<CGdegree> taux, tauy;
+        taux.resizeLike(avgU);
+        tauy.resizeLike(avgV);
+
+#pragma omp parallel for
+        for (int i = 0; i < taux.rows(); ++i) {
+            double uOcnRel = avgU(i) - uOcean(i);
+            double vOcnRel = avgV(i) - vOcean(i);
+            double absocn = sqrt(SQR(uOcnRel) + SQR(vOcnRel));
+
+            taux(i) = params.F_ocean * absocn * uOcnRel;
+            tauy(i) = params.F_ocean * absocn * vOcnRel;
+        }
+
+        if (name == uIOStressName) {
+            return taux;
+        } else if (name == vIOStressName) {
+            return tauy;
+        } else {
+            throw std::logic_error(std::string(__func__) + " called with an unknown argument "
+                + name + ". Only " + uIOStressName + " and " + vIOStressName + " are supported\n");
+        }
+    }
+
 protected:
     CGVector<CGdegree> avgU;
     CGVector<CGdegree> avgV;

--- a/dynamics/src/include/BrittleCGDynamicsKernel.hpp
+++ b/dynamics/src/include/BrittleCGDynamicsKernel.hpp
@@ -1,7 +1,7 @@
 /*!
  * @file BrittleCGDynamicsKernel.hpp
  *
- * @date Aug 22, 2024
+ * @date 27 Aug 2024
  * @author Tim Spain <timothy.spain@nersc.no>
  * @author Einar Ólason <einar.olason@nersc.no>
  */
@@ -59,7 +59,8 @@ protected:
 public:
     BrittleCGDynamicsKernel(StressUpdateStep<DGadvection, DGstressComp>& stressStepIn,
         const DynamicsParameters& paramsIn)
-        : CGDynamicsKernel<DGadvection>(cos(radians * paramsIn.ocean_turning_angle), sin(radians * paramsIn.ocean_turning_angle), paramsIn, avgU, avgV)
+        : CGDynamicsKernel<DGadvection>(cos(radians * paramsIn.ocean_turning_angle),
+            sin(radians * paramsIn.ocean_turning_angle), paramsIn, avgU, avgV)
         , stressStep(stressStepIn)
         , params(reinterpret_cast<const MEBParameters&>(paramsIn))
         , stresstransport(nullptr)

--- a/dynamics/src/include/BrittleCGDynamicsKernel.hpp
+++ b/dynamics/src/include/BrittleCGDynamicsKernel.hpp
@@ -170,12 +170,12 @@ public:
 
 #pragma omp parallel for
         for (int i = 0; i < taux.rows(); ++i) {
-            double uOcnRel = avgU(i) - uOcean(i);
-            double vOcnRel = avgV(i) - vOcean(i);
-            double absocn = sqrt(SQR(uOcnRel) + SQR(vOcnRel));
+            const double uOceanRel = uOcean(i) - avgU(i);
+            const double vOceanRel = vOcean(i) - avgV(i);
+            const double cPrime = params.F_ocean * std::hypot(uOceanRel, vOceanRel);
 
-            taux(i) = params.F_ocean * absocn * uOcnRel;
-            tauy(i) = params.F_ocean * absocn * vOcnRel;
+            taux(i) = cPrime * (uOceanRel * cosOceanAngle - vOceanRel * sinOceanAngle);
+            tauy(i) = cPrime * (vOceanRel * cosOceanAngle + uOceanRel * sinOceanAngle);
         }
 
         if (name == uIOStressName) {

--- a/dynamics/src/include/CGDynamicsKernel.hpp
+++ b/dynamics/src/include/CGDynamicsKernel.hpp
@@ -50,6 +50,8 @@ public:
     void applyBoundaries() override;
     void prepareAdvection() override;
 
+    virtual CGVector<CGdegree> getIceOceanStress(const std::string& name) const = 0;
+
 protected:
     void addStressTensorCell(const size_t eid, const size_t cx, const size_t cy);
     void dirichletZero(CGVector<CGdegree>&) const;

--- a/dynamics/src/include/CGDynamicsKernel.hpp
+++ b/dynamics/src/include/CGDynamicsKernel.hpp
@@ -1,8 +1,9 @@
 /*!
  * @file CGDynamicsKernel.hpp
  *
- * @date Jan 31, 2024
+ * @date Aug 22, 2024
  * @author Tim Spain <timothy.spain@nersc.no>
+ * @author Einar Ólason <einar.olason@nersc.no>
  */
 
 #ifndef CGDYNAMICSKERNEL_HPP

--- a/dynamics/src/include/CGDynamicsKernel.hpp
+++ b/dynamics/src/include/CGDynamicsKernel.hpp
@@ -1,7 +1,7 @@
 /*!
  * @file CGDynamicsKernel.hpp
  *
- * @date Aug 22, 2024
+ * @date 27 Aug 2024
  * @author Tim Spain <timothy.spain@nersc.no>
  * @author Einar Ólason <einar.olason@nersc.no>
  */
@@ -39,19 +39,17 @@ protected:
     using DynamicsKernel<DGadvection, DGstressComp>::sinOceanAngle;
 
 public:
-    CGDynamicsKernel(double cosOceanAngleIn,
-            double sinOceanAngleIn,
-            const DynamicsParameters& paramsIn,
-            CGVector<CGdegree>& uStressRef,
-            CGVector<CGdegree>& vStressRef)
+    CGDynamicsKernel(double cosOceanAngleIn, double sinOceanAngleIn,
+        const DynamicsParameters& paramsIn, CGVector<CGdegree>& uStressRef,
+        CGVector<CGdegree>& vStressRef)
         : DynamicsKernel<DGadvection, DGstressComp>(cosOceanAngleIn, sinOceanAngleIn, paramsIn)
         , pmap(nullptr)
         , uStress(uStressRef)
         , vStress(vStressRef)
     {
     }
-    CGDynamicsKernel(double cosOceanAngleIn, const DynamicsParameters& paramsIn,
-double sinOceanAngleIn)
+    CGDynamicsKernel(
+        double cosOceanAngleIn, const DynamicsParameters& paramsIn, double sinOceanAngleIn)
         : CGDynamicsKernel(cosOceanAngleIn, sinOceanAngleIn, paramsIn, u, v)
     {
     }

--- a/dynamics/src/include/DynamicsKernel.hpp
+++ b/dynamics/src/include/DynamicsKernel.hpp
@@ -1,7 +1,7 @@
 /*!
  * @file DynamicsKernel.hpp
  *
- * @date Jan 5, 2024
+ * @date 27 Aug 2024
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 
@@ -33,14 +33,15 @@
 namespace Nextsim {
 
 // forward define the class holding the potentially non-DG parts
-template<int DGdegree> class DynamicsInternals;
+template <int DGdegree> class DynamicsInternals;
 
-template<int DGadvection, int DGstress> class DynamicsKernel {
+template <int DGadvection, int DGstress> class DynamicsKernel {
 public:
     typedef std::pair<const std::string, const DGVector<DGadvection>&> DataMapping;
     typedef std::map<typename DataMapping::first_type, typename DataMapping::second_type> DataMap;
 
-    DynamicsKernel(double cosOceanAngleIn, double sinOceanAngleIn, const DynamicsParameters& paramsIn)
+    DynamicsKernel(
+        double cosOceanAngleIn, double sinOceanAngleIn, const DynamicsParameters& paramsIn)
         : cosOceanAngle(cosOceanAngleIn)
         , sinOceanAngle(sinOceanAngleIn)
         , baseParams(paramsIn)
@@ -157,10 +158,7 @@ public:
         }
     }
 
-    virtual void update(const TimestepTime& tst)
-    {
-        ++stepNumber;
-    }
+    virtual void update(const TimestepTime& tst) { ++stepNumber; }
 
     void advectionAndLimits(const TimestepTime& tst)
     {
@@ -177,7 +175,7 @@ public:
     }
 
 protected:
-    Nextsim::DGTransport<DGadvection> *dgtransport;
+    Nextsim::DGTransport<DGadvection>* dgtransport;
 
     DGVector<DGadvection> hice;
     DGVector<DGadvection> cice;
@@ -192,7 +190,7 @@ protected:
 
     double deltaT;
 
-    Nextsim::ParametricMesh *smesh;
+    Nextsim::ParametricMesh* smesh;
 
     // Components of the ocean turning angle
     const double cosOceanAngle = 1.;
@@ -231,6 +229,7 @@ protected:
      * Returns a const reference to the dynamics parameters
      */
     const DynamicsParameters& getParams() const { return baseParams; }
+
 private:
     std::unordered_map<std::string, DGVector<DGadvection>> advectedFields;
 

--- a/dynamics/src/include/FreeDriftDynamicsKernel.hpp
+++ b/dynamics/src/include/FreeDriftDynamicsKernel.hpp
@@ -4,7 +4,7 @@
  * Implementation of "classic free drift", where we ignore all \rho h terms in the momentum
  * equation. This is equivalent to assuming that the ice is very thin.
  *
- * @date 17 Feb 2023
+ * @date 22 Aug 2024
  * @author Tim Spain <timothy.spain@nersc.no>
  * @author Einar Ólason <einar.olason@nersc.no>
  */

--- a/dynamics/src/include/FreeDriftDynamicsKernel.hpp
+++ b/dynamics/src/include/FreeDriftDynamicsKernel.hpp
@@ -4,7 +4,7 @@
  * Implementation of "classic free drift", where we ignore all \rho h terms in the momentum
  * equation. This is equivalent to assuming that the ice is very thin.
  *
- * @date 22 Aug 2024
+ * @date 27 Aug 2024
  * @author Tim Spain <timothy.spain@nersc.no>
  * @author Einar Ólason <einar.olason@nersc.no>
  */
@@ -35,7 +35,8 @@ template <int DGadvection> class FreeDriftDynamicsKernel : public CGDynamicsKern
 
 public:
     FreeDriftDynamicsKernel(const DynamicsParameters& paramsIn)
-        : CGDynamicsKernel<DGadvection>(cos(radians * paramsIn.ocean_turning_angle), sin(radians * paramsIn.ocean_turning_angle), paramsIn, u, v)
+        : CGDynamicsKernel<DGadvection>(cos(radians * paramsIn.ocean_turning_angle),
+            sin(radians * paramsIn.ocean_turning_angle), paramsIn, u, v)
         , params(paramsIn)
     {
     }

--- a/dynamics/src/include/FreeDriftDynamicsKernel.hpp
+++ b/dynamics/src/include/FreeDriftDynamicsKernel.hpp
@@ -89,8 +89,8 @@ protected:
         } else if (name == vIOStressName) {
             return tauy;
         } else {
-            throw std::logic_error(std::string(__func__) + " called with an unknown argument " + name
-                                   + ". Only " + uIOStressName + " and " + vIOStressName + " are supported\n");
+            throw std::logic_error(std::string(__func__) + " called with an unknown argument "
+                + name + ". Only " + uIOStressName + " and " + vIOStressName + " are supported\n");
         }
     }
 };

--- a/dynamics/src/include/FreeDriftDynamicsKernel.hpp
+++ b/dynamics/src/include/FreeDriftDynamicsKernel.hpp
@@ -76,12 +76,12 @@ protected:
 
 #pragma omp parallel for
         for (int i = 0; i < taux.rows(); ++i) {
-            double uOcnRel = u(i) - uOcean(i);
-            double vOcnRel = v(i) - vOcean(i);
-            double absocn = sqrt(SQR(uOcnRel) + SQR(vOcnRel));
+            const double uOceanRel = uOcean(i) - u(i);
+            const double vOceanRel = vOcean(i) - v(i);
+            const double cPrime = params.F_ocean * std::hypot(uOceanRel, vOceanRel);
 
-            taux(i) = params.F_ocean * absocn * uOcnRel;
-            tauy(i) = params.F_ocean * absocn * vOcnRel;
+            taux(i) = cPrime * (uOceanRel * cosOceanAngle - vOceanRel * sinOceanAngle);
+            tauy(i) = cPrime * (vOceanRel * cosOceanAngle + uOceanRel * sinOceanAngle);
         }
 
         if (name == uIOStressName) {

--- a/dynamics/src/include/FreeDriftDynamicsKernel.hpp
+++ b/dynamics/src/include/FreeDriftDynamicsKernel.hpp
@@ -67,6 +67,32 @@ protected:
                 + NansenNumber * (-uAtmos(i) * sinOceanAngle + vAtmos(i) * cosOceanAngle);
         }
     }
+
+    CGVector<CGdegree> getIceOceanStress(const std::string& name) const override
+    {
+        CGVector<CGdegree> taux, tauy;
+        taux.resizeLike(u);
+        tauy.resizeLike(v);
+
+#pragma omp parallel for
+        for (int i = 0; i < taux.rows(); ++i) {
+            double uOcnRel = u(i) - uOcean(i);
+            double vOcnRel = v(i) - vOcean(i);
+            double absocn = sqrt(SQR(uOcnRel) + SQR(vOcnRel));
+
+            taux(i) = params.F_ocean * absocn * uOcnRel;
+            tauy(i) = params.F_ocean * absocn * vOcnRel;
+        }
+
+        if (name == uIOStressName) {
+            return taux;
+        } else if (name == vIOStressName) {
+            return tauy;
+        } else {
+            throw std::logic_error(std::string(__func__) + " called with an unknown argument " + name
+                                   + ". Only " + uIOStressName + " and " + vIOStressName + " are supported\n");
+        }
+    }
 };
 } /* namespace Nextsim */
 

--- a/dynamics/src/include/VPCGDynamicsKernel.hpp
+++ b/dynamics/src/include/VPCGDynamicsKernel.hpp
@@ -1,8 +1,9 @@
 /*!
  * @file VPCGDynamicsKernel.hpp
  *
- * @date Feb 2, 2024
+ * @date Aug 22, 2024
  * @author Tim Spain <timothy.spain@nersc.no>
+* @author Einar Ólason <einar.olason@nersc.no>
  */
 
 #ifndef VPCGDYNAMICSKERNEL_HPP

--- a/dynamics/src/include/VPCGDynamicsKernel.hpp
+++ b/dynamics/src/include/VPCGDynamicsKernel.hpp
@@ -90,6 +90,32 @@ public:
         DynamicsKernel<DGadvection, DGstressComp>::update(tst);
     }
 
+    CGVector<CGdegree> getIceOceanStress(const std::string& name) const override
+    {
+        CGVector<CGdegree> taux, tauy;
+        taux.resizeLike(u);
+        tauy.resizeLike(v);
+
+#pragma omp parallel for
+        for (int i = 0; i < taux.rows(); ++i) {
+            double uOcnRel = u(i) - uOcean(i);
+            double vOcnRel = v(i) - vOcean(i);
+            double absocn = sqrt(SQR(uOcnRel) + SQR(vOcnRel));
+
+            taux(i) = params.F_ocean * absocn * uOcnRel;
+            tauy(i) = params.F_ocean * absocn * vOcnRel;
+        }
+
+        if (name == uIOStressName) {
+            return taux;
+        } else if (name == vIOStressName) {
+            return tauy;
+        } else {
+            throw std::logic_error(std::string(__func__) + " called with an unknown argument "
+                + name + ". Only " + uIOStressName + " and " + vIOStressName + " are supported\n");
+        }
+    }
+
 protected:
     StressUpdateStep<DGadvection, DGstressComp>& stressStep;
     const VPParameters& params;

--- a/dynamics/src/include/VPCGDynamicsKernel.hpp
+++ b/dynamics/src/include/VPCGDynamicsKernel.hpp
@@ -3,7 +3,7 @@
  *
  * @date Aug 22, 2024
  * @author Tim Spain <timothy.spain@nersc.no>
-* @author Einar Ólason <einar.olason@nersc.no>
+ * @author Einar Ólason <einar.olason@nersc.no>
  */
 
 #ifndef VPCGDYNAMICSKERNEL_HPP

--- a/dynamics/test/AdvectionPeriodicBC_test.cpp
+++ b/dynamics/test/AdvectionPeriodicBC_test.cpp
@@ -1,6 +1,6 @@
 /*!
  * @file AdvectionPeriodicBC_test.cpp
- * @date 19 August 2024
+ * @date 27 Aug 2024
  * @author Thomas Richter <thomas.richter@ovgu.de>
  */
 

--- a/dynamics/test/Advection_test.cpp
+++ b/dynamics/test/Advection_test.cpp
@@ -1,6 +1,6 @@
 /*!
  * @file Advection_test.cpp
- * @date 19 August 2024
+ * @date 27 Aug 2024
  * @author Thomas Richter <thomas.richter@ovgu.de>
  */
 


### PR DESCRIPTION
# Get the ice-ocean stress into the ModelArrayRef system
## Fixes #649 

### Task List
- [ ] Defined the tests that specify a complete and functioning change (*It may help to create a [design specification & test specification](../../../wiki/Specification-Template)*)
- [x] Implemented the source code change that satisfies the tests
- [ ] Documented the feature by providing worked example
- [ ] Updated the README or other documentation
- [ ] Completed the pre-Request checklist below

---
# Change Description

Introduces a getIceOceanStress function into CGDynamicsKernel, called by getDG0Data when that function gets the right arguments. All derived DynamicsKernels (VPCGDynamicsKernel, BrittleCGDynamicsKernel, and FreeDriftDynamicsKernel) must implement getIceOceanStress.

There is quite a bit of code repetition between the implementations in the different kernels, but I'm not sure how to reduce this.

---
# Test Description

No CI test. I just ran the benchmark code and checked that the values returned are of the right order of magnitude.

---
# Documentation Impact

None

---
# Other Details

None

---
### Pre-Request Checklist

- [x] The requirements of this pull request are fully captured in an issue or design specification and are linked and summarised in the description of this PR
- [x] No new warnings are generated
- [x] The documentation has been updated (or an issue has been created to track the corresponding change)
- [x] Methods and Tests are commented such that they can be understood without having to obtain additional context
- [x] This PR/Issue is labelled as a bug/feature/enhancement/breaking change
- [x] File dates have been updated to reflect modification date
- [x] This change conforms to the conventions described in the README