### PR TITLE
Add the relevant module files for mocked module implementations.

### DIFF
--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -214,7 +214,7 @@ else()
     target_link_libraries(testModelArrayRef PRIVATE nextsimlib doctest::doctest)
 
     # PrognosticData (and hopefully that alone) requires code from the physics tree
-    add_executable(testPrognosticData "PrognosticData_test.cpp" "DynamicsModuleForPDtest.cpp")
+    add_executable(testPrognosticData "PrognosticData_test.cpp" "DynamicsModuleForPDtest.cpp" "../../physics/src/modules/OceanBoundaryModule/module.cpp")
     target_include_directories(
         testPrognosticData
         PRIVATE

--- a/physics/test/CMakeLists.txt
+++ b/physics/test/CMakeLists.txt
@@ -38,7 +38,7 @@ if(ENABLE_MPI)
     )
     target_link_libraries(testTOPAZOcn_MPI1 PRIVATE nextsimlib doctest::doctest)
 else()
-    add_executable(testERA5Atm "ERA5Atm_test.cpp")
+    add_executable(testERA5Atm "ERA5Atm_test.cpp" "../src/modules/FluxCalculationModule/module.cpp")
     target_compile_definitions(testERA5Atm PRIVATE TEST_FILES_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}\")
     target_include_directories(testERA5Atm PRIVATE "${ModulesRoot}/AtmosphereBoundaryModule")
     target_link_libraries(testERA5Atm PRIVATE nextsimlib doctest::doctest)
@@ -48,7 +48,7 @@ else()
     target_compile_definitions(testTOPAZOcn PRIVATE TEST_FILES_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}\")
     target_link_libraries(testTOPAZOcn PRIVATE nextsimlib doctest::doctest)
 
-    add_executable(testIceGrowth "IceGrowth_test.cpp")
+    add_executable(testIceGrowth "IceGrowth_test.cpp" "../src/modules/IceThermodynamicsModule/module.cpp")
     target_include_directories(
         testIceGrowth
         PRIVATE "${ModulesRoot}/OceanBoundaryModule" "${CoreModulesRoot}/FreezingPointModule"


### PR DESCRIPTION
# Pull Request Title
## Fixes \#657

---
# Change Description

In tests where `setExtrnalImplementation()` is called, add the relevant `module.cpp` file to the list of source files for that test. This prevents the link error.

---
# Test Description

Build completes for Release configuration on MacOS/clang++ without link error or warnings.
