### PR TITLE
Fix MPI tests for intel MPI

### DIFF
--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -30,8 +30,13 @@ if(ENABLE_MPI)
                 # In the MPI tests it's important to include the "-ns" flag which tells doctest to
                 # fail if test has been skipped. Without this, the test will technically pass if we
                 # run with fewer ranks than requested.
+                #
+                # With Intel-MPI the `mpirun` wrapper expects a path to the executable.
+                # It will not pick it up from the current working directory
+                # Hence we need to prepend the `test_exec` with `./`
+                #
                 add_test(NAME ${test_exec} COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG}
-                                                   ${num_ranks} ${test_exec} -ns)
+                                                   ${num_ranks} ./${test_exec} -ns)
             else()
                 message(WARNING "Could not extract MPI rank from test name: ${test_exec}")
             endif()

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -31,7 +31,7 @@ if(ENABLE_MPI)
                 # fail if test has been skipped. Without this, the test will technically pass if we
                 # run with fewer ranks than requested.
                 add_test(NAME ${test_exec} COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG}
-                                                   ${num_ranks} ${test_exec} -ns)
+                                                   ${num_ranks} ./${test_exec} -ns)
             else()
                 message(WARNING "Could not extract MPI rank from test name: ${test_exec}")
             endif()


### PR DESCRIPTION
# Fix MPI tests for intel MPI

Fixes #1097 

---
# Change Description

Simple change to specify path to binaries for intel MPI (will also work for openMPI)

---
# Other Details

This fixes the issue, and now the tests run correctly.

<details><summary>Test output</summary>

```
$ ctest
Test project /home/tdm39/nextsimdg/build-mpi
    Start 1: testHaloExchangeCB_MPI3
1/6 Test #1: testHaloExchangeCB_MPI3 ..........***Failed    4.10 sec
    Start 2: testParaGrid_MPI2
2/6 Test #2: testParaGrid_MPI2 ................   Passed    2.94 sec
    Start 3: testRectGrid_MPI3
3/6 Test #3: testRectGrid_MPI3 ................   Passed    1.97 sec
    Start 4: testModelMetadataCB_MPI3
4/6 Test #4: testModelMetadataCB_MPI3 .........   Passed    1.66 sec
    Start 5: testModelMetadataPB_MPI3
5/6 Test #5: testModelMetadataPB_MPI3 .........   Passed    2.68 sec
    Start 6: testConfigOutput_MPI2
6/6 Test #6: testConfigOutput_MPI2 ............   Passed   14.18 sec

83% tests passed, 1 tests failed out of 6

Total Test time (real) =  27.58 sec

The following tests FAILED:
          1 - testHaloExchangeCB_MPI3 (Failed)
Errors while running CTest
Output from these tests are in: /home/tdm39/nextsimdg/build-mpi/Testing/Temporary/LastTest.log
Use "--rerun-failed --output-on-failure" to re-run the failed cases verbosely.
```

</details> 



Interestingly, the `testHaloExchangeCB_MPI3` "fails". The test actually runs, but the MPI clean up fails:

<details><summary>testHaloExchangeCB_MPI3 output</summary>

```
$ ctest --rerun-failed --output-on-failure
Test project /home/tdm39/nextsimdg/build-mpi
    Start 1: testHaloExchangeCB_MPI3
1/1 Test #1: testHaloExchangeCB_MPI3 ..........***Failed    0.99 sec
MPI startup(): Warning: I_MPI_PMI_LIBRARY will be ignored since the hydra process manager was found
MPI startup(): Warning: I_MPI_PMI_LIBRARY will be ignored since the hydra process manager was found
MPI startup(): Warning: I_MPI_PMI_LIBRARY will be ignored since the hydra process manager was found
[doctest] doctest version is "2.4.11"
[doctest] run with "--help" for options
===============================================================================
[doctest] test cases:   5 |   5 passed | 0 failed | 0 skipped
[doctest] assertions: 927 | 927 passed | 0 failed |
[doctest] Status: SUCCESS!
===============================================================================
[doctest] assertions on all processes:   2949 |   2949 passed |      0 failed |
===============================================================================
[doctest] Status: SUCCESS!
malloc_consolidate(): invalid chunk size
malloc_consolidate(): unaligned fastbin chunk detected

===================================================================================
=   BAD TERMINATION OF ONE OF YOUR APPLICATION PROCESSES
=   RANK 1 PID 2924112 RUNNING AT cpu-q-565
=   KILLED BY SIGNAL: 6 (Aborted)
===================================================================================

===================================================================================
=   BAD TERMINATION OF ONE OF YOUR APPLICATION PROCESSES
=   RANK 2 PID 2924113 RUNNING AT cpu-q-565
=   KILLED BY SIGNAL: 6 (Aborted)
===================================================================================


0% tests passed, 1 tests failed out of 1

Total Test time (real) =   1.02 sec

The following tests FAILED:
          1 - testHaloExchangeCB_MPI3 (Failed)
Errors while running CTest
```

</details> 

I haven't had chance to look into this error. I think it should be handled as a separate PR. This PR does fix the intended problem described in the issue.

I have created a new issue #1100 to track the failing test.
