### PR TITLE
Specify building in Release with CMake in docs

### DIFF
--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -64,9 +64,8 @@ jobs:
     - name: build and compile without XIOS or MPI
       run: |
         . /opt/spack-environment/activate.sh
-        mkdir -p build && cd build
-        cmake -DCMAKE_BUILD_TYPE=Release ..
-        make -j 4
+        cmake -B build -S . -DCMAKE_BUILD_TYPE=Release
+        cmake --build build -j 4
 
     - name: installs for python tests
       run: |
@@ -110,8 +109,8 @@ jobs:
         git submodule init
         git submodule update
         cd domain_decomp
-        cmake -G "Unix Makefiles" -Bbuild -S.
-        cmake --build build --config Release
+        cmake -G "Unix Makefiles" -B build -S . -DCMAKE_BUILD_TYPE=Release
+        cmake --build build
 
     - name: build and compile with MPI but not XIOS
       run: |
@@ -122,9 +121,8 @@ jobs:
         . /opt/spack-environment/activate.sh
         # provide path to domain_decomp binary
         export PATH="${PATH}:${PWD}/domain_decomp/build"
-        mkdir -p build && cd build
-        cmake -DENABLE_MPI=ON -DENABLE_XIOS=OFF -DCMAKE_CXX_COMPILER="$(which mpic++)" ..
-        make -j 4
+        cmake -B build -S . -DENABLE_MPI=ON -DENABLE_XIOS=OFF -DCMAKE_CXX_COMPILER="$(which mpic++)" -DCMAKE_BUILD_TYPE=Release
+        cmake --build build -j 4
 
     - name: run MPI tests
       run: |
@@ -165,8 +163,8 @@ jobs:
         git submodule init
         git submodule update
         cd domain_decomp
-        cmake -G "Unix Makefiles" -Bbuild -S.
-        cmake --build build --config Release
+        cmake -G "Unix Makefiles" -B build -S . -DCMAKE_BUILD_TYPE=Release
+        cmake --build build
 
     - name: build and compile with XIOS and MPI
       run: |
@@ -178,9 +176,8 @@ jobs:
         . $HOME/nextsim/bin/activate
         # provide path to domain_decomp binary
         export PATH="${PATH}:${PWD}/domain_decomp/build"
-        mkdir -p build && cd build
-        cmake -DENABLE_MPI=ON -Dxios_DIR="/xios" -DENABLE_XIOS=ON -DCMAKE_CXX_COMPILER="$(which mpic++)" ..
-        make -j 4
+        cmake -B build -S . -DENABLE_MPI=ON -Dxios_DIR="/xios" -DENABLE_XIOS=ON -DCMAKE_CXX_COMPILER="$(which mpic++)" -DCMAKE_BUILD_TYPE=Release
+        cmake --build build -j 4
 
     - name: run MPI tests
       run: |
@@ -234,10 +231,8 @@ jobs:
       run: |
         export CMAKE_PREFIX_PATH=/opt/homebrew/Cellar/eigen@3/3.4.1/share/eigen3/cmake
         . $HOME/nextsim/bin/activate
-        mkdir -p build
-        cd build
-        cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_MPI=OFF -DENABLE_XIOS=OFF ..
-        make -j 4
+        cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DENABLE_MPI=OFF -DENABLE_XIOS=OFF
+        cmake --build build -j 4
 
     - name: run serial tests
       run: |

--- a/Dockerfiles/Dockerfile.devenv
+++ b/Dockerfiles/Dockerfile.devenv
@@ -32,8 +32,8 @@ RUN git clone --branch xios-3.0.6.0 https://gitlab.in2p3.fr/ipsl/projets/xios-pr
 RUN spack env activate /opt/spack-environment \
     && git clone https://github.com/nextsimhub/domain_decomp.git /decomp \
     && cd /decomp \
-    && cmake -G "Unix Makefiles" -Bbuild -S. \
-    && cmake --build build --config Release \
+    && cmake -G "Unix Makefiles" -B build -S . -DCMAKE_BUILD_TYPE=Release \
+    && cmake --build build \
     && cd - \
     && bash install-xios.sh
 

--- a/Dockerfiles/Dockerfile.production
+++ b/Dockerfiles/Dockerfile.production
@@ -2,13 +2,13 @@ FROM ghcr.io/nextsimhub/nextsimdg-dev-env:latest
 
 RUN git clone https://github.com/nextsimhub/nextsimdg.git /nextsimdg
 
-WORKDIR /nextsimdg/build
+WORKDIR /nextsimdg
 
 ARG mpi=OFF
 ARG xios=OFF
 ARG jobs=1
 
-RUN . /opt/spack-environment/activate.sh && cmake -DENABLE_MPI=$mpi -DENABLE_XIOS=$xios -Dxios_DIR=/xios .. && make -j $jobs
+RUN . /opt/spack-environment/activate.sh && cmake -B build -S . -DENABLE_MPI=$mpi -DENABLE_XIOS=$xios -Dxios_DIR=/xios -DCMAKE_BUILD_TYPE=Release && cmake --build build -j $jobs
 
 WORKDIR /nextsimdg/run
 RUN ln -sf /nextsimdg/build/nextsim

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -199,13 +199,13 @@ The cmake call has to enable MPI support:
 
 .. code::
 
-        cmake .. -DENABLE_MPI=ON
+        cmake .. -DENABLE_MPI=ON -DCMAKE_BUILD_TYPE=Release
 
 You might need to tell cmake which compiler to use, e.g.
 
 .. code::
 
-        cmake .. -DCMAKE_CXX_COMPILER=/usr/bin/mpicxx -DENABLE_MPI=ON
+        cmake .. -DCMAKE_CXX_COMPILER=/usr/bin/mpicxx -DENABLE_MPI=ON -DCMAKE_BUILD_TYPE=Release
 
 Dependencies and Build for GPU
 ----------------------------------------------
@@ -220,7 +220,7 @@ To build with GPU support, it is necessary to enable both the feature itself and
 
 .. code::
 
-        cmake .. -DWITH_KOKKOS=ON -DKokkos_ENABLE_CUDA=ON -DWITH_THREADS=ON
+        cmake .. -DWITH_KOKKOS=ON -DKokkos_ENABLE_CUDA=ON -DWITH_THREADS=ON -DCMAKE_BUILD_TYPE=Release
  
 While it is currently not possible to use Kokkos and MPI together, OpenMP (``WITH_THREADS``) can be enabled to run modules that have not been ported to the device in parallel on the CPU. The OpenMP backend of Kokkos can be enabled as well, however it will only be used if no device backend is enabled. Same as the device backends, it should be used in concert with the basic OpenMP parallelisation and may have different performance characteristics then ``WITH_THREADS=ON`` alone.
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -156,8 +156,16 @@ After all dependencies have been installed, we can build the code:
         cd nextsimdg
         mkdir -p build
         cd build
-        cmake ..
+        cmake .. -DCMAKE_BUILD_TYPE=Release
         make
+
+.. note::
+
+   The build type is set at configure time with ``CMAKE_BUILD_TYPE``
+   (`CMake docs <https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html>`_).
+   ``Release`` enables compiler optimizations and is recommended for running
+   simulations. Use ``Debug`` instead (``-DCMAKE_BUILD_TYPE=Debug``) when
+   developing, e.g. for a build with debug symbols and no optimizations.
 
 Configuring the dynamics
 ------------------------

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -138,8 +138,10 @@ the submodule before building it. You can do this with the following commands:
         git submodule init
         git submodule update
         cd domain_decomp
-        cmake -Bbuild -S.
-        cmake --build build --config Release
+        mkdir -p build
+        cd build
+        cmake .. -DCMAKE_BUILD_TYPE=Release
+        make
 
 The ``domain_decomp`` library is not required to build the nextSIM-DG model but
 it is required for running the tests and for generating domain decompositions

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -138,10 +138,8 @@ the submodule before building it. You can do this with the following commands:
         git submodule init
         git submodule update
         cd domain_decomp
-        mkdir -p build
-        cd build
-        cmake .. -DCMAKE_BUILD_TYPE=Release
-        make
+        cmake -B build -S . -DCMAKE_BUILD_TYPE=Release
+        cmake --build build
 
 The ``domain_decomp`` library is not required to build the nextSIM-DG model but
 it is required for running the tests and for generating domain decompositions
@@ -156,10 +154,8 @@ After all dependencies have been installed, we can build the code:
 .. code::
 
         cd nextsimdg
-        mkdir -p build
-        cd build
-        cmake .. -DCMAKE_BUILD_TYPE=Release
-        make
+        cmake -B build -S . -DCMAKE_BUILD_TYPE=Release
+        cmake --build build
 
 .. note::
 
@@ -183,7 +179,7 @@ The syntax for chosing the dynamics via CMake is the standard method of providin
 
 .. code::
 
-        cmake -DDynamicsType=DG2 ..
+        cmake -B build -S . -DDynamicsType=DG2
 
 Dependencies and Build for MPI Parallelisation
 ----------------------------------------------
@@ -201,13 +197,13 @@ The cmake call has to enable MPI support:
 
 .. code::
 
-        cmake .. -DENABLE_MPI=ON -DCMAKE_BUILD_TYPE=Release
+        cmake -B build -S . -DENABLE_MPI=ON -DCMAKE_BUILD_TYPE=Release
 
 You might need to tell cmake which compiler to use, e.g.
 
 .. code::
 
-        cmake .. -DCMAKE_CXX_COMPILER=/usr/bin/mpicxx -DENABLE_MPI=ON -DCMAKE_BUILD_TYPE=Release
+        cmake -B build -S . -DCMAKE_CXX_COMPILER=/usr/bin/mpicxx -DENABLE_MPI=ON -DCMAKE_BUILD_TYPE=Release
 
 Dependencies and Build for GPU
 ----------------------------------------------
@@ -222,7 +218,7 @@ To build with GPU support, it is necessary to enable both the feature itself and
 
 .. code::
 
-        cmake .. -DWITH_KOKKOS=ON -DKokkos_ENABLE_CUDA=ON -DWITH_THREADS=ON -DCMAKE_BUILD_TYPE=Release
+        cmake -B build -S . -DWITH_KOKKOS=ON -DKokkos_ENABLE_CUDA=ON -DWITH_THREADS=ON -DCMAKE_BUILD_TYPE=Release
  
 While it is currently not possible to use Kokkos and MPI together, OpenMP (``WITH_THREADS``) can be enabled to run modules that have not been ported to the device in parallel on the CPU. The OpenMP backend of Kokkos can be enabled as well, however it will only be used if no device backend is enabled. Same as the device backends, it should be used in concert with the basic OpenMP parallelisation and may have different performance characteristics then ``WITH_THREADS=ON`` alone.
 
@@ -232,7 +228,7 @@ With Kokkos, there is experimental support for single precision, which is contro
 
 .. code::
 
-        cmake .. -DUSE_SINGLE_PRECISION=ON
+        cmake -B build -S . -DUSE_SINGLE_PRECISION=ON
 
 When switched on all data and computations use ``float`` instead of ``double``, cutting the memory footprint in half and providing a significant speedup, especially on consumer grade GPUs. This option currently does not work with XIOS or MPI.
 
@@ -299,23 +295,23 @@ Running Tests
 
 After building the code, you can run the tests provided with the repository using `ctest`. This ensures that the installation and build process was successful.
 
-To run all tests, navigate to the `build` directory and execute:
+To run all tests, execute:
 
 .. code-block:: console
 
-    ctest
+    ctest --test-dir build
 
 If you want to see more detailed output for each test, use the `-V` option:
 
 .. code-block:: console
 
-    ctest -V
+    ctest --test-dir build -V
 
 If you want to run a subset of tests, you can use the `-R` option with a regular expression to match the test names. For example, to run only the tests related to `XIOS`, use:
 
 .. code-block:: console
 
-    ctest -R Xios
+    ctest --test-dir build -R Xios
 
 For more information on `ctest` options, you can refer to the official `ctest` documentation.
 


### PR DESCRIPTION
# Specify building in Release with CMake in docs

Fixes #1094 

### Task List
- [x] Linked an issue above that captures the requirements of this PR
- [-] Defined the tests that specify a complete and functioning change
- [-] Implemented the source code change that satisfies the tests
- [-] Commented all code so that it can be understood without additional context
- [-] No new warnings are generated or they are mentioned below
- [x] The documentation has been updated (or an issue has been created to do so)
- [x] Relevant labels (e.g., enhancement, bug) have been applied to this PR
- [x] This change conforms to the conventions described in the README

---
# Change Description

As discussed in #1094 installation docs do not specify adding a CMake Build Type flag for Release.
This can lead to new users naively building in debug which is orders of magnitude slower.
This PR adds the flag explicitly.

In addition I note that decomp is documented with CMake modern, whilst neXtSIM is CMake classic.
I took the opportunity to standardise these in 54284b5456ea13cbd6544abe2dc7ba613c9dbdf0
If we would prefer to standardise all to Modern I can do that here.

Further I believe there is a small issue with decomp in that Release was not specified [at configure time](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html) via `CMake_BUILD_TYPE`.
It was [applied at build time via `--config`](https://cmake.org/cmake/help/latest/manual/cmake.1.html#build-a-project) but I believe this is only for [multi-config](https://cmake.org/cmake/help/latest/manual/cmake-buildsystem.7.html#build-configurations) generators like VSCode andf Ninja, so would not have been applied for Makefiles.
I am assuming users of this code are using a Makefile approach, but this should be confirmed by more experienced developers.

---
# Test Description

No code changes, therefore no tests changes.

---
# Documentation Impact

Installation docs are the target of the updates described above.

---
# Other Details

None