### PR TITLE
Halo add pb test for halo exchange

### DIFF
--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -260,22 +260,15 @@ if(ENABLE_MPI)
                     "../../dynamics/src" "../../dynamics/src/include")
         target_link_libraries(testHaloExchangeCB_MPI3 PRIVATE nextsimlib doctest::doctest)
 
-        add_executable(testHaloExchangePB_MPI3
-            "HaloExchangePB_test.cpp"
-            "MainMPI.cpp"
-            "../src/ModelArray.cpp"
-            "../src/ModelArraySlice.cpp"
-        )
-        target_compile_definitions(testHaloExchangePB_MPI3 PRIVATE USE_MPI
-          TEST_FILES_DIR=\"${CMAKE_CURRENT_BINARY_DIR}\")
+        add_executable(testHaloExchangePB_MPI3 "HaloExchangePB_test.cpp" "MainMPI.cpp"
+                                                "../src/ModelArray.cpp"
+                                                "../src/ModelArraySlice.cpp")
+        target_compile_definitions(testHaloExchangePB_MPI3
+                                   PRIVATE USE_MPI TEST_FILES_DIR=\"${CMAKE_CURRENT_BINARY_DIR}\")
         target_include_directories(
-            testHaloExchangePB_MPI3 PRIVATE
-            ${MODEL_INCLUDE_DIR}
-            "${ModulesRoot}/StructureModule"
-            "../src"
-            "../../dynamics/src"
-            "../../dynamics/src/include"
-        )
+            testHaloExchangePB_MPI3
+            PRIVATE ${MODEL_INCLUDE_DIR} "${ModulesRoot}/StructureModule" "../src"
+            "../../dynamics/src" "../../dynamics/src/include")
         target_link_libraries(testHaloExchangePB_MPI3 PRIVATE nextsimlib doctest::doctest)
 
         add_executable(testParaGrid_MPI2 "ParaGrid_test.cpp" "MainMPI.cpp")

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -260,6 +260,24 @@ if(ENABLE_MPI)
                     "../../dynamics/src" "../../dynamics/src/include")
         target_link_libraries(testHaloExchangeCB_MPI3 PRIVATE nextsimlib doctest::doctest)
 
+        add_executable(testHaloExchangePB_MPI3
+            "HaloExchangePB_test.cpp"
+            "MainMPI.cpp"
+            "../src/ModelArray.cpp"
+            "../src/ModelArraySlice.cpp"
+        )
+        target_compile_definitions(testHaloExchangePB_MPI3 PRIVATE USE_MPI
+          TEST_FILES_DIR=\"${CMAKE_CURRENT_BINARY_DIR}\")
+        target_include_directories(
+            testHaloExchangePB_MPI3 PRIVATE
+            ${MODEL_INCLUDE_DIR}
+            "${ModulesRoot}/StructureModule"
+            "../src"
+            "../../dynamics/src"
+            "../../dynamics/src/include"
+        )
+        target_link_libraries(testHaloExchangePB_MPI3 PRIVATE nextsimlib doctest::doctest)
+
         add_executable(testParaGrid_MPI2 "ParaGrid_test.cpp" "MainMPI.cpp")
         target_compile_definitions(
             testParaGrid_MPI2 PRIVATE USE_MPI TEST_FILES_DIR=\"${CMAKE_CURRENT_BINARY_DIR}\"
@@ -301,6 +319,7 @@ if(ENABLE_MPI)
 
         set(MPI_TESTS
             testHaloExchangeCB_MPI3
+            testHaloExchangePB_MPI3
             testParaGrid_MPI2
             testRectGrid_MPI3
             testModelMetadataCB_MPI3

--- a/core/test/HaloExchangePB_test.cpp
+++ b/core/test/HaloExchangePB_test.cpp
@@ -1,0 +1,313 @@
+/*!
+ * @author  Tom Meltzer <tdm39@cam.ac.uk>
+ * @brief   Test halo exchange class for Periodic Boundaries (PB)
+ * @details
+ *
+ * Test halo exchange class for Periodic Boundaries (PB) on following fields:
+ * - HField
+ * - VertexField
+ * - DGField
+ * - DGVector
+ */
+
+#include <doctest/extensions/doctest_mpi.h>
+
+#include "ModelMPI.hpp"
+#include "ModelMetadata.hpp"
+#include "include/DGModelArray.hpp"
+#include "include/Halo.hpp"
+
+namespace Nextsim {
+
+const std::string testFilesDir = TEST_FILES_DIR;
+const std::string file = testFilesDir + "/partition_metadata_3_pb.nc";
+
+static const int DG = 3;
+static const bool debug = false;
+
+// reference data for each process
+static std::array<std::vector<double>, 3> refDataAllProcs = {
+    std::vector<double>(
+        { 0, 208, 218, 228, 238, 248, 258, 268, 0, 390, 100, 110, 120, 130, 140, 150, 160, 370, 391,
+            101, 111, 121, 131, 141, 151, 161, 371, 392, 102, 112, 122, 132, 142, 152, 162, 372,
+            393, 103, 113, 123, 133, 143, 153, 163, 373, 0, 204, 214, 224, 234, 244, 254, 264, 0 }),
+    std::vector<double>({ 0, 103, 113, 123, 133, 143, 153, 163, 0, 394, 204, 214, 224, 234, 244,
+        254, 264, 374, 395, 205, 215, 225, 235, 245, 255, 265, 375, 396, 206, 216, 226, 236, 246,
+        256, 266, 376, 397, 207, 217, 227, 237, 247, 257, 267, 377, 398, 208, 218, 228, 238, 248,
+        258, 268, 378, 0, 100, 110, 120, 130, 140, 150, 160, 0 }),
+    std::vector<double>({ 0, 378, 388, 398, 0, 160, 370, 380, 390, 100, 161, 371, 381, 391, 101,
+        162, 372, 382, 392, 102, 163, 373, 383, 393, 103, 264, 374, 384, 394, 204, 265, 375, 385,
+        395, 205, 266, 376, 386, 396, 206, 267, 377, 387, 397, 207, 268, 378, 388, 398, 208, 0, 370,
+        380, 390, 0 }),
+};
+
+void initializeTestData(ModelArray::DataType& data, size_t localNx, size_t localNy, size_t offsetX,
+    size_t offsetY, size_t numComps, int test_rank)
+{
+    // initialize with test data
+    for (size_t j = 0; j < localNy; ++j) {
+        for (size_t i = 0; i < localNx; ++i) {
+            for (size_t d = 0; d < numComps; ++d) {
+                data(d + i * numComps + j * localNx * numComps)
+                    = (d + 1) * 1000 + (test_rank + 1) * 100 + (i + offsetX) * 10 + (j + offsetY);
+            }
+        }
+    }
+}
+
+TEST_SUITE_BEGIN("Halo exchange tests");
+MPI_TEST_CASE("test halo exchange on 3 proc grid with periodic boundary conditions", 3)
+{
+    // test for a 3 proc grid
+    // ┌─┬─┐
+    // │1│ │
+    // ├─┤2│
+    // │0│ │
+    // └─┴─┘ (proc id)
+
+    auto& modelMPI = ModelMPI::getInstance(test_comm);
+    auto& metadata = ModelMetadata::getInstance(file);
+
+    const size_t nx = metadata.getGlobalExtentX();
+    const size_t ny = metadata.getGlobalExtentY();
+    const size_t localNx = metadata.getLocalExtentX() + 2 * Halo::haloWidth;
+    const size_t localNy = metadata.getLocalExtentY() + 2 * Halo::haloWidth;
+    const size_t offsetX = metadata.getLocalCornerX();
+    const size_t offsetY = metadata.getLocalCornerY();
+
+    ModelArray::setDimension(ModelArray::Dimension::X, nx, localNx, offsetX);
+    ModelArray::setDimension(ModelArray::Dimension::Y, ny, localNy, offsetY);
+    ModelArray::setDimension(ModelArray::Dimension::XVERTEX, nx + 1, localNx + 1, offsetX);
+    ModelArray::setDimension(ModelArray::Dimension::YVERTEX, ny + 1, localNy + 1, offsetY);
+
+    // create example 2D field on each process
+    auto testData = ModelArray::HField();
+    testData.resize();
+    testData = 0.;
+
+    // create halo for testData model array
+    Halo halo(testData);
+
+    // create and allocate temporary Eigen array
+    ModelArray::DataType innerData;
+    innerData.resize(halo.getInnerSize(), testData.nComponents());
+    initializeTestData(
+        innerData, localNx - 2, localNy - 2, offsetX, offsetY, testData.nComponents(), test_rank);
+
+    // populate inner block of modelarray
+    halo.setInnerBlock(innerData, testData.getDataRef());
+    // exchange halos
+    halo.exchangeHalos(testData.getDataRef());
+
+    // initialize reference data for each proc
+    ModelArray::DataType refData;
+    refData.resize(localNx * localNy, 1);
+    refData
+        = Eigen::Map<ModelArray::DataType>(refDataAllProcs[test_rank].data(), refData.size(), 1);
+
+    for (size_t j = 0; j < localNy; j++) {
+        for (size_t i = 0; i < localNx; i++) {
+            if (refData(i + j * localNx) > 0) {
+                REQUIRE(testData(i, j) == 1000. + refData(i + j * localNx));
+            } else {
+                REQUIRE(testData(i, j) == 0.);
+            }
+        }
+    }
+
+    VertexField coordinates = ModelArray::VertexField();
+    coordinates.resize();
+    coordinates = 0.;
+
+    Halo haloVertex(coordinates);
+
+    // Vetex coordinates
+    auto localNxVertex = localNx + 1;
+    auto localNyVertex = localNy + 1;
+    for (size_t i = 0; i < localNxVertex - 2 * Halo::haloWidth; ++i) {
+        for (size_t j = 0; j < localNyVertex - 2 * Halo::haloWidth; ++j) {
+            double x = (i + offsetX) - 0.5 - float(nx) / 2;
+            double y = (j + offsetY) - 0.5 - float(ny) / 2;
+            coordinates.components({ i + Halo::haloWidth, j + Halo::haloWidth })[0] = x * 100.;
+            coordinates.components({ i + Halo::haloWidth, j + Halo::haloWidth })[1] = y * 100.;
+        }
+    }
+
+    haloVertex.exchangeHalos(coordinates.getDataRef());
+
+    std::vector<double> refDataVertex;
+
+    if (test_rank == 0) {
+        refDataVertex = std::vector<double>({ 0., 0., -550., 300., -450., 300., -350., 300., -250.,
+            300., -150., 300., -50., 300., 50., 300., 150., 300., 0., 0., 350., -500., -550., -500.,
+            -450., -500., -350., -500., -250., -500., -150., -500., -50., -500., 50., -500., 150.,
+            -500., 250., -500., 350., -400., -550., -400., -450., -400., -350., -400., -250., -400.,
+            -150., -400., -50., -400., 50., -400., 150., -400., 250., -400., 350., -300., -550.,
+            -300., -450., -300., -350., -300., -250., -300., -150., -300., -50., -300., 50., -300.,
+            150., -300., 250., -300., 350., -200., -550., -200., -450., -200., -350., -200., -250.,
+            -200., -150., -200., -50., -200., 50., -200., 150., -200., 250., -200., 350., -100.,
+            -550., -100., -450., -100., -350., -100., -250., -100., -150., -100., -50., -100., 50.,
+            -100., 150., -100., 250., -100., 0., 0., -550., 0., -450., 0., -350., 0., -250., 0.,
+            -150., 0., -50., 0., 50., 0., 150., 0., 0., 0. });
+    }
+    if (test_rank == 1) {
+        refDataVertex = std::vector<double>({ 0., 0., -550., -200., -450., -200., -350., -200.,
+            -250., -200., -150., -200., -50., -200., 50., -200., 150., -200., 0., 0., 350., -100.,
+            -550., -100., -450., -100., -350., -100., -250., -100., -150., -100., -50., -100., 50.,
+            -100., 150., -100., 250., -100., 350., 0., -550., 0., -450., 0., -350., 0., -250., 0.,
+            -150., 0., -50., 0., 50., 0., 150., 0., 250., 0., 350., 100., -550., 100., -450., 100.,
+            -350., 100., -250., 100., -150., 100., -50., 100., 50., 100., 150., 100., 250., 100.,
+            350., 200., -550., 200., -450., 200., -350., 200., -250., 200., -150., 200., -50., 200.,
+            50., 200., 150., 200., 250., 200., 350., 300., -550., 300., -450., 300., -350., 300.,
+            -250., 300., -150., 300., -50., 300., 50., 300., 150., 300., 250., 300., 350., 400.,
+            -550., 400., -450., 400., -350., 400., -250., 400., -150., 400., -50., 400., 50., 400.,
+            150., 400., 250., 400., 0., 0., -550., -400., -450., -400., -350., -400., -250., -400.,
+            -150., -400., -50., -400., 50., -400., 150., -400., 0., 0. });
+    }
+    if (test_rank == 2) {
+        refDataVertex = std::vector<double>({ 0., 0., 150., 300., 250., 300., 350., 300., 450.,
+            300., 0., 0., 50., -500., 150., -500., 250., -500., 350., -500., 450., -500., -450.,
+            -500., 50., -400., 150., -400., 250., -400., 350., -400., 450., -400., -450., -400.,
+            50., -300., 150., -300., 250., -300., 350., -300., 450., -300., -450., -300., 50.,
+            -200., 150., -200., 250., -200., 350., -200., 450., -200., -450., -200., 50., -100.,
+            150., -100., 250., -100., 350., -100., 450., -100., -450., -100., 50., 0., 150., 0.,
+            250., 0., 350., 0., 450., 0., -450., 0., 50., 100., 150., 100., 250., 100., 350., 100.,
+            450., 100., -450., 100., 50., 200., 150., 200., 250., 200., 350., 200., 450., 200.,
+            -450., 200., 50., 300., 150., 300., 250., 300., 350., 300., 450., 300., -450., 300.,
+            50., 400., 150., 400., 250., 400., 350., 400., 450., 400., -450., 400., 0., 0., 150.,
+            -400., 250., -400., 350., -400., 450., -400., 0., 0. });
+    }
+
+    auto coordRef = coordinates.getDataRef();
+    for (size_t j = 0; j < localNyVertex; j++) {
+        for (size_t i = 0; i < localNxVertex; i++) {
+            for (size_t coord = 0; coord < 2; coord++) {
+                REQUIRE(coordRef(i + j * localNxVertex, coord)
+                    == refDataVertex[coord + i * 2 + j * localNxVertex * 2]);
+            }
+        }
+    }
+}
+
+MPI_TEST_CASE("DGField", 3)
+{
+    auto& modelMPI = ModelMPI::getInstance();
+    auto& metadata = ModelMetadata::getInstance();
+
+    const size_t nx = metadata.getGlobalExtentX();
+    const size_t ny = metadata.getGlobalExtentY();
+    const size_t localNx = metadata.getLocalExtentX() + 2 * Halo::haloWidth;
+    const size_t localNy = metadata.getLocalExtentY() + 2 * Halo::haloWidth;
+    const size_t offsetX = metadata.getLocalCornerX();
+    const size_t offsetY = metadata.getLocalCornerY();
+
+    ModelArray::setDimension(ModelArray::Dimension::X, nx, localNx, offsetX);
+    ModelArray::setDimension(ModelArray::Dimension::Y, ny, localNy, offsetY);
+    ModelArray::setNComponents(ModelArray::Type::DG, DG);
+
+    // create example 2D field on each process
+    auto testData = ModelArray::DGField();
+    testData.resize();
+    testData = 0.;
+
+    // create halo for testData model array
+    Halo halo(testData);
+
+    // create and allocate temporary Eigen array
+    ModelArray::DataType innerData;
+    innerData.resize(halo.getInnerSize(), testData.nComponents());
+    initializeTestData(
+        innerData, localNx - 2, localNy - 2, offsetX, offsetY, testData.nComponents(), test_rank);
+
+    // populate inner block of modelarray
+    halo.setInnerBlock(innerData, testData.getDataRef());
+    // exchange halos
+    halo.exchangeHalos(testData.getDataRef());
+
+    // initialize reference data for each proc
+    ModelArray::DataType refData;
+    refData.resize(localNx * localNy, 1);
+    refData
+        = Eigen::Map<ModelArray::DataType>(refDataAllProcs[test_rank].data(), refData.size(), 1);
+
+    for (size_t j = 0; j < localNy; j++) {
+        for (size_t i = 0; i < localNx; i++) {
+            for (size_t d = 0; d < DG; ++d) {
+                if (refData(i + j * localNx) > 0) {
+                    REQUIRE(testData.components({ i, j })[d]
+                        == (d + 1) * 1000. + refData(i + j * localNx));
+                } else {
+                    REQUIRE(testData.components({ i, j })[d] == 0.);
+                }
+            }
+        }
+    }
+}
+
+MPI_TEST_CASE("DGVector", 3)
+{
+    auto& modelMPI = ModelMPI::getInstance();
+    auto& metadata = ModelMetadata::getInstance();
+
+    const size_t nx = metadata.getGlobalExtentX();
+    const size_t ny = metadata.getGlobalExtentY();
+    const size_t localNx = metadata.getLocalExtentX() + 2 * Halo::haloWidth;
+    const size_t localNy = metadata.getLocalExtentY() + 2 * Halo::haloWidth;
+    const size_t offsetX = metadata.getLocalCornerX();
+    const size_t offsetY = metadata.getLocalCornerY();
+
+    ModelArray::setDimension(ModelArray::Dimension::X, nx, localNx, offsetX);
+    ModelArray::setDimension(ModelArray::Dimension::Y, ny, localNy, offsetY);
+    ModelArray::setNComponents(ModelArray::Type::DG, DG);
+
+    ParametricMesh smesh(CARTESIAN);
+    smesh.nx = localNx;
+    smesh.ny = localNy;
+    smesh.nnodes = localNx * localNy;
+    smesh.nelements = localNx * localNy;
+    smesh.vertices.resize(smesh.nelements, Eigen::NoChange);
+    for (size_t i = 0; i < localNx; ++i) {
+        for (size_t j = 0; j < localNy; ++j) {
+            smesh.vertices(i * localNy + j, 0) = i;
+            smesh.vertices(i * localNy + j, 1) = j;
+        }
+    }
+
+    // create example DGVector
+    DGVector<DG> testData(smesh);
+    testData.zero();
+
+    // create halo for testData model array
+    Halo halo(testData);
+
+    // create and allocate temporary Eigen array
+    ModelArray::DataType innerData;
+    innerData.resize(halo.getInnerSize(), DG);
+    initializeTestData(innerData, localNx - 2, localNy - 2, offsetX, offsetY, DG, test_rank);
+
+    // populate inner block of modelarray
+    halo.setInnerBlock(innerData, testData);
+
+    // exchange halos
+    halo.exchangeHalos(testData);
+
+    // initialize reference data for each proc
+    ModelArray::DataType refData;
+    refData.resize(localNx * localNy, 1);
+    refData
+        = Eigen::Map<ModelArray::DataType>(refDataAllProcs[test_rank].data(), refData.size(), 1);
+
+    for (size_t j = 0; j < localNy; j++) {
+        for (size_t i = 0; i < localNx; i++) {
+            for (size_t d = 0; d < DG; ++d) {
+                if (refData(i + j * localNx) > 0) {
+                    REQUIRE(
+                        testData(i + j * localNx, d) == (d + 1) * 1000. + refData(i + j * localNx));
+                } else {
+                    REQUIRE(testData(i + j * localNx, d) == 0.);
+                }
+            }
+        }
+    }
+}
+}

--- a/core/test/HaloExchangePB_test.cpp
+++ b/core/test/HaloExchangePB_test.cpp
@@ -1,62 +1,204 @@
 /*!
- * @author  Tom Meltzer <tdm39@cam.ac.uk>
+ * @author  Tom Meltzer <tdm39@cam.ac.uk> & Mikolaj Adam Kowalski <mak60@cam.ac.uk>
  * @brief   Test halo exchange class for Periodic Boundaries (PB)
  * @details
+ *
+ * The purpose of this test is to verify the Halo exchange.
+ *
+ * We accomplish that by:
+ *  - Assigning each value in the grid with a unique id (hash) based on its global
+ *    coordinates
+ *  - We take care to not assign any values in the halo region for each rank
+ *  - We then perform tha halo exchange
+ *  - For each rank we verify that the values stored in the field match the
+ *    hash
  *
  * Test halo exchange class for Periodic Boundaries (PB) on following fields:
  * - HField
  * - VertexField
  * - DGField
  * - DGVector
+ * - CGVector
  */
 
 #include <doctest/extensions/doctest_mpi.h>
+#include <iostream>
+#include <ostream>
+#include <utility>
 
 #include "ModelMPI.hpp"
 #include "ModelMetadata.hpp"
+#include "cgVector.hpp"
 #include "include/DGModelArray.hpp"
 #include "include/Halo.hpp"
+#include "include/Interpolations.hpp"
 
 namespace Nextsim {
 
 const std::string testFilesDir = TEST_FILES_DIR;
-const std::string file = testFilesDir + "/partition_metadata_3_pb.nc";
+const std::string file = testFilesDir + "/halo_pb_test_partition_metadata_3.nc";
 
 static const int DG = 3;
+static const int CGDEGREE = 2;
 static const bool debug = false;
 
-// reference data for each process
-static std::array<std::vector<double>, 3> refDataAllProcs = {
-    std::vector<double>(
-        { 0, 208, 218, 228, 238, 248, 258, 268, 0, 390, 100, 110, 120, 130, 140, 150, 160, 370, 391,
-            101, 111, 121, 131, 141, 151, 161, 371, 392, 102, 112, 122, 132, 142, 152, 162, 372,
-            393, 103, 113, 123, 133, 143, 153, 163, 373, 0, 204, 214, 224, 234, 244, 254, 264, 0 }),
-    std::vector<double>({ 0, 103, 113, 123, 133, 143, 153, 163, 0, 394, 204, 214, 224, 234, 244,
-        254, 264, 374, 395, 205, 215, 225, 235, 245, 255, 265, 375, 396, 206, 216, 226, 236, 246,
-        256, 266, 376, 397, 207, 217, 227, 237, 247, 257, 267, 377, 398, 208, 218, 228, 238, 248,
-        258, 268, 378, 0, 100, 110, 120, 130, 140, 150, 160, 0 }),
-    std::vector<double>({ 0, 378, 388, 398, 0, 160, 370, 380, 390, 100, 161, 371, 381, 391, 101,
-        162, 372, 382, 392, 102, 163, 373, 383, 393, 103, 264, 374, 384, 394, 204, 265, 375, 385,
-        395, 205, 266, 376, 386, 396, 206, 267, 377, 387, 397, 207, 268, 378, 388, 398, 208, 0, 370,
-        380, 390, 0 }),
+/**
+ * Helper class to group all domain-dependent calculations
+ *
+ * It is hardcoded for a periodic topology both in X and Y.
+ * The interpretation of  wraparound for the cell based fields (e.g. H or DG) is
+ * quite straightforward. It is just that on the right edge, the right neighbours
+ * of the cells are the cells on the left edge of the domain.
+ *
+ * For point based fields there is only one caveat. The points on the right edge
+ * ARE the points on the left edge. There is continuity and they need to have
+ * the same identity.
+ *
+ * Hence while without a periodic boundary a domain of NxM cells will have
+ * (N+1)x(M+1) vertices, with periodic boundaries it will have NxM vertices only.
+ *
+ */
+struct DomainModel {
+    int nx;
+    int ny;
+    int localNx;
+    int localNy;
+    int offsetX;
+    int offsetY;
+    int haloSize;
+    ModelArray::Type type;
+
+    /**
+     * @brief Construct a helper representation of the calculation domain
+     *
+     * @param nx X-axis size of the whole domain (number of cells in x direction)
+     * @param ny Same as nx but for the Y-axis
+     * @param localNx X-axis size of on the current rank (number of cells in x direction)
+     * @param localNy Same as localNx but for the Y-axis
+     * @param offsetX X-axis offset of the current rank. Defined as the index of the bottom left
+     * cell of the patch assigned to the current rank. It excludes the halo cells
+     * @param offsetY Y-axis offset. See offsetX for details.
+     * @param type Type of the model array)
+     */
+    DomainModel(
+        int nx, int ny, int localNx, int localNy, int offsetX, int offsetY, ModelArray::Type type)
+        : nx(nx)
+        , ny(ny)
+        , localNx(localNx)
+        , localNy(localNy)
+        , offsetX(offsetX)
+        , offsetY(offsetY)
+        , haloSize(1)
+        , type(type)
+    {
+        if (type == ModelArray::Type::VERTEX) {
+            //  Vertex fields have an extra entries (e.g. 3 cells in 1D have 4 vertices)
+            this->nx = nx;
+            this->ny = ny;
+            this->localNx = localNx + 1;
+            this->localNy = localNy + 1;
+        } else if (type == ModelArray::Type::CG) {
+            //  CG fields have an extra entries
+            //  Cells are subdivided by degrees in addition to the normal vertices
+            this->nx = nx * CGDEGREE;
+            this->ny = ny * CGDEGREE;
+            this->localNx = localNx * CGDEGREE + 1;
+            this->localNy = localNy * CGDEGREE + 1;
+            this->offsetX = offsetX * CGDEGREE;
+            this->offsetY = offsetY * CGDEGREE;
+            this->haloSize = CGDEGREE;
+        }
+    }
+
+    /**
+     * @brief Assign a unique id to each point
+     *
+     * We do it by enumerating the data points in the Y, X order for each component.
+     */
+    FloatType data_point_unique_id(int component, int i, int j) const
+    {
+        const auto [globalI, globalJ] = global_coordinates(i, j);
+        const int domain_size = this->nx * this->ny;
+
+        // Next power of 10 after the grid size is the component offset
+        const int component_offset = [](int size) {
+            int offset = 1;
+            // This may result in an infinite loop if size is too large
+            // But since it is used only in test we can cut some corners
+            while (offset <= size) {
+                offset *= 10;
+            }
+            return offset;
+        }(domain_size);
+
+        return component_offset * (component + 1) + globalI * this->ny + globalJ;
+    }
+
+    /**
+     * @brief Map the local coorinates of the domain to the global coordinates
+     *
+     * Assumes the periodic X and Y topology
+     */
+    std::pair<int, int> global_coordinates(int x, int y) const
+    {
+        const auto calculate_global = [](int local, int offset, int size, int haloSize) {
+            // The double remainder is here to deal with the negative numbers
+            // For positive single remainder if enough to map the value
+            // into the range [0, size)
+            //
+            // For the negative we need to project them into the positive range
+            // by adding the size again:
+            //  E.g. for size 8 and global position -1, we need to map it to 7
+            //
+            // Last remainder is the fixup of the `shift` for the positive inputs
+            // This allows us to avoid a branch
+            return ((local + offset - haloSize) % size + size) % size;
+        };
+        return { calculate_global(x, offsetX, nx, haloSize),
+            calculate_global(y, offsetY, ny, haloSize) };
+    }
 };
 
-void initializeTestData(ModelArray::DataType& data, size_t localNx, size_t localNy, size_t offsetX,
-    size_t offsetY, size_t numComps, int test_rank)
+template <typename T> void initializeTestData(T& data, const DomainModel& domain)
 {
-    // initialize with test data
-    for (size_t j = 0; j < localNy; ++j) {
-        for (size_t i = 0; i < localNx; ++i) {
-            for (size_t d = 0; d < numComps; ++d) {
-                data(d + i * numComps + j * localNx * numComps)
-                    = (d + 1) * 1000 + (test_rank + 1) * 100 + (i + offsetX) * 10 + (j + offsetY);
+    // nCells is the effective size of the halo
+    // The interior of the domain is [nCells, localNx - nCells) x [nCells, localNy - nCells)]
+    const int nCells = domain.haloSize;
+    const auto numComps = data.cols();
+
+    // initialize only inner block of data (to mimic behaviour of Halo::setInnerBlock())
+    for (int j = nCells; j < domain.localNy - nCells; ++j) {
+        for (int i = nCells; i < domain.localNx - nCells; ++i) {
+            for (int d = 0; d < numComps; ++d) {
+                data(d + i * numComps + j * domain.localNx * numComps)
+                    = domain.data_point_unique_id(d, i, j);
+            }
+        }
+    }
+}
+
+template <typename T> void verifyTestData(T& data, const DomainModel& domain)
+{
+    const int nCells = domain.haloSize;
+    const auto numComps = static_cast<int>(data.cols());
+
+    // Verify the test data
+    for (int j = 0; j < domain.localNy; j++) {
+        for (int i = 0; i < domain.localNx; i++) {
+            for (int d = 0; d < numComps; d++) {
+                const auto [globalI, globalJ] = domain.global_coordinates(i, j);
+
+                const auto expectedValue = domain.data_point_unique_id(d, i, j);
+                const auto actualValue = data(d + i * numComps + j * domain.localNx * numComps);
+
+                REQUIRE(actualValue == expectedValue);
             }
         }
     }
 }
 
 TEST_SUITE_BEGIN("Halo exchange tests");
-MPI_TEST_CASE("test halo exchange on 3 proc grid with periodic boundary conditions", 3)
+MPI_TEST_CASE("test halo exchange on 3 proc grid", 3)
 {
     // test for a 3 proc grid
     // ┌─┬─┐
@@ -68,12 +210,20 @@ MPI_TEST_CASE("test halo exchange on 3 proc grid with periodic boundary conditio
     auto& modelMPI = ModelMPI::getInstance(test_comm);
     auto& metadata = ModelMetadata::getInstance(file);
 
-    const size_t nx = metadata.getGlobalExtentX();
-    const size_t ny = metadata.getGlobalExtentY();
-    const size_t localNx = metadata.getLocalExtentX() + 2 * Halo::haloWidth;
-    const size_t localNy = metadata.getLocalExtentY() + 2 * Halo::haloWidth;
-    const size_t offsetX = metadata.getLocalCornerX();
-    const size_t offsetY = metadata.getLocalCornerY();
+    // We work on signed integers to represent extents and grid
+    // coordinates
+    // Size of the entire computational domain
+    const int nx = metadata.getGlobalExtentX();
+    const int ny = metadata.getGlobalExtentY();
+
+    // Size of the domain of the current rank with halo
+    const int localNx = metadata.getLocalExtentX() + 2 * static_cast<int>(Halo::haloWidth);
+    const int localNy = metadata.getLocalExtentY() + 2 * static_cast<int>(Halo::haloWidth);
+
+    // Position of the lower left corner of the patch (excluding halo) in the global
+    // mesh
+    const int offsetX = metadata.getLocalCornerX();
+    const int offsetY = metadata.getLocalCornerY();
 
     ModelArray::setDimension(ModelArray::Dimension::X, nx, localNx, offsetX);
     ModelArray::setDimension(ModelArray::Dimension::Y, ny, localNy, offsetY);
@@ -81,112 +231,35 @@ MPI_TEST_CASE("test halo exchange on 3 proc grid with periodic boundary conditio
     ModelArray::setDimension(ModelArray::Dimension::YVERTEX, ny + 1, localNy + 1, offsetY);
 
     // create example 2D field on each process
+    DomainModel HFieldDomain { nx, ny, localNx, localNy, offsetX, offsetY, ModelArray::Type::H };
     auto testData = ModelArray::HField();
-    testData.resize();
+    testData.reinitialize();
     testData = 0.;
 
     // create halo for testData model array
     Halo halo(testData);
 
-    // create and allocate temporary Eigen array
-    ModelArray::DataType innerData;
-    innerData.resize(halo.getInnerSize(), testData.nComponents());
-    initializeTestData(
-        innerData, localNx - 2, localNy - 2, offsetX, offsetY, testData.nComponents(), test_rank);
+    initializeTestData(testData.getDataRef(), HFieldDomain);
 
-    // populate inner block of modelarray
-    halo.setInnerBlock(innerData, testData.getDataRef());
     // exchange halos
     halo.exchangeHalos(testData.getDataRef());
 
-    // initialize reference data for each proc
-    ModelArray::DataType refData;
-    refData.resize(localNx * localNy, 1);
-    refData
-        = Eigen::Map<ModelArray::DataType>(refDataAllProcs[test_rank].data(), refData.size(), 1);
+    // Verify the test data after halo exchange
+    verifyTestData(testData.getDataRef(), HFieldDomain);
 
-    for (size_t j = 0; j < localNy; j++) {
-        for (size_t i = 0; i < localNx; i++) {
-            if (refData(i + j * localNx) > 0) {
-                REQUIRE(testData(i, j) == 1000. + refData(i + j * localNx));
-            } else {
-                REQUIRE(testData(i, j) == 0.);
-            }
-        }
-    }
-
+    DomainModel VertexFieldDomain { nx, ny, localNx, localNy, offsetX, offsetY,
+        ModelArray::Type::VERTEX };
     VertexField coordinates = ModelArray::VertexField();
-    coordinates.resize();
+    coordinates.reinitialize();
     coordinates = 0.;
 
     Halo haloVertex(coordinates);
 
-    // Vetex coordinates
-    auto localNxVertex = localNx + 1;
-    auto localNyVertex = localNy + 1;
-    for (size_t i = 0; i < localNxVertex - 2 * Halo::haloWidth; ++i) {
-        for (size_t j = 0; j < localNyVertex - 2 * Halo::haloWidth; ++j) {
-            double x = (i + offsetX) - 0.5 - float(nx) / 2;
-            double y = (j + offsetY) - 0.5 - float(ny) / 2;
-            coordinates.components({ i + Halo::haloWidth, j + Halo::haloWidth })[0] = x * 100.;
-            coordinates.components({ i + Halo::haloWidth, j + Halo::haloWidth })[1] = y * 100.;
-        }
-    }
+    initializeTestData(coordinates.getDataRef(), VertexFieldDomain);
 
     haloVertex.exchangeHalos(coordinates.getDataRef());
 
-    std::vector<double> refDataVertex;
-
-    if (test_rank == 0) {
-        refDataVertex = std::vector<double>({ 0., 0., -550., 300., -450., 300., -350., 300., -250.,
-            300., -150., 300., -50., 300., 50., 300., 150., 300., 0., 0., 350., -500., -550., -500.,
-            -450., -500., -350., -500., -250., -500., -150., -500., -50., -500., 50., -500., 150.,
-            -500., 250., -500., 350., -400., -550., -400., -450., -400., -350., -400., -250., -400.,
-            -150., -400., -50., -400., 50., -400., 150., -400., 250., -400., 350., -300., -550.,
-            -300., -450., -300., -350., -300., -250., -300., -150., -300., -50., -300., 50., -300.,
-            150., -300., 250., -300., 350., -200., -550., -200., -450., -200., -350., -200., -250.,
-            -200., -150., -200., -50., -200., 50., -200., 150., -200., 250., -200., 350., -100.,
-            -550., -100., -450., -100., -350., -100., -250., -100., -150., -100., -50., -100., 50.,
-            -100., 150., -100., 250., -100., 0., 0., -550., 0., -450., 0., -350., 0., -250., 0.,
-            -150., 0., -50., 0., 50., 0., 150., 0., 0., 0. });
-    }
-    if (test_rank == 1) {
-        refDataVertex = std::vector<double>({ 0., 0., -550., -200., -450., -200., -350., -200.,
-            -250., -200., -150., -200., -50., -200., 50., -200., 150., -200., 0., 0., 350., -100.,
-            -550., -100., -450., -100., -350., -100., -250., -100., -150., -100., -50., -100., 50.,
-            -100., 150., -100., 250., -100., 350., 0., -550., 0., -450., 0., -350., 0., -250., 0.,
-            -150., 0., -50., 0., 50., 0., 150., 0., 250., 0., 350., 100., -550., 100., -450., 100.,
-            -350., 100., -250., 100., -150., 100., -50., 100., 50., 100., 150., 100., 250., 100.,
-            350., 200., -550., 200., -450., 200., -350., 200., -250., 200., -150., 200., -50., 200.,
-            50., 200., 150., 200., 250., 200., 350., 300., -550., 300., -450., 300., -350., 300.,
-            -250., 300., -150., 300., -50., 300., 50., 300., 150., 300., 250., 300., 350., 400.,
-            -550., 400., -450., 400., -350., 400., -250., 400., -150., 400., -50., 400., 50., 400.,
-            150., 400., 250., 400., 0., 0., -550., -400., -450., -400., -350., -400., -250., -400.,
-            -150., -400., -50., -400., 50., -400., 150., -400., 0., 0. });
-    }
-    if (test_rank == 2) {
-        refDataVertex = std::vector<double>({ 0., 0., 150., 300., 250., 300., 350., 300., 450.,
-            300., 0., 0., 50., -500., 150., -500., 250., -500., 350., -500., 450., -500., -450.,
-            -500., 50., -400., 150., -400., 250., -400., 350., -400., 450., -400., -450., -400.,
-            50., -300., 150., -300., 250., -300., 350., -300., 450., -300., -450., -300., 50.,
-            -200., 150., -200., 250., -200., 350., -200., 450., -200., -450., -200., 50., -100.,
-            150., -100., 250., -100., 350., -100., 450., -100., -450., -100., 50., 0., 150., 0.,
-            250., 0., 350., 0., 450., 0., -450., 0., 50., 100., 150., 100., 250., 100., 350., 100.,
-            450., 100., -450., 100., 50., 200., 150., 200., 250., 200., 350., 200., 450., 200.,
-            -450., 200., 50., 300., 150., 300., 250., 300., 350., 300., 450., 300., -450., 300.,
-            50., 400., 150., 400., 250., 400., 350., 400., 450., 400., -450., 400., 0., 0., 150.,
-            -400., 250., -400., 350., -400., 450., -400., 0., 0. });
-    }
-
-    auto coordRef = coordinates.getDataRef();
-    for (size_t j = 0; j < localNyVertex; j++) {
-        for (size_t i = 0; i < localNxVertex; i++) {
-            for (size_t coord = 0; coord < 2; coord++) {
-                REQUIRE(coordRef(i + j * localNxVertex, coord)
-                    == refDataVertex[coord + i * 2 + j * localNxVertex * 2]);
-            }
-        }
-    }
+    verifyTestData(coordinates.getDataRef(), VertexFieldDomain);
 }
 
 MPI_TEST_CASE("DGField", 3)
@@ -194,54 +267,40 @@ MPI_TEST_CASE("DGField", 3)
     auto& modelMPI = ModelMPI::getInstance();
     auto& metadata = ModelMetadata::getInstance();
 
-    const size_t nx = metadata.getGlobalExtentX();
-    const size_t ny = metadata.getGlobalExtentY();
-    const size_t localNx = metadata.getLocalExtentX() + 2 * Halo::haloWidth;
-    const size_t localNy = metadata.getLocalExtentY() + 2 * Halo::haloWidth;
-    const size_t offsetX = metadata.getLocalCornerX();
-    const size_t offsetY = metadata.getLocalCornerY();
+    // We work on signed integers to represent extents and grid
+    // coordinates
+    // Size of the entire computational domain
+    const int nx = metadata.getGlobalExtentX();
+    const int ny = metadata.getGlobalExtentY();
+
+    // Size of the domain of the current rank with halo
+    const int localNx = metadata.getLocalExtentX() + 2 * static_cast<int>(Halo::haloWidth);
+    const int localNy = metadata.getLocalExtentY() + 2 * static_cast<int>(Halo::haloWidth);
+
+    // Position of the lower left corner of the patch (excluding halo) in the global
+    // mesh
+    const int offsetX = metadata.getLocalCornerX();
+    const int offsetY = metadata.getLocalCornerY();
 
     ModelArray::setDimension(ModelArray::Dimension::X, nx, localNx, offsetX);
     ModelArray::setDimension(ModelArray::Dimension::Y, ny, localNy, offsetY);
     ModelArray::setNComponents(ModelArray::Type::DG, DG);
 
     // create example 2D field on each process
+    DomainModel DGFieldDomain { nx, ny, localNx, localNy, offsetX, offsetY, ModelArray::Type::DG };
     auto testData = ModelArray::DGField();
-    testData.resize();
+    testData.reinitialize();
     testData = 0.;
 
     // create halo for testData model array
     Halo halo(testData);
 
-    // create and allocate temporary Eigen array
-    ModelArray::DataType innerData;
-    innerData.resize(halo.getInnerSize(), testData.nComponents());
-    initializeTestData(
-        innerData, localNx - 2, localNy - 2, offsetX, offsetY, testData.nComponents(), test_rank);
+    initializeTestData(testData.getDataRef(), DGFieldDomain);
 
-    // populate inner block of modelarray
-    halo.setInnerBlock(innerData, testData.getDataRef());
     // exchange halos
     halo.exchangeHalos(testData.getDataRef());
 
-    // initialize reference data for each proc
-    ModelArray::DataType refData;
-    refData.resize(localNx * localNy, 1);
-    refData
-        = Eigen::Map<ModelArray::DataType>(refDataAllProcs[test_rank].data(), refData.size(), 1);
-
-    for (size_t j = 0; j < localNy; j++) {
-        for (size_t i = 0; i < localNx; i++) {
-            for (size_t d = 0; d < DG; ++d) {
-                if (refData(i + j * localNx) > 0) {
-                    REQUIRE(testData.components({ i, j })[d]
-                        == (d + 1) * 1000. + refData(i + j * localNx));
-                } else {
-                    REQUIRE(testData.components({ i, j })[d] == 0.);
-                }
-            }
-        }
-    }
+    verifyTestData(testData.getDataRef(), DGFieldDomain);
 }
 
 MPI_TEST_CASE("DGVector", 3)
@@ -249,12 +308,20 @@ MPI_TEST_CASE("DGVector", 3)
     auto& modelMPI = ModelMPI::getInstance();
     auto& metadata = ModelMetadata::getInstance();
 
-    const size_t nx = metadata.getGlobalExtentX();
-    const size_t ny = metadata.getGlobalExtentY();
-    const size_t localNx = metadata.getLocalExtentX() + 2 * Halo::haloWidth;
-    const size_t localNy = metadata.getLocalExtentY() + 2 * Halo::haloWidth;
-    const size_t offsetX = metadata.getLocalCornerX();
-    const size_t offsetY = metadata.getLocalCornerY();
+    // We work on signed integers to represent extents and grid
+    // coordinates
+    // Size of the entire computational domain
+    const int nx = metadata.getGlobalExtentX();
+    const int ny = metadata.getGlobalExtentY();
+
+    // Size of the domain of the current rank with halo
+    const int localNx = metadata.getLocalExtentX() + 2 * static_cast<int>(Halo::haloWidth);
+    const int localNy = metadata.getLocalExtentY() + 2 * static_cast<int>(Halo::haloWidth);
+
+    // Position of the lower left corner of the patch (excluding halo) in the global
+    // mesh
+    const int offsetX = metadata.getLocalCornerX();
+    const int offsetY = metadata.getLocalCornerY();
 
     ModelArray::setDimension(ModelArray::Dimension::X, nx, localNx, offsetX);
     ModelArray::setDimension(ModelArray::Dimension::Y, ny, localNy, offsetY);
@@ -263,51 +330,86 @@ MPI_TEST_CASE("DGVector", 3)
     ParametricMesh smesh(CARTESIAN);
     smesh.nx = localNx;
     smesh.ny = localNy;
-    smesh.nnodes = localNx * localNy;
     smesh.nelements = localNx * localNy;
-    smesh.vertices.resize(smesh.nelements, Eigen::NoChange);
-    for (size_t i = 0; i < localNx; ++i) {
-        for (size_t j = 0; j < localNy; ++j) {
-            smesh.vertices(i * localNy + j, 0) = i;
-            smesh.vertices(i * localNy + j, 1) = j;
+    smesh.nnodes = (localNx + 1) * (localNy + 1);
+    smesh.vertices.resize(smesh.nnodes, Eigen::NoChange);
+    for (size_t i = 0; i < localNx + 1; ++i) {
+        for (size_t j = 0; j < localNy + 1; ++j) {
+            smesh.vertices(i * (localNy + 1) + j, 0) = i;
+            smesh.vertices(i * (localNy + 1) + j, 1) = j;
         }
     }
 
     // create example DGVector
+    // The DGVector is not a ModelArray, but it is cell-centred with DG components,
+    // so in terms of topology it behaves exactly like the DG field
+    DomainModel DGVectorDomain { nx, ny, localNx, localNy, offsetX, offsetY, ModelArray::Type::DG };
     DGVector<DG> testData(smesh);
     testData.zero();
 
     // create halo for testData model array
     Halo halo(testData);
 
-    // create and allocate temporary Eigen array
-    ModelArray::DataType innerData;
-    innerData.resize(halo.getInnerSize(), DG);
-    initializeTestData(innerData, localNx - 2, localNy - 2, offsetX, offsetY, DG, test_rank);
-
-    // populate inner block of modelarray
-    halo.setInnerBlock(innerData, testData);
+    initializeTestData(testData, DGVectorDomain);
 
     // exchange halos
     halo.exchangeHalos(testData);
 
-    // initialize reference data for each proc
-    ModelArray::DataType refData;
-    refData.resize(localNx * localNy, 1);
-    refData
-        = Eigen::Map<ModelArray::DataType>(refDataAllProcs[test_rank].data(), refData.size(), 1);
+    verifyTestData(testData, DGVectorDomain);
+}
 
-    for (size_t j = 0; j < localNy; j++) {
-        for (size_t i = 0; i < localNx; i++) {
-            for (size_t d = 0; d < DG; ++d) {
-                if (refData(i + j * localNx) > 0) {
-                    REQUIRE(
-                        testData(i + j * localNx, d) == (d + 1) * 1000. + refData(i + j * localNx));
-                } else {
-                    REQUIRE(testData(i + j * localNx, d) == 0.);
-                }
-            }
+MPI_TEST_CASE("CGVector", 3)
+{
+    auto& modelMPI = ModelMPI::getInstance();
+    auto& metadata = ModelMetadata::getInstance();
+
+    // We work on signed integers to represent extents and grid
+    // coordinates
+    // Size of the entire computational domain
+    const int nx = metadata.getGlobalExtentX();
+    const int ny = metadata.getGlobalExtentY();
+
+    // Size of the domain of the current rank with halo
+    const int localNx = metadata.getLocalExtentX() + 2 * static_cast<int>(Halo::haloWidth);
+    const int localNy = metadata.getLocalExtentY() + 2 * static_cast<int>(Halo::haloWidth);
+
+    // Position of the lower left corner of the patch (excluding halo) in the global
+    // mesh
+    const int offsetX = metadata.getLocalCornerX();
+    const int offsetY = metadata.getLocalCornerY();
+
+    ModelArray::setDimension(ModelArray::Dimension::X, nx, localNx, offsetX);
+    ModelArray::setDimension(ModelArray::Dimension::Y, ny, localNy, offsetY);
+    ModelArray::setNComponents(ModelArray::Type::DG, DG);
+
+    ParametricMesh smesh(CARTESIAN);
+    smesh.nx = localNx;
+    smesh.ny = localNy;
+    smesh.nelements = localNx * localNy;
+    smesh.nnodes = (localNx + 1) * (localNy + 1);
+    smesh.vertices.resize(smesh.nnodes, Eigen::NoChange);
+    for (size_t i = 0; i < localNx + 1; ++i) {
+        for (size_t j = 0; j < localNy + 1; ++j) {
+            smesh.vertices(i * (localNy + 1) + j, 0) = i;
+            smesh.vertices(i * (localNy + 1) + j, 1) = j;
         }
     }
+
+    // create CGVector
+    // The CGVector is not a ModelArray, but it lives on a shared-node lattice that
+    // subdivides each cell CGDEGREE times, which Type::CG encodes in DomainModel
+    DomainModel CGDomain { nx, ny, localNx, localNy, offsetX, offsetY, ModelArray::Type::CG };
+    CGVector<CGDEGREE> cgVector;
+    cgVector.resize_by_mesh(smesh);
+    cgVector.zero();
+
+    // initialize data
+    initializeTestData(cgVector, CGDomain);
+
+    // create halo and exchange
+    Halo halo(cgVector);
+    halo.exchangeHalos(cgVector);
+
+    verifyTestData(cgVector, CGDomain);
 }
 }

--- a/core/test/HaloExchangePB_test.cpp
+++ b/core/test/HaloExchangePB_test.cpp
@@ -51,16 +51,35 @@ static const bool debug = false;
  * Helper class to group all domain-dependent calculations
  *
  * It is hardcoded for a periodic topology both in X and Y.
- * The interpretation of  wraparound for the cell based fields (e.g. H or DG) is
+ * The interpretation of wraparound for the cell based fields (e.g. H or DG) is
  * quite straightforward. It is just that on the right edge, the right neighbours
  * of the cells are the cells on the left edge of the domain.
+ * See the following diagram
  *
- * For point based fields there is only one caveat. The points on the right edge
- * ARE the points on the left edge. There is continuity and they need to have
- * the same identity.
+ * For an axis with size 4 and periodic boundary:
  *
- * Hence while without a periodic boundary a domain of NxM cells will have
- * (N+1)x(M+1) vertices, with periodic boundaries it will have NxM vertices only.
+ *      |     Domain    |         Domain
+ *  | 3 | 0 | 1 | 2 | 3 | 0 |     Cells
+ *
+ * For point-based fields (e.g. Vertex or CG) there is only one caveat. The
+ * points on the right edge ARE the points on the left edge. There is continuity
+ * and they need to have the same identity. Hence while without a periodic
+ * boundary a domain of NxM cells will have (N+1)x(M+1) vertices, with periodic
+ * boundaries it will have NxM vertices only.
+ *
+ * With periodic boundary and size 4 (cells):
+ *
+ *      |     Domain    |        Domain
+ *  | 3 | 0 | 1 | 2 | 3 | 0 |    Cells
+ *  ●   ●   ●   ●   ●   ●   ●    Vertices
+ *  3   0   1   2   3   0   1    Vertex global index
+ *
+ * Without periodic boundary and size 4 (cells):
+ *
+ *      |     Domain    |        Domain
+ *  | x | 0 | 1 | 2 | 3 | x |    Cells
+ *  ●   ●   ●   ●   ●   ●   ●    Vertices
+ *  x   0   1   2   3   4   x    Vertex global index
  *
  */
 struct DomainModel {

--- a/core/test/HaloExchangePB_test.cpp
+++ b/core/test/HaloExchangePB_test.cpp
@@ -220,7 +220,9 @@ MPI_TEST_CASE("test halo exchange on 3 proc grid", 3)
     auto& modelMPI = ModelMPI::getInstance(test_comm);
     auto& metadata = ModelMetadata::getInstance(file);
 
-    // We work on signed integers to represent extents and grid
+    // We work on signed integers to represent extents and grid in contrast
+    // to the CB version of the test.
+    // It makes the wraparound calculations much easier.
     // coordinates
     // Size of the entire computational domain
     const int nx = metadata.getGlobalExtentX();
@@ -277,8 +279,9 @@ MPI_TEST_CASE("DGField", 3)
     auto& modelMPI = ModelMPI::getInstance();
     auto& metadata = ModelMetadata::getInstance();
 
-    // We work on signed integers to represent extents and grid
-    // coordinates
+    // We work on signed integers to represent extents and grid in contrast
+    // to the CB version of the test.
+    // It makes the wraparound calculations much easier.
     // Size of the entire computational domain
     const int nx = metadata.getGlobalExtentX();
     const int ny = metadata.getGlobalExtentY();
@@ -318,8 +321,9 @@ MPI_TEST_CASE("DGVector", 3)
     auto& modelMPI = ModelMPI::getInstance();
     auto& metadata = ModelMetadata::getInstance();
 
-    // We work on signed integers to represent extents and grid
-    // coordinates
+    // We work on signed integers to represent extents and grid in contrast
+    // to the CB version of the test.
+    // It makes the wraparound calculations much easier.
     // Size of the entire computational domain
     const int nx = metadata.getGlobalExtentX();
     const int ny = metadata.getGlobalExtentY();
@@ -373,8 +377,9 @@ MPI_TEST_CASE("CGVector", 3)
     auto& modelMPI = ModelMPI::getInstance();
     auto& metadata = ModelMetadata::getInstance();
 
-    // We work on signed integers to represent extents and grid
-    // coordinates
+    // We work on signed integers to represent extents and grid in contrast
+    // to the CB version of the test.
+    // It makes the wraparound calculations much easier.
     // Size of the entire computational domain
     const int nx = metadata.getGlobalExtentX();
     const int ny = metadata.getGlobalExtentY();

--- a/core/test/HaloExchangePB_test.cpp
+++ b/core/test/HaloExchangePB_test.cpp
@@ -1,19 +1,24 @@
 /*!
  * @author  Tom Meltzer <tdm39@cam.ac.uk> & Mikolaj Adam Kowalski <mak60@cam.ac.uk>
  * @brief   Test halo exchange class for Periodic Boundaries (PB)
- * @details
  *
- * The purpose of this test is to verify the Halo exchange.
+ * @details
+ * The purpose of this test is to verify the halo exchange implementation with
+ * periodic boundary conditions.
  *
  * We accomplish that by:
- *  - Assigning each value in the grid with a unique id (hash) based on its global
- *    coordinates
- *  - We take care to not assign any values in the halo region for each rank
+ *  - Assigning each value in the grid with a unique id (hash) based on the global
+ *    coordinates. Note that the value depends only on the global position and
+ *    the component index.
+ *  - In each rank, we assign the values of the hash to the field in the interior only.
+ *    The halo regions are left uninitialized (set to zero).
  *  - We then perform the halo exchange
- *  - For each rank we verify that the values stored in the field match the
- *    hash
+ *  - On each rank, we verify that all values in the field (including those in
+ *    the halo regions) match the expected hash. It is performed for the
+ *    interior as well to detect any cases of data corruption during the halo
+ *    exchange (e.g. accidental copy outside the halo region)
  *
- * Test halo exchange class for Periodic Boundaries (PB) on following fields:
+ * We apply this verification procedure to the following fields:
  * - HField
  * - VertexField
  * - DGField

--- a/core/test/HaloExchangePB_test.cpp
+++ b/core/test/HaloExchangePB_test.cpp
@@ -9,7 +9,7 @@
  *  - Assigning each value in the grid with a unique id (hash) based on its global
  *    coordinates
  *  - We take care to not assign any values in the halo region for each rank
- *  - We then perform tha halo exchange
+ *  - We then perform the halo exchange
  *  - For each rank we verify that the values stored in the field match the
  *    hash
  *
@@ -135,7 +135,7 @@ struct DomainModel {
     }
 
     /**
-     * @brief Map the local coorinates of the domain to the global coordinates
+     * @brief Map the local coordinates of the domain to the global coordinates
      *
      * Assumes the periodic X and Y topology
      */

--- a/core/test/HaloExchangePB_test.cpp
+++ b/core/test/HaloExchangePB_test.cpp
@@ -97,14 +97,19 @@ struct DomainModel {
         , type(type)
     {
         if (type == ModelArray::Type::VERTEX) {
-            //  Vertex fields have an extra entries (e.g. 3 cells in 1D have 4 vertices)
+            // Vertex fields have extra entries (e.g. 3 cells in 1D have 4 vertices)
+            // But only for local sizes (size in each rank).
+            // Due to the periodic boundary conditions the global size is not increased
+            // because vertices on the right edge are the same vertices that are on the left edge.
             this->nx = nx;
             this->ny = ny;
             this->localNx = localNx + 1;
             this->localNy = localNy + 1;
         } else if (type == ModelArray::Type::CG) {
-            //  CG fields have an extra entries
-            //  Cells are subdivided by degrees in addition to the normal vertices
+            // CG fields are stored on the node mesh and the remark for the Vertex fields and their
+            // size applies for them as well.
+            // In addition, extra points are placed inside each cell, with the number being
+            // dependent on the degree.
             this->nx = nx * CGDEGREE;
             this->ny = ny * CGDEGREE;
             this->localNx = localNx * CGDEGREE + 1;


### PR DESCRIPTION
# Add periodic boundary test for Halo Exchange

### Task List
- [x] Linked an issue above that captures the requirements of this PR
- [ ] Defined the tests that specify a complete and functioning change
- [ ] Implemented the source code change that satisfies the tests
- [ ] Commented all code so that it can be understood without additional context
- [ ] No new warnings are generated or they are mentioned below
- [ ] The documentation has been updated (or an issue has been created to do so)
- [x] Relevant labels (e.g., enhancement, bug) have been applied to this PR
- [x] This change conforms to the conventions described in the README

---
# Change Description

- Adds a test for halo exchange with periodic boundaries

---
# Test Description

### `HaloExchangePB_test.cpp`

`HaloExchangePB_test.cpp` is based on `HaloExchangeCB_test.cpp`. It creates test data for all the array types:
- `HField`
- `VertexField`
- `DGField`
- `DGVector`
- `CGVector`

They  are created in such a way that the value of each cell can be calculated based on its indices. Therefore we can check after exchange that all of the cells have been exchanged successfully.

This would be a good PR for @niravshah241 to take over.