### PR TITLE
Flush netCDF buffers on write

### DIFF
--- a/core/src/ParaGridIO.cpp
+++ b/core/src/ParaGridIO.cpp
@@ -570,6 +570,9 @@ void ParaGridIO::writeDiagnosticTime(const ModelState& state, const std::string&
 #endif
         }
     }
+
+    // Flush buffer to disc for monitoring and diagnostic purposes.
+    ncFile.sync();
 }
 
 void ParaGridIO::close(const std::string& filePath)


### PR DESCRIPTION
# Flush netCDF buffers on write

Fixes #953

### Task List
- [x] Defined the tests that specify a complete and functioning change (*It may help to create a [design specification & test specification](../../../wiki/Specification-Template)*)
- [x] Implemented the source code change that satisfies the tests
- [x] Documented the feature by providing worked example
- [x] Updated the README or other documentation
- [x] Completed the pre-Request checklist below

---
# Change Description

Call netCDF::NcFile's sync in ParaGridIO::writeDiagnosticTime. This flushes the netCDF buffers, as requested in issue #953

---
# Test Description

I ran the model, using ConfigOutput and frequent outputs (every-other time step). I checked that the time axis of the output file was being updated so that I could monitor the simulation in real time. I then stopped the simulation with ctrl-c and confirmed that the diagnostics file was readable and contained all the output time steps expected.

---
# Documentation Impact

None

---
# Other Details

N/A

---
### Pre-Request Checklist

- [x] The requirements of this pull request are fully captured in an issue or design specification and are linked and summarised in the description of this PR
- [x] No new warnings are generated
- [x] The documentation has been updated (or an issue has been created to track the corresponding change)
- [x] Methods and Tests are commented such that they can be understood without having to obtain additional context
- [x] This PR/Issue is labelled as a bug/feature/enhancement/breaking change
- [x] This change conforms to the conventions described in the README
