### PR TITLE
Fix typo in CMakeLists to set Python_EXECUTABLE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ target_link_libraries(nextsimlib PUBLIC Eigen3::Eigen)
 
 if(DEFINED PYTHON_EXECUTABLE)
     set(Python_EXECUTABLE
-        PYTHON_EXECUTABLE
+        ${PYTHON_EXECUTABLE}
         CACHE STRING "")
 else()
     set(Python_FIND_VIRTUALENV FIRST)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.15)
 
 # set globally because we have a number of independent targets
 set(CMAKE_CXX_STANDARD 17)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.16)
 
 # set globally because we have a number of independent targets
 set(CMAKE_CXX_STANDARD 17)
@@ -63,14 +63,8 @@ if(NOT TARGET Eigen3::Eigen)
 endif()
 target_link_libraries(nextsimlib PUBLIC Eigen3::Eigen)
 
-if(DEFINED PYTHON_EXECUTABLE)
-    set(Python_EXECUTABLE
-        ${PYTHON_EXECUTABLE}
-        CACHE STRING "")
-else()
-    set(Python_FIND_VIRTUALENV FIRST)
-    find_package(Python COMPONENTS Interpreter)
-endif()
+set(Python_FIND_VIRTUALENV FIRST)
+find_package(Python COMPONENTS Interpreter REQUIRED)
 
 # The location of the module_builder.py scripts
 set(ScriptDirectory "${PROJECT_SOURCE_DIR}/scripts")

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -112,7 +112,8 @@ if(ENABLE_MPI)
         add_custom_command(
             OUTPUT iodef.xml
             COMMAND
-                python3 ${CMAKE_CURRENT_SOURCE_DIR}/../src/generate_iodef.py ${DGComp}
+                "${Python_EXECUTABLE}"
+                ${CMAKE_CURRENT_SOURCE_DIR}/../src/generate_iodef.py ${DGComp}
                 ${DGStressComp} ${CMAKE_CURRENT_SOURCE_DIR}/../src/iodef.xml.jinja
                 ${CMAKE_CURRENT_BINARY_DIR}/iodef.xml
             DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../src/iodef.xml.jinja)

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -125,6 +125,13 @@ required Python packages with
 
         pip install -r requirements.txt
 
+.. note::
+
+   The build system locates the Python interpreter using CMake's ``FindPython``
+   module, preferring the interpreter of any active ``conda`` or ``virtualenv``
+   environment. If you need to point the build at a specific Python interpreter,
+   pass ``-DPython_EXECUTABLE=/path/to/python`` when configuring CMake.
+
 Building domain_decomp
 ----------------------
 NextSIM-DG uses the ``domain_decomp`` library for generating domain


### PR DESCRIPTION
# Fix typo in CMakeLists to set Python_EXECUTABLE

Fixes No #1090 

### Task List
- [x] Linked an issue above that captures the requirements of this PR
- [-] Defined the tests that specify a complete and functioning change
- [x] Implemented the source code change that satisfies the tests
- [-] Commented all code so that it can be understood without additional context
- [-] No new warnings are generated or they are mentioned below
- [-] The documentation has been updated (or an issue has been created to do so)
- [x] Relevant labels (e.g., enhancement, bug) have been applied to this PR
- [x] This change conforms to the conventions described in the README

---
# Change Description

Currently the CMakeLists doesn't correctly parse the command-line option for specifying PYTHON_EXECUTABLE as described in #1090.

An indication of this was the CMake warning generated by the current code:
```
CMake Warning:
  Manually-specified variables were not used by the project:

    PYTHON_EXECUTABLE
```

This is because it was not being parsed as a variable when setting the internal `Python_EXECUTABLE`.

As a result two NetCDF files did not get generated in `core/test/`

---
# Test Description

Previously `testParaGrid_MPI2` failed due to not locating those files.
It now passes.

---
# Documentation Impact

None

---
# Other Details

None
