### PR TITLE
Bilinear interpolation for ParaGrid

### DIFF
--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -6,7 +6,8 @@ if(ENABLE_XIOS)
     set(NextsimIncludeDirs "${NextsimIncludeDirs}" "${XIOS_INCLUDE_LIST}")
     set(ParaGridIOImplSource "${CMAKE_CURRENT_SOURCE_DIR}/ParaGridIO_Xios.cpp")
 else()
-    set(ParaGridIOImplSource "${CMAKE_CURRENT_SOURCE_DIR}/ParaGridIO.cpp")
+    set(ParaGridIOImplSource "${CMAKE_CURRENT_SOURCE_DIR}/ParaGridIO.cpp"
+                             "${CMAKE_CURRENT_SOURCE_DIR}/ParaGridInputs.cpp")
 endif()
 
 # Create a stable generated include dir and copy the chosen ModelArrayDetails.hpp

--- a/core/src/ParaGridInputs.cpp
+++ b/core/src/ParaGridInputs.cpp
@@ -15,7 +15,7 @@
 
 namespace Nextsim {
 
-void ParaGridInputs::setData(const TimePoint& time, const std::string& filePathIn,
+void ParaGridInputs::setData(const TimePoint& time, const std::string& pathSpecIn,
     const std::string& ncLonNameIn, const std::string& ncLatNameIn, const std::string& ncTimeNameIn,
     const std::set<std::string>& forcingsIn,
     const std::set<std::pair<std::string, std::string>>& vectorsIn, const ModelArray& modelLonsIn,
@@ -23,7 +23,7 @@ void ParaGridInputs::setData(const TimePoint& time, const std::string& filePathI
 {
     currentTime = time;
 
-    filePath = filePathIn;
+    pathSpec = pathSpecIn;
     forcings = forcingsIn;
     vectors = vectorsIn;
 
@@ -43,7 +43,10 @@ void ParaGridInputs::update(const TimePoint& time)
 {
     currentTime = time;
 
-    if (time < timeRange.before || time > timeRange.after) {
+    /* Only actually do something if we find ourselves outside the previous time range. We only
+     * check timeRange.after, because time moves forward.
+     */
+    if (time > timeRange.after) {
         RawDataMap rawDataBefore, rawDataAfter;
         readRawForcing(rawDataBefore, rawDataAfter);
 
@@ -60,6 +63,7 @@ ModelArray ParaGridInputs::getField(const std::string& fieldName)
     ModelArray ma;
     ma.reinitialize();
 
+    // Just a linear interpolation between forcing data time steps.
     const FloatType frac = (currentTime - timeRange.before).seconds()
         / (timeRange.after - timeRange.before).seconds();
 
@@ -83,9 +87,11 @@ void ParaGridInputs::setWeights()
     ij10.resize(xi.size());
     ij11.resize(xi.size());
 
+    // Useful aliases
     const auto& lonDimSize = forcingLonLats.dims.at(ncLonName).size();
     const auto& latDimSize = forcingLonLats.dims.at(ncLatName).size();
 
+    // Different methods for Mercator maps and curvilinear grids
     if (lonDimSize == 1 && latDimSize == 1) {
         // Lat and lon are 1D
         setWeights1D();
@@ -105,17 +111,10 @@ void ParaGridInputs::setWeights1D()
     const auto& choiceVar = readRawData(currentTime, { *forcings.begin() });
     const auto& gridDims = choiceVar.dims.at(*forcings.begin());
 
+    // The axis may be flipped. Probably only the latitude one ... but you never know
     auto forcingLons = forcingLonLats.data[ncLonName];
     auto forcingLats = forcingLonLats.data[ncLatName];
 
-    // Careful to wrap the longitudes of the model the same as that of the data
-    FloatType lon0;
-    if (*std::min_element(forcingLons.begin(), forcingLons.end()) < 0.)
-        lon0 = 180.;
-    else
-        lon0 = 360.;
-
-    // The axis may be flipped. Probably only the latitude one ... but you never know
     bool flippedLons = false;
     bool flippedLats = false;
     if (*forcingLons.begin() > *forcingLons.end()) {
@@ -126,6 +125,13 @@ void ParaGridInputs::setWeights1D()
         flippedLats = true;
         std::reverse(forcingLats.begin(), forcingLats.end());
     }
+
+    // Careful to wrap the longitudes of the model the same as that of the data
+    FloatType lon0;
+    if (*std::min_element(forcingLons.begin(), forcingLons.end()) < 0.)
+        lon0 = 180.;
+    else
+        lon0 = 360.;
 
 #pragma omp parallel for
     for (size_t i = 0; i < modelLons.size(); ++i) {
@@ -182,6 +188,10 @@ void ParaGridInputs::setWeights1D()
 
 void ParaGridInputs::setWeights2D()
 {
+    /* Just call recursiveBisectSearch for every model grid point. Start off with the full grid. The
+     * recursive routine returns false if it didn't find anything at the given level. So a false
+     * here means the model point is not in the forcing data set grid.
+     */
 #pragma omp parallel for
     for (size_t k = 0; k < modelLons.size(); ++k) {
         // Careful with the C-style indexing!
@@ -235,8 +245,8 @@ bool ParaGridInputs::recursiveBisectSearch(const size_t k, const FloatType targe
     }
 
     // Bisect and call self to continue searching
-    const size_t iHalf = i + (ii - i) / 2;
-    const size_t jHalf = j + (jj - j) / 2;
+    const size_t iHalf = (i + ii) / 2;
+    const size_t jHalf = (j + jj) / 2;
 
     // Search quadrant 00
     if (recursiveBisectSearch(k, targetLon, targetLat, i, iHalf, j, jHalf))
@@ -261,6 +271,9 @@ bool ParaGridInputs::recursiveBisectSearch(const size_t k, const FloatType targe
 void ParaGridInputs::orthographicProjection(const FloatType lon, const FloatType lat,
     const FloatType lon0, const FloatType lat0, FloatType& x, FloatType& y) const
 {
+    /* Most of these are used twice, but not all. But anyway, it's easier to read like this, and the
+     * compiler should optimise the excessive assignments out, right?
+     */
     const FloatType cosPhi = std::cos(lat * PhysicalConstants::deg2rad);
     const FloatType cosPhi0 = std::cos(lat0 * PhysicalConstants::deg2rad);
     const FloatType sinPhi = std::sin(lat * PhysicalConstants::deg2rad);
@@ -268,6 +281,7 @@ void ParaGridInputs::orthographicProjection(const FloatType lon, const FloatType
     const FloatType cosDeltaLambda = std::cos((lon - lon0) * PhysicalConstants::deg2rad);
     const FloatType sinDeltaLambda = std::sin((lon - lon0) * PhysicalConstants::deg2rad);
 
+    // Projected coordinates
     x = cosPhi * sinDeltaLambda;
     y = cosPhi0 * sinPhi - sinPhi0 * cosPhi * cosDeltaLambda;
 
@@ -282,11 +296,11 @@ void ParaGridInputs::orthographicProjection(const FloatType lon, const FloatType
 bool ParaGridInputs::pointInBoundingBox(
     const std::vector<FloatType>& xCorners, const std::vector<FloatType>& yCorners)
 {
-    const double xMin = *std::min_element(xCorners.begin(), xCorners.end());
-    const double xMax = *std::max_element(xCorners.begin(), xCorners.end());
+    const FloatType xMin = *std::min_element(xCorners.begin(), xCorners.end());
+    const FloatType xMax = *std::max_element(xCorners.begin(), xCorners.end());
 
-    const double yMin = *std::min_element(yCorners.begin(), yCorners.end());
-    const double yMax = *std::max_element(yCorners.begin(), yCorners.end());
+    const FloatType yMin = *std::min_element(yCorners.begin(), yCorners.end());
+    const FloatType yMax = *std::max_element(yCorners.begin(), yCorners.end());
 
     // The target point is at the origin
     return 0. >= xMin && 0. <= xMax && 0. >= yMin && 0. <= yMax;
@@ -323,8 +337,9 @@ bool ParaGridInputs::findLocalCoordinates(const size_t k, const FloatType x00, c
     /* Newton iteration:
      *     F(xi, eta) = mapping(xi, eta) - query_point
      */
-    constexpr FloatType tolerance = 100 * std::numeric_limits<FloatType>::epsilon();
     for (int iteration = 0; iteration < 20; ++iteration) {
+        // What is the right tolerance for both single and double? I guess this is fine.
+        constexpr FloatType tolerance = 10 * std::numeric_limits<FloatType>::epsilon();
 
         // Bilinear mapping from local coordinates to physical coordinates.
         const FloatType N00 = (1.0 - xi[k]) * (1.0 - eta[k]);
@@ -363,7 +378,6 @@ bool ParaGridInputs::findLocalCoordinates(const size_t k, const FloatType x00, c
         eta[k] += (dy_dxi * xp - dx_dxi * yp) / determinant;
 
         // If the solution is far outside the cell, then this is probably not the correct cell.
-        //
         if (xi[k] < -0.1 || xi[k] > 1.1 || eta[k] < -0.1 || eta[k] > 1.1)
             return false;
     }
@@ -423,16 +437,19 @@ void ParaGridInputs::vectorRotationLogic(const std::vector<FloatType>& vectorIn1
 
 void ParaGridInputs::readRawForcing(RawDataMap& rawDataBefore, RawDataMap& rawDataAfter)
 {
-    const std::string fileNameBefore = formatFileName(filePath, currentTime, *forcings.begin());
+    /* First we find the correct time, time slice, and files. For multi-file datasets we just pick
+     * any (first) file/variable.
+     */
+    const std::string fileName = formatFileName(currentTime, *forcings.begin());
     size_t targetTIndexAfter, targetTIndexBefore;
     try {
-        netCDF::NcFile ncFile(fileNameBefore, netCDF::NcFile::read);
+        netCDF::NcFile ncFile(fileName, netCDF::NcFile::read);
 
         // Read the time axis
         netCDF::NcDim timeDim = ncFile.getDim(ncTimeName);
         // Read the time variable
         netCDF::NcVar timeVar = ncFile.getVar(ncTimeName);
-        // Get the time axis as a vector
+        // Get the time axis as a vector. We use double here, because Duration expects double.
         std::vector<double> timeVec(timeDim.getSize());
         timeVar.getVar(timeVec.data());
 
@@ -464,6 +481,7 @@ void ParaGridInputs::readRawForcing(RawDataMap& rawDataBefore, RawDataMap& rawDa
 
         // Because currentTime can't be captured in the lambda function
         const TimePoint& time = currentTime;
+
         // Get the index of the first TimePoint greater than the target.
         targetTIndexAfter = std::find_if(timeVec.begin(), timeVec.end(),
                                 [time, timePointOrigin](const double t) {
@@ -476,13 +494,16 @@ void ParaGridInputs::readRawForcing(RawDataMap& rawDataBefore, RawDataMap& rawDa
         timeRange.after = TimePoint(timePointOrigin, Duration(timeVec[targetTIndexAfter]));
 
         /* We need to check if targetTIndexAfter is actually pointing at the right time, or if we
-         * need to go on to the next file */
-        if (TimePoint(timePointOrigin, Duration(timeVec[targetTIndexAfter])) < currentTime) {
-            timeRange.before = TimePoint(timePointOrigin, Duration(timeVec[targetTIndexBefore]));
+         * need to go on to the next file. Lucky for us, std::find_if returns timeVec.end() if it
+         * finds nothing, so targetTIndexBefore is always right.
+         */
+        if (targetTIndexAfter == timeVec.size()) {
+            // Assume time is increasing at a constant rate(!)
             timeRange.after = timeRange.before + Duration(timeVec[1] - timeVec[0]);
             targetTIndexAfter = 0;
         }
 
+        // Sanity check. Not really needed.
         if (targetTIndexAfter < 0 || targetTIndexBefore < 0 || targetTIndexAfter >= timeVec.size()
             || targetTIndexBefore >= timeVec.size())
             throw std::out_of_range(
@@ -492,10 +513,11 @@ void ParaGridInputs::readRawForcing(RawDataMap& rawDataBefore, RawDataMap& rawDa
         ncFile.close();
     } catch (const netCDF::exceptions::NcException& nce) {
         std::string ncWhat(nce.what());
-        ncWhat += ": " + fileNameBefore;
+        ncWhat += ": " + fileName;
         throw std::runtime_error(ncWhat);
     }
 
+    // Read the data
     rawDataBefore = readRawData(timeRange.before, forcings, targetTIndexBefore);
     rawDataAfter = readRawData(timeRange.after, forcings, targetTIndexAfter);
 }
@@ -504,15 +526,17 @@ ParaGridInputs::RawDataMap ParaGridInputs::readRawData(
     const TimePoint& time, const std::set<std::string>& fields, const size_t timeIndex) const
 {
     RawDataMap data;
+    std::string fileName;
+
+    // Loop over the variable names at the top, because we may have one variable per file.
     for (const std::string& varName : fields) {
         try {
 
             // We may need to be more careful selecting the right file if we're reading lat/lon info
-            std::string fileName;
             if (varName == ncLonName || varName == ncLatName)
-                fileName = formatFileName(filePath, time, *forcings.begin());
+                fileName = formatFileName(time, *forcings.begin());
             else
-                fileName = formatFileName(filePath, time, varName);
+                fileName = formatFileName(time, varName);
 
             netCDF::NcFile ncFile(fileName, netCDF::NcFile::read);
 
@@ -541,13 +565,14 @@ ParaGridInputs::RawDataMap ParaGridInputs::readRawData(
             // Needs to be reversed because of netCDF shenanigans
             std::reverse(data.dims[varName].begin(), data.dims[varName].end());
 
+            // Resize and read!
             data.data[varName] = std::vector<FloatType>(std::accumulate(
                 count.begin(), count.end(), static_cast<size_t>(1), std::multiplies<>()));
-            readNetCDFVar(var, start, count, data.data[varName].data());
+            var.getVar(start, count, data.data[varName].data());
 
         } catch (const netCDF::exceptions::NcException& nce) {
             std::string ncWhat(nce.what());
-            ncWhat += ": " + formatFileName(filePath, time, varName);
+            ncWhat += ": " + fileName;
             throw std::runtime_error(ncWhat);
         }
     }

--- a/core/src/ParaGridInputs.cpp
+++ b/core/src/ParaGridInputs.cpp
@@ -34,7 +34,7 @@ void ParaGridInputs::setData(const TimePoint& time, const std::string& filePathI
     modelLons = modelLonsIn;
     modelLats = modelLatsIn;
 
-    forcingLonLats = readRawData(currentTime.format(filePath), { ncLatName, ncLonName });
+    forcingLonLats = readRawData(currentTime, { ncLatName, ncLonName });
 
     setWeights();
 }
@@ -379,8 +379,7 @@ void ParaGridInputs::vectorRotationLogic(const std::vector<FloatType>& vectorIn1
 
 void ParaGridInputs::readRawForcing(RawDataMap& rawDataBefore, RawDataMap& rawDataAfter)
 {
-    const std::string fileNameBefore = currentTime.format(filePath);
-    std::string fileNameAfter = fileNameBefore;
+    const std::string fileNameBefore = formatFileName(filePath, currentTime, *forcings.begin());
     size_t targetTIndexAfter, targetTIndexBefore;
     try {
         netCDF::NcFile ncFile(fileNameBefore, netCDF::NcFile::read);
@@ -438,7 +437,6 @@ void ParaGridInputs::readRawForcing(RawDataMap& rawDataBefore, RawDataMap& rawDa
             timeRange.before = TimePoint(timePointOrigin, Duration(timeVec[targetTIndexBefore]));
             timeRange.after = timeRange.before + Duration(timeVec[1] - timeVec[0]);
             targetTIndexAfter = 0;
-            fileNameAfter = timeRange.after.format(filePath);
         }
 
         if (targetTIndexAfter < 0 || targetTIndexBefore < 0 || targetTIndexAfter >= timeVec.size()
@@ -454,23 +452,22 @@ void ParaGridInputs::readRawForcing(RawDataMap& rawDataBefore, RawDataMap& rawDa
         throw std::runtime_error(ncWhat);
     }
 
-    rawDataBefore = readRawData(fileNameBefore, forcings, targetTIndexBefore);
-    rawDataAfter = readRawData(fileNameAfter, forcings, targetTIndexAfter);
+    rawDataBefore = readRawData(timeRange.before, forcings, targetTIndexBefore);
+    rawDataAfter = readRawData(timeRange.after, forcings, targetTIndexAfter);
 }
 
 ParaGridInputs::RawDataMap ParaGridInputs::readRawData(
-    const std::string& fileName, const std::set<std::string>& fields, const size_t timeIndex) const
+    const TimePoint& time, const std::set<std::string>& fields, const size_t timeIndex) const
 {
     RawDataMap data;
-    try {
-        netCDF::NcFile ncFile(fileName, netCDF::NcFile::read);
+    for (const std::string& varName : fields) {
+        try {
+            netCDF::NcFile ncFile(formatFileName(filePath, time, varName), netCDF::NcFile::read);
 
-        auto availableForcings = ncFile.getVars();
-        for (const std::string& varName : fields) {
             // Don't try to read non-existent data
-            if (!availableForcings.count(varName)) {
+            if (ncFile.getVars().count(varName) == 0)
                 continue;
-            }
+
             netCDF::NcVar var = ncFile.getVar(varName);
 
             std::vector<netCDF::NcDim> dims = var.getDims();
@@ -495,12 +492,11 @@ ParaGridInputs::RawDataMap ParaGridInputs::readRawData(
                 data.dims = count;
                 std::reverse(data.dims.begin(), data.dims.end());
             }
+        } catch (const netCDF::exceptions::NcException& nce) {
+            std::string ncWhat(nce.what());
+            ncWhat += ": " + formatFileName(filePath, time, varName);
+            throw std::runtime_error(ncWhat);
         }
-        ncFile.close();
-    } catch (const netCDF::exceptions::NcException& nce) {
-        std::string ncWhat(nce.what());
-        ncWhat += ": " + fileName;
-        throw std::runtime_error(ncWhat);
     }
     return data;
 }

--- a/core/src/ParaGridInputs.cpp
+++ b/core/src/ParaGridInputs.cpp
@@ -1,0 +1,222 @@
+/*!
+ * @author  Einar Olason on 21/07/2026.
+ */
+
+#include <ncDim.h>
+#include <ncFile.h>
+#include <ncVar.h>
+
+#include "include/NetCDFUtils.hpp"
+#include "include/ParaGridInputs.hpp"
+
+namespace Nextsim {
+
+void ParaGridInputs::configure(const std::string& filePathIn, const std::string& ncLonNameIn,
+    const std::string& ncLatNameIn, const std::string& ncTimeNameIn,
+    const std::set<std::string>& forcingsIn,
+    const std::set<std::pair<std::string, std::string>>& vectorsIn, const ModelArray& modelLonsIn,
+    const ModelArray& modelLatsIn)
+{
+    filePath = filePathIn;
+    forcings = forcingsIn;
+    vectors = vectorsIn;
+
+    ncTimeName = ncTimeNameIn;
+    ncLatName = ncLatNameIn;
+    ncLonName = ncLonNameIn;
+
+    modelLons = modelLonsIn;
+    modelLats = modelLatsIn;
+}
+
+void ParaGridInputs::update(const TimePoint& time)
+{
+    currentTime = time;
+
+    if (time < timeRange.before || time > timeRange.after) {
+        std::map<std::string, std::vector<FloatType>> rawDataBefore, rawDataAfter;
+        readRawForcing(rawDataBefore, rawDataAfter);
+
+        rotateInputVectors(rawDataBefore);
+        rotateInputVectors(rawDataAfter);
+
+        forcingStateBefore = interpolateSpatially(rawDataBefore);
+        forcingStateAfter = interpolateSpatially(rawDataAfter);
+    }
+}
+
+ModelArray ParaGridInputs::getField(const std::string& fieldName)
+{
+    ModelArray ma;
+    ma.reinitialize();
+
+    const double frac = (currentTime - timeRange.before).seconds()
+        / (timeRange.after - timeRange.before).seconds();
+
+    for (size_t i = 0; i < ma.size(); ++i) {
+        ma[i] = frac * forcingStateAfter.data[fieldName][i]
+            + (1. - frac) * forcingStateBefore.data[fieldName][i];
+    }
+
+    return ma;
+}
+
+ModelState ParaGridInputs::interpolateSpatially(
+    const std::map<std::string, std::vector<FloatType>>& rawData)
+{
+    ModelState state;
+    for (const auto& [name, data] : rawData) {
+        state.data[name].reinitialize();
+        for (size_t i = 0; i < data.size(); ++i) {
+            state.data[name][i] = data[i]; // TODO: Actually interpolate
+        }
+    }
+
+    return state;
+}
+
+void ParaGridInputs::rotateInputVectors(std::map<std::string, std::vector<FloatType>>& rawData)
+{
+    auto rawDataCopy = rawData;
+    for (auto& pair : vectors) {
+        vectorRotationLogic(rawDataCopy[pair.first], rawDataCopy[pair.second], rawData[pair.first],
+            rawDataCopy[pair.second]);
+    }
+}
+
+void ParaGridInputs::vectorRotationLogic(const std::vector<FloatType>& vectorIn1st,
+    const std::vector<FloatType>& vectorIn2nd, std::vector<FloatType>& vectorOut1st,
+    std::vector<FloatType>& vectorOut2nd)
+{
+    // Nothing done yet
+    vectorOut1st = vectorIn1st;
+    vectorOut2nd = vectorIn2nd;
+}
+
+void ParaGridInputs::readRawForcing(std::map<std::string, std::vector<FloatType>>& rawDataBefore,
+    std::map<std::string, std::vector<FloatType>>& rawDataAfter)
+{
+    const std::string fileNameBefore = currentTime.format(filePath);
+    std::string fileNameAfter = fileNameBefore;
+    size_t targetTIndexAfter, targetTIndexBefore;
+    try {
+        netCDF::NcFile ncFile(fileNameBefore, netCDF::NcFile::read);
+
+        // Read the time axis
+        netCDF::NcDim timeDim = ncFile.getDim(ncTimeName);
+        // Read the time variable
+        netCDF::NcVar timeVar = ncFile.getVar(ncTimeName);
+        // Get the time axis as a vector
+        std::vector<double> timeVec(timeDim.getSize());
+        timeVar.getVar(timeVec.data());
+
+        // Time units nonsense
+        std::string unitStr, timeUnit, sinceKeyWord, timeOrigin;
+        timeVar.getAtt("units").getValues(unitStr);
+        std::stringstream ss(unitStr);
+        ss >> timeUnit >> sinceKeyWord >> timeOrigin;
+
+        // Get a TimePoint for the origin
+        const auto timePointOrigin = TimePoint(timeOrigin);
+
+        // Multiply the time axis to get seconds
+        double multiplier;
+        if (timeUnit == "seconds")
+            multiplier = 1.;
+        else if (timeUnit == "minutes")
+            multiplier = 60.;
+        else if (timeUnit == "hours")
+            multiplier = 3600.;
+        else if (timeUnit == "days")
+            multiplier = 24. * 3600.;
+        else
+            throw std::runtime_error("ParaGridInputs::readRawForcing(): unsupported time unit "
+                + timeUnit + " in '" + unitStr + "'.\n");
+
+        std::transform(timeVec.begin(), timeVec.end(), timeVec.begin(),
+            [multiplier](const double t) { return t * multiplier; });
+
+        // Because currentTime can't be captured in the lambda function
+        const TimePoint& time = currentTime;
+        // Get the index of the first TimePoint greater than the target.
+        targetTIndexAfter = std::find_if(timeVec.begin(), timeVec.end(),
+                                [time, timePointOrigin](const double t) {
+                                    return TimePoint(timePointOrigin, Duration(t)) > time;
+                                })
+            - timeVec.begin();
+
+        targetTIndexBefore = targetTIndexAfter - 1;
+        timeRange.before = TimePoint(timePointOrigin, Duration(timeVec[targetTIndexBefore]));
+        timeRange.after = TimePoint(timePointOrigin, Duration(timeVec[targetTIndexAfter]));
+
+        /* We need to check if targetTIndexAfter is actually pointing at the right time, or if we
+         * need to go on to the next file */
+        if (TimePoint(timePointOrigin, Duration(timeVec[targetTIndexAfter])) < currentTime) {
+            targetTIndexBefore = targetTIndexAfter;
+            timeRange.before = TimePoint(timePointOrigin, Duration(timeVec[targetTIndexBefore]));
+            timeRange.after = TimePoint(timePointOrigin, Duration(timeVec[targetTIndexAfter]))
+                + Duration(timeVec[1] - timeVec[0]);
+            targetTIndexAfter = 0;
+            fileNameAfter = timeRange.after.format(filePath);
+        }
+
+        if (targetTIndexAfter < 0 || targetTIndexBefore < 0 || targetTIndexAfter >= timeVec.size()
+            || targetTIndexBefore >= timeVec.size())
+            throw std::out_of_range(
+                "ParaGridInputs::readRawForcing::Target time index is out of range "
+                "- how could this happen?\n");
+
+        ncFile.close();
+    } catch (const netCDF::exceptions::NcException& nce) {
+        std::string ncWhat(nce.what());
+        ncWhat += ": " + fileNameBefore;
+        throw std::runtime_error(ncWhat);
+    }
+
+    rawDataBefore = readRawData(fileNameBefore, targetTIndexBefore);
+    rawDataAfter = readRawData(fileNameAfter, targetTIndexAfter);
+}
+
+std::map<std::string, std::vector<FloatType>> ParaGridInputs::readRawData(
+    const std::string& fileName, const size_t timeIndex = 0) const
+{
+    std::map<std::string, std::vector<FloatType>> data;
+    try {
+        netCDF::NcFile ncFile(fileName, netCDF::NcFile::read);
+
+        auto availableForcings = ncFile.getVars();
+        for (const std::string& varName : forcings) {
+            // Don't try to read non-existent data
+            if (!availableForcings.count(varName)) {
+                continue;
+            }
+            netCDF::NcVar var = ncFile.getVar(varName);
+
+            std::vector<netCDF::NcDim> dims = var.getDims();
+            std::vector<size_t> start(dims.size(), 0);
+            std::vector<size_t> count(dims.size());
+            for (int i = 0; i < count.size(); ++i)
+                count[i] = dims[i].getSize();
+
+            // Pick the time slice if we have a time axis
+            for (int i = 0; i < dims.size(); ++i) {
+                if (dims[0].getName() == ncTimeName) {
+                    start[0] = timeIndex;
+                    count[0] = 1;
+                }
+            }
+
+            data[varName] = std::vector<FloatType>(
+                std::accumulate(count.begin(), count.end(), 1, std::multiplies<size_t>()));
+            readNetCDFVar(var, start, count, data[varName].data());
+        }
+        ncFile.close();
+    } catch (const netCDF::exceptions::NcException& nce) {
+        std::string ncWhat(nce.what());
+        ncWhat += ": " + filePath;
+        throw std::runtime_error(ncWhat);
+    }
+    return data;
+}
+
+}

--- a/core/src/ParaGridInputs.cpp
+++ b/core/src/ParaGridInputs.cpp
@@ -83,57 +83,100 @@ void ParaGridInputs::setWeights()
     ij10.resize(xi.size());
     ij11.resize(xi.size());
 
-    if (forcingLonLats.dims.size() == 1) {
+    const auto& lonDimSize = forcingLonLats.dims.at(ncLonName).size();
+    const auto& latDimSize = forcingLonLats.dims.at(ncLatName).size();
+
+    if (lonDimSize == 1 && latDimSize == 1) {
         // Lat and lon are 1D
         setWeights1D();
-    } else if (forcingLonLats.dims.size() == 2) {
+    } else if (lonDimSize == 2 && latDimSize == 2) {
         // Lat and lon are 2D
         setWeights2D();
     } else {
         throw std::out_of_range(
             "ParaGridInputs::setWeights: Unsupported dimensionality of forcing grid: "
-            + std::to_string(forcingLonLats.dims.size()) + ".\n");
+            + std::to_string(lonDimSize) + " & " + std::to_string(latDimSize) + ".\n");
     }
 }
 
 void ParaGridInputs::setWeights1D()
 {
+    // We need to read one of the variables to get the grid ordering
+    const auto& choiceVar = readRawData(currentTime, { *forcings.begin() });
+    const auto& gridDims = choiceVar.dims.at(*forcings.begin());
+
+    auto forcingLons = forcingLonLats.data[ncLonName];
+    auto forcingLats = forcingLonLats.data[ncLatName];
+
+    // Careful to wrap the longitudes of the model the same as that of the data
+    FloatType lon0;
+    if (*std::min_element(forcingLons.begin(), forcingLons.end()) < 0.)
+        lon0 = 180.;
+    else
+        lon0 = 360.;
+
+    // The axis may be flipped. Probably only the latitude one ... but you never know
+    bool flippedLons = false;
+    bool flippedLats = false;
+    if (*forcingLons.begin() > *forcingLons.end()) {
+        flippedLons = true;
+        std::reverse(forcingLons.begin(), forcingLons.end());
+    }
+    if (*forcingLats.begin() > *forcingLats.end()) {
+        flippedLats = true;
+        std::reverse(forcingLats.begin(), forcingLats.end());
+    }
+
 #pragma omp parallel for
     for (size_t i = 0; i < modelLons.size(); ++i) {
-        // Useful aliases
-        const auto& forcingLons = forcingLonLats.data[ncLonName];
-        const auto& forcingLats = forcingLonLats.data[ncLatName];
-        const auto& dims = forcingLonLats.dims;
-
-        // Find the bounding box
-        const size_t aLon = std::lower_bound(forcingLons.begin(), forcingLons.end(), modelLons[i])
-            - forcingLons.begin();
-        const size_t aLat = std::lower_bound(forcingLats.begin(), forcingLats.end(), modelLats[i])
-            - forcingLats.begin();
-
-        // Use modulo for periodic boundaries in longitude
-        const size_t bLon = (aLon + 1) % forcingLons.size();
-        const size_t bLat = (aLat + 1) % forcingLons.size();
-
         /* Calculate the weights on a local tangent plane, with
          * x = R \cos(\phi) \lambda
          * y = R \phi
          * but R and \cos(\phi) cancel out */
-        const FloatType x = modelLons[i];
+
+        // This is the target
+        const FloatType x = wrapLon(modelLons[i], lon0);
         const FloatType y = modelLats[i];
 
+        // Find the bounding box
+        size_t bLon
+            = std::upper_bound(forcingLons.begin(), forcingLons.end(), x) - forcingLons.begin();
+        size_t bLat
+            = std::upper_bound(forcingLats.begin(), forcingLats.end(), y) - forcingLats.begin();
+
+        size_t aLon = bLon - 1;
+        size_t aLat = bLat - 1;
+
+        /* Use modulo for periodic boundaries in longitude. Different formulations because aLon
+         * maybe negative, but bLon is always positive.
+         */
+        aLon = (aLon % forcingLons.size() + forcingLons.size()) % forcingLons.size();
+        bLon %= forcingLons.size();
+
+        // Now for the weights
         const FloatType x1 = forcingLons[aLon];
         const FloatType x2 = forcingLons[bLon];
         const FloatType y1 = forcingLats[aLat];
         const FloatType y2 = forcingLats[bLat];
 
-        xi[i] = wrapLon(x - x1) / wrapLon(x2 - x1);
+        xi[i] = wrapLon(x - x1, lon0) / wrapLon(x2 - x1, lon0);
         eta[i] = (y - y1) / (y2 - y1);
 
-        ij00[i] = indexer(dims, { aLon, aLat });
-        ij01[i] = indexer(dims, { aLon, bLat });
-        ij10[i] = indexer(dims, { bLon, aLat });
-        ij11[i] = indexer(dims, { bLon, bLat });
+        // If we flipped the axis, we need to point to the right elements in the original vector
+        if (flippedLons) {
+            aLon = (forcingLons.size() - 1) - aLon;
+            bLon = (forcingLons.size() - 1) - bLon;
+        }
+        if (flippedLats) {
+            aLat = (forcingLats.size() - 1) - aLat;
+            bLat = (forcingLats.size() - 1) - bLat;
+        }
+
+        // Record the bounds
+        ij00[i] = indexer(gridDims, { aLon, aLat });
+        ij10[i] = indexer(gridDims, { bLon, aLat });
+        ij01[i] = indexer(gridDims, { aLon, bLat });
+        ij11[i] = indexer(gridDims, { bLon, bLat });
     }
 }
 
@@ -142,8 +185,8 @@ void ParaGridInputs::setWeights2D()
 #pragma omp parallel for
     for (size_t k = 0; k < modelLons.size(); ++k) {
         // Careful with the C-style indexing!
-        if (!recursiveBisectSearch(k, modelLons[k], modelLats[k], 0, forcingLonLats.dims[0] - 1, 0,
-                forcingLonLats.dims[1] - 1))
+        if (const auto& dims = forcingLonLats.dims.at(ncLonName);
+            !recursiveBisectSearch(k, modelLons[k], modelLats[k], 0, dims[0] - 1, 0, dims[1] - 1))
             throw std::out_of_range("ParaGridInputs::setWeights2D: Couldn't find "
                 + std::to_string(modelLons[k]) + ", " + std::to_string(modelLats[k])
                 + " in the forcing grid.\n");
@@ -153,14 +196,14 @@ void ParaGridInputs::setWeights2D()
 bool ParaGridInputs::recursiveBisectSearch(const size_t k, const FloatType targetLon,
     const FloatType targetLat, const size_t i, const size_t ii, const size_t j, const size_t jj)
 {
-    // Useful aliases
-    const auto& forcingLons = forcingLonLats.data[ncLonName];
-    const auto& forcingLats = forcingLonLats.data[ncLatName];
-    const auto& dims = forcingLonLats.dims;
-
     // If one of the dimensions has collapsed, then the point is not here(!)
     if (i == ii || j == jj)
         return false;
+
+    // Useful aliases
+    const auto& forcingLons = forcingLonLats.data.at(ncLonName);
+    const auto& forcingLats = forcingLonLats.data.at(ncLatName);
+    const auto& dims = forcingLonLats.dims.at(ncLonName);
 
     /* Project the corner points onto an orthographic projection, centred on the target. We do the
      * rest of the work in {x,y} coordinates. The target {x,y} is now always at the origin.
@@ -336,12 +379,13 @@ ModelState ParaGridInputs::interpolateSpatially(const RawDataMap& rawData)
 {
     ModelState state;
     for (const auto& dataPair : rawData.data) {
+        // Structured bindings and omp don't mesh
         const std::string& name = dataPair.first;
         const std::vector<FloatType>& data = dataPair.second;
 
         state.data[name].reinitialize();
 #pragma omp parallel for
-        for (size_t i = 0; i < state.data[name].size(); ++i) {
+        for (size_t i = 0; i < state.data.at(name).size(); ++i) {
             const FloatType f00 = data[ij00[i]];
             const FloatType f10 = data[ij10[i]];
             const FloatType f01 = data[ij01[i]];
@@ -352,7 +396,7 @@ ModelState ParaGridInputs::interpolateSpatially(const RawDataMap& rawData)
             const FloatType N01 = (1.0 - xi[i]) * eta[i];
             const FloatType N11 = xi[i] * eta[i];
 
-            state.data[name][i] = N00 * f00 + N10 * f10 + N01 * f01 + N11 * f11;
+            state.data.at(name)[i] = N00 * f00 + N10 * f10 + N01 * f01 + N11 * f11;
         }
     }
 
@@ -462,7 +506,15 @@ ParaGridInputs::RawDataMap ParaGridInputs::readRawData(
     RawDataMap data;
     for (const std::string& varName : fields) {
         try {
-            netCDF::NcFile ncFile(formatFileName(filePath, time, varName), netCDF::NcFile::read);
+
+            // We may need to be more careful selecting the right file if we're reading lat/lon info
+            std::string fileName;
+            if (varName == ncLonName || varName == ncLatName)
+                fileName = formatFileName(filePath, time, *forcings.begin());
+            else
+                fileName = formatFileName(filePath, time, varName);
+
+            netCDF::NcFile ncFile(fileName, netCDF::NcFile::read);
 
             // Don't try to read non-existent data
             if (ncFile.getVars().count(varName) == 0)
@@ -478,20 +530,21 @@ ParaGridInputs::RawDataMap ParaGridInputs::readRawData(
 
             // Pick the time slice if we have a time axis
             for (int i = 0; i < dims.size(); ++i) {
-                if (dims[0].getName() == ncTimeName) {
-                    start[0] = timeIndex;
-                    count[0] = 1;
+                if (dims[i].getName() == ncFile.getVar(ncTimeName).getDims()[0].getName()) {
+                    start[i] = timeIndex;
+                    count[i] = 1;
+                    continue;
                 }
+                // Push all non-time dimension counts to the output data map
+                data.dims[varName].push_back(count[i]);
             }
+            // Needs to be reversed because of netCDF shenanigans
+            std::reverse(data.dims[varName].begin(), data.dims[varName].end());
 
             data.data[varName] = std::vector<FloatType>(std::accumulate(
                 count.begin(), count.end(), static_cast<size_t>(1), std::multiplies<>()));
             readNetCDFVar(var, start, count, data.data[varName].data());
 
-            if (varName == ncLonName || varName == ncLatName) {
-                data.dims = count;
-                std::reverse(data.dims.begin(), data.dims.end());
-            }
         } catch (const netCDF::exceptions::NcException& nce) {
             std::string ncWhat(nce.what());
             ncWhat += ": " + formatFileName(filePath, time, varName);

--- a/core/src/ParaGridInputs.cpp
+++ b/core/src/ParaGridInputs.cpp
@@ -274,12 +274,12 @@ void ParaGridInputs::orthographicProjection(const FloatType lon, const FloatType
     /* Most of these are used twice, but not all. But anyway, it's easier to read like this, and the
      * compiler should optimise the excessive assignments out, right?
      */
-    const FloatType cosPhi = std::cos(lat * PhysicalConstants::deg2rad);
-    const FloatType cosPhi0 = std::cos(lat0 * PhysicalConstants::deg2rad);
-    const FloatType sinPhi = std::sin(lat * PhysicalConstants::deg2rad);
-    const FloatType sinPhi0 = std::sin(lat0 * PhysicalConstants::deg2rad);
-    const FloatType cosDeltaLambda = std::cos((lon - lon0) * PhysicalConstants::deg2rad);
-    const FloatType sinDeltaLambda = std::sin((lon - lon0) * PhysicalConstants::deg2rad);
+    const FloatType cosPhi = std::cos(radians(lat));
+    const FloatType cosPhi0 = std::cos(radians(lat0));
+    const FloatType sinPhi = std::sin(radians(lat));
+    const FloatType sinPhi0 = std::sin(radians(lat0));
+    const FloatType cosDeltaLambda = std::cos(radians(lon - lon0));
+    const FloatType sinDeltaLambda = std::sin(radians(lon - lon0));
 
     // Projected coordinates
     x = cosPhi * sinDeltaLambda;
@@ -568,7 +568,7 @@ ParaGridInputs::RawDataMap ParaGridInputs::readRawData(
             // Resize and read!
             data.data[varName] = std::vector<FloatType>(std::accumulate(
                 count.begin(), count.end(), static_cast<size_t>(1), std::multiplies<>()));
-            var.getVar(start, count, data.data[varName].data());
+            readNetCDFVar(var, start, count, data.data[varName].data());
 
         } catch (const netCDF::exceptions::NcException& nce) {
             std::string ncWhat(nce.what());

--- a/core/src/ParaGridInputs.cpp
+++ b/core/src/ParaGridInputs.cpp
@@ -9,14 +9,20 @@
 #include "include/NetCDFUtils.hpp"
 #include "include/ParaGridInputs.hpp"
 
+#include "NextsimDynamics.hpp"
+#include "include/constants.hpp"
+#include "include/indexer.hpp"
+
 namespace Nextsim {
 
-void ParaGridInputs::configure(const std::string& filePathIn, const std::string& ncLonNameIn,
-    const std::string& ncLatNameIn, const std::string& ncTimeNameIn,
+void ParaGridInputs::setData(const TimePoint& time, const std::string& filePathIn,
+    const std::string& ncLonNameIn, const std::string& ncLatNameIn, const std::string& ncTimeNameIn,
     const std::set<std::string>& forcingsIn,
     const std::set<std::pair<std::string, std::string>>& vectorsIn, const ModelArray& modelLonsIn,
     const ModelArray& modelLatsIn)
 {
+    currentTime = time;
+
     filePath = filePathIn;
     forcings = forcingsIn;
     vectors = vectorsIn;
@@ -27,6 +33,10 @@ void ParaGridInputs::configure(const std::string& filePathIn, const std::string&
 
     modelLons = modelLonsIn;
     modelLats = modelLatsIn;
+
+    forcingLonLats = readRawData(currentTime.format(filePath), { ncLatName, ncLonName });
+
+    setWeights();
 }
 
 void ParaGridInputs::update(const TimePoint& time)
@@ -34,7 +44,7 @@ void ParaGridInputs::update(const TimePoint& time)
     currentTime = time;
 
     if (time < timeRange.before || time > timeRange.after) {
-        std::map<std::string, std::vector<FloatType>> rawDataBefore, rawDataAfter;
+        RawDataMap rawDataBefore, rawDataAfter;
         readRawForcing(rawDataBefore, rawDataAfter);
 
         rotateInputVectors(rawDataBefore);
@@ -50,9 +60,10 @@ ModelArray ParaGridInputs::getField(const std::string& fieldName)
     ModelArray ma;
     ma.reinitialize();
 
-    const double frac = (currentTime - timeRange.before).seconds()
+    const FloatType frac = (currentTime - timeRange.before).seconds()
         / (timeRange.after - timeRange.before).seconds();
 
+#pragma omp parallel for
     for (size_t i = 0; i < ma.size(); ++i) {
         ma[i] = frac * forcingStateAfter.data[fieldName][i]
             + (1. - frac) * forcingStateBefore.data[fieldName][i];
@@ -61,26 +72,299 @@ ModelArray ParaGridInputs::getField(const std::string& fieldName)
     return ma;
 }
 
-ModelState ParaGridInputs::interpolateSpatially(
-    const std::map<std::string, std::vector<FloatType>>& rawData)
+void ParaGridInputs::setWeights()
+{
+    // Initialise the size of the weights and indexes
+    xi.reinitialize();
+    eta.reinitialize();
+
+    ij00.resize(xi.size());
+    ij01.resize(xi.size());
+    ij10.resize(xi.size());
+    ij11.resize(xi.size());
+
+    if (forcingLonLats.dims.size() == 1) {
+        // Lat and lon are 1D
+        setWeights1D();
+    } else if (forcingLonLats.dims.size() == 2) {
+        // Lat and lon are 2D
+        setWeights2D();
+    } else {
+        throw std::out_of_range(
+            "ParaGridInputs::setWeights: Unsupported dimensionality of forcing grid: "
+            + std::to_string(forcingLonLats.dims.size()) + ".\n");
+    }
+}
+
+void ParaGridInputs::setWeights1D()
+{
+#pragma omp parallel for
+    for (size_t i = 0; i < modelLons.size(); ++i) {
+        // Useful aliases
+        const auto& forcingLons = forcingLonLats.data[ncLonName];
+        const auto& forcingLats = forcingLonLats.data[ncLatName];
+        const auto& dims = forcingLonLats.dims;
+
+        // Find the bounding box
+        const size_t aLon = std::lower_bound(forcingLons.begin(), forcingLons.end(), modelLons[i])
+            - forcingLons.begin();
+        const size_t aLat = std::lower_bound(forcingLats.begin(), forcingLats.end(), modelLats[i])
+            - forcingLats.begin();
+
+        // Use modulo for periodic boundaries in longitude
+        const size_t bLon = (aLon + 1) % forcingLons.size();
+        const size_t bLat = (aLat + 1) % forcingLons.size();
+
+        /* Calculate the weights on a local tangent plane, with
+         * x = R \cos(\phi) \lambda
+         * y = R \phi
+         * but R and \cos(\phi) cancel out */
+        const FloatType x = modelLons[i];
+        const FloatType y = modelLats[i];
+
+        const FloatType x1 = forcingLons[aLon];
+        const FloatType x2 = forcingLons[bLon];
+        const FloatType y1 = forcingLats[aLat];
+        const FloatType y2 = forcingLats[bLat];
+
+        xi[i] = wrapLon(x - x1) / wrapLon(x2 - x1);
+        eta[i] = (y - y1) / (y2 - y1);
+
+        ij00[i] = indexer(dims, { aLon, aLat });
+        ij01[i] = indexer(dims, { aLon, bLat });
+        ij10[i] = indexer(dims, { bLon, aLat });
+        ij11[i] = indexer(dims, { bLon, bLat });
+    }
+}
+
+void ParaGridInputs::setWeights2D()
+{
+#pragma omp parallel for
+    for (size_t k = 0; k < modelLons.size(); ++k) {
+        // Careful with the C-style indexing!
+        if (!recursiveBisectSearch(k, modelLons[k], modelLats[k], 0, forcingLonLats.dims[0] - 1, 0,
+                forcingLonLats.dims[1] - 1))
+            throw std::out_of_range("ParaGridInputs::setWeights2D: Couldn't find "
+                + std::to_string(modelLons[k]) + ", " + std::to_string(modelLats[k])
+                + " in the forcing grid.\n");
+    }
+}
+
+bool ParaGridInputs::recursiveBisectSearch(const size_t k, const FloatType targetLon,
+    const FloatType targetLat, const size_t i, const size_t ii, const size_t j, const size_t jj)
+{
+    // Useful aliases
+    const auto& forcingLons = forcingLonLats.data[ncLonName];
+    const auto& forcingLats = forcingLonLats.data[ncLatName];
+    const auto& dims = forcingLonLats.dims;
+
+    // If one of the dimensions has collapsed, then the point is not here(!)
+    if (i == ii || j == jj)
+        return false;
+
+    /* Project the corner points onto an orthographic projection, centred on the target. We do the
+     * rest of the work in {x,y} coordinates. The target {x,y} is now always at the origin.
+     */
+    FloatType x00, y00, x10, y10, x01, y01, x11, y11;
+    orthographicProjection(forcingLons[indexer(dims, { i, j })],
+        forcingLats[indexer(dims, { i, j })], targetLon, targetLat, x00, y00);
+    orthographicProjection(forcingLons[indexer(dims, { ii, j })],
+        forcingLats[indexer(dims, { ii, j })], targetLon, targetLat, x10, y10);
+    orthographicProjection(forcingLons[indexer(dims, { i, jj })],
+        forcingLats[indexer(dims, { i, jj })], targetLon, targetLat, x01, y01);
+    orthographicProjection(forcingLons[indexer(dims, { ii, jj })],
+        forcingLats[indexer(dims, { ii, jj })], targetLon, targetLat, x11, y11);
+
+    // If we're not inside the bounding box, then there's no point in going further
+    if (!pointInBoundingBox({ x00, x10, x01, x11 }, { y00, y10, y01, y11 }))
+        return false;
+
+    // If the size of the box is one, then we can try to find the local coordinates
+    if (ii == i + 1 && jj == j + 1) {
+        // Save the index
+        ij00[k] = indexer(dims, { i, j });
+        ij10[k] = indexer(dims, { ii, j });
+        ij01[k] = indexer(dims, { i, jj });
+        ij11[k] = indexer(dims, { ii, jj });
+
+        // Try to find local coordinates
+        return findLocalCoordinates(k, x00, y00, x10, y10, x01, y01, x11, y11);
+    }
+
+    // Bisect and call self to continue searching
+    const size_t iHalf = i + (ii - i) / 2;
+    const size_t jHalf = j + (jj - j) / 2;
+
+    // Search quadrant 00
+    if (recursiveBisectSearch(k, targetLon, targetLat, i, iHalf, j, jHalf))
+        return true;
+
+    // Search quadrant 10
+    if (recursiveBisectSearch(k, targetLon, targetLat, iHalf, ii, j, jHalf))
+        return true;
+
+    // Search quadrant 01
+    if (recursiveBisectSearch(k, targetLon, targetLat, i, iHalf, jHalf, jj))
+        return true;
+
+    // Search quadrant 11
+    if (recursiveBisectSearch(k, targetLon, targetLat, iHalf, ii, jHalf, jj))
+        return true;
+
+    // Nothing found
+    return false;
+}
+
+void ParaGridInputs::orthographicProjection(const FloatType lon, const FloatType lat,
+    const FloatType lon0, const FloatType lat0, FloatType& x, FloatType& y) const
+{
+    const FloatType cosPhi = std::cos(lat * PhysicalConstants::deg2rad);
+    const FloatType cosPhi0 = std::cos(lat0 * PhysicalConstants::deg2rad);
+    const FloatType sinPhi = std::sin(lat * PhysicalConstants::deg2rad);
+    const FloatType sinPhi0 = std::sin(lat0 * PhysicalConstants::deg2rad);
+    const FloatType cosDeltaLambda = std::cos((lon - lon0) * PhysicalConstants::deg2rad);
+    const FloatType sinDeltaLambda = std::sin((lon - lon0) * PhysicalConstants::deg2rad);
+
+    x = cosPhi * sinDeltaLambda;
+    y = cosPhi0 * sinPhi - sinPhi0 * cosPhi * cosDeltaLambda;
+
+    // If the point is outside the projected area, then we move it to the map edge
+    if (const FloatType c = sinPhi0 * sinPhi - cosPhi0 * cosPhi * cosDeltaLambda;
+        std::cos(c) < 0.) {
+        x = std::copysign(1., x);
+        y = std::copysign(1., y);
+    }
+}
+
+bool ParaGridInputs::pointInBoundingBox(
+    const std::vector<FloatType>& xCorners, const std::vector<FloatType>& yCorners)
+{
+    const double xMin = *std::min_element(xCorners.begin(), xCorners.end());
+    const double xMax = *std::max_element(xCorners.begin(), xCorners.end());
+
+    const double yMin = *std::min_element(yCorners.begin(), yCorners.end());
+    const double yMax = *std::max_element(yCorners.begin(), yCorners.end());
+
+    // The target point is at the origin
+    return 0. >= xMin && 0. <= xMax && 0. >= yMin && 0. <= yMax;
+}
+
+bool ParaGridInputs::findLocalCoordinates(const size_t k, const FloatType x00, const FloatType y00,
+    const FloatType x10, const FloatType y10, const FloatType x01, const FloatType y01,
+    const FloatType x11, const FloatType y11)
+{
+    /*
+     * Cell corners:
+     *
+     *       p01 -------- p11
+     *        |            |
+     *        |            |
+     *       p00 -------- p10
+     *
+     * Local coordinates:
+     *
+     *       eta = 1
+     *          ^
+     *          |
+     *          |
+     *       eta = 0
+     *
+     *       xi = 0 ---> xi = 1
+     */
+
+    // Initial guess.
+    // The center of the cell is usually a reasonable starting point.
+    xi[k] = 0.5;
+    eta[k] = 0.5;
+
+    /* Newton iteration:
+     *     F(xi, eta) = mapping(xi, eta) - query_point
+     */
+    constexpr FloatType tolerance = 100 * std::numeric_limits<FloatType>::epsilon();
+    for (int iteration = 0; iteration < 20; ++iteration) {
+
+        // Bilinear mapping from local coordinates to physical coordinates.
+        const FloatType N00 = (1.0 - xi[k]) * (1.0 - eta[k]);
+        const FloatType N10 = xi[k] * (1.0 - eta[k]);
+        const FloatType N01 = (1.0 - xi[k]) * eta[k];
+        const FloatType N11 = xi[k] * eta[k];
+
+        const FloatType xp = N00 * x00 + N10 * x10 + N01 * x01 + N11 * x11;
+        const FloatType yp = N00 * y00 + N10 * y10 + N01 * y01 + N11 * y11;
+
+        // Convergence test - target is at origin
+        if (std::sqrt(xp * xp + yp * yp) < tolerance)
+            break;
+
+        /* Jacobian:
+         *     [ dx/dxi   dx/deta ]
+         * J = [                  ]
+         *     [ dy/dxi   dy/deta ]
+         */
+        const FloatType dx_dxi = (1.0 - eta[k]) * (x10 - x00) + eta[k] * (x11 - x01);
+        const FloatType dx_deta = (1.0 - xi[k]) * (x01 - x00) + xi[k] * (x11 - x10);
+        const FloatType dy_dxi = (1.0 - eta[k]) * (y10 - y00) + eta[k] * (y11 - y01);
+        const FloatType dy_deta = (1.0 - xi[k]) * (y01 - y00) + xi[k] * (y11 - y10);
+
+        const FloatType determinant = dx_dxi * dy_deta - dx_deta * dy_dxi;
+
+        // Check if the cell is degenerate
+        if (std::abs(determinant) < tolerance)
+            return false;
+
+        /* Solve:
+         *     J [d_xi ] = -F
+         *       [d_eta]
+         */
+        xi[k] -= (xp * dy_deta - dx_deta * yp) / determinant;
+        eta[k] += (dy_dxi * xp - dx_dxi * yp) / determinant;
+
+        // If the solution is far outside the cell, then this is probably not the correct cell.
+        //
+        if (xi[k] < -0.1 || xi[k] > 1.1 || eta[k] < -0.1 || eta[k] > 1.1)
+            return false;
+    }
+
+    // Check whether the point is actually inside the cell.
+    if (!(xi[k] >= 0. && xi[k] <= 1. && eta[k] >= 0. && eta[k] <= 1.))
+        return false;
+
+    return true;
+}
+
+ModelState ParaGridInputs::interpolateSpatially(const RawDataMap& rawData)
 {
     ModelState state;
-    for (const auto& [name, data] : rawData) {
+    for (const auto& dataPair : rawData.data) {
+        const std::string& name = dataPair.first;
+        const std::vector<FloatType>& data = dataPair.second;
+
         state.data[name].reinitialize();
-        for (size_t i = 0; i < data.size(); ++i) {
-            state.data[name][i] = data[i]; // TODO: Actually interpolate
+#pragma omp parallel for
+        for (size_t i = 0; i < state.data[name].size(); ++i) {
+            const FloatType f00 = data[ij00[i]];
+            const FloatType f10 = data[ij10[i]];
+            const FloatType f01 = data[ij01[i]];
+            const FloatType f11 = data[ij11[i]];
+
+            const FloatType N00 = (1.0 - xi[i]) * (1.0 - eta[i]);
+            const FloatType N10 = xi[i] * (1.0 - eta[i]);
+            const FloatType N01 = (1.0 - xi[i]) * eta[i];
+            const FloatType N11 = xi[i] * eta[i];
+
+            state.data[name][i] = N00 * f00 + N10 * f10 + N01 * f01 + N11 * f11;
         }
     }
 
     return state;
 }
 
-void ParaGridInputs::rotateInputVectors(std::map<std::string, std::vector<FloatType>>& rawData)
+void ParaGridInputs::rotateInputVectors(RawDataMap& rawData)
 {
-    auto rawDataCopy = rawData;
-    for (auto& pair : vectors) {
-        vectorRotationLogic(rawDataCopy[pair.first], rawDataCopy[pair.second], rawData[pair.first],
-            rawDataCopy[pair.second]);
+    const auto originalRotation = rawData.data;
+    for (const auto& [first, second] : vectors) {
+        vectorRotationLogic(originalRotation.at(first), originalRotation.at(second),
+            rawData.data.at(first), rawData.data.at(second));
     }
 }
 
@@ -93,8 +377,7 @@ void ParaGridInputs::vectorRotationLogic(const std::vector<FloatType>& vectorIn1
     vectorOut2nd = vectorIn2nd;
 }
 
-void ParaGridInputs::readRawForcing(std::map<std::string, std::vector<FloatType>>& rawDataBefore,
-    std::map<std::string, std::vector<FloatType>>& rawDataAfter)
+void ParaGridInputs::readRawForcing(RawDataMap& rawDataBefore, RawDataMap& rawDataAfter)
 {
     const std::string fileNameBefore = currentTime.format(filePath);
     std::string fileNameAfter = fileNameBefore;
@@ -125,7 +408,7 @@ void ParaGridInputs::readRawForcing(std::map<std::string, std::vector<FloatType>
             multiplier = 1.;
         else if (timeUnit == "minutes")
             multiplier = 60.;
-        else if (timeUnit == "hours")
+        else if (timeUnit == "hour" || timeUnit == "hours")
             multiplier = 3600.;
         else if (timeUnit == "days")
             multiplier = 24. * 3600.;
@@ -152,10 +435,8 @@ void ParaGridInputs::readRawForcing(std::map<std::string, std::vector<FloatType>
         /* We need to check if targetTIndexAfter is actually pointing at the right time, or if we
          * need to go on to the next file */
         if (TimePoint(timePointOrigin, Duration(timeVec[targetTIndexAfter])) < currentTime) {
-            targetTIndexBefore = targetTIndexAfter;
             timeRange.before = TimePoint(timePointOrigin, Duration(timeVec[targetTIndexBefore]));
-            timeRange.after = TimePoint(timePointOrigin, Duration(timeVec[targetTIndexAfter]))
-                + Duration(timeVec[1] - timeVec[0]);
+            timeRange.after = timeRange.before + Duration(timeVec[1] - timeVec[0]);
             targetTIndexAfter = 0;
             fileNameAfter = timeRange.after.format(filePath);
         }
@@ -173,19 +454,19 @@ void ParaGridInputs::readRawForcing(std::map<std::string, std::vector<FloatType>
         throw std::runtime_error(ncWhat);
     }
 
-    rawDataBefore = readRawData(fileNameBefore, targetTIndexBefore);
-    rawDataAfter = readRawData(fileNameAfter, targetTIndexAfter);
+    rawDataBefore = readRawData(fileNameBefore, forcings, targetTIndexBefore);
+    rawDataAfter = readRawData(fileNameAfter, forcings, targetTIndexAfter);
 }
 
-std::map<std::string, std::vector<FloatType>> ParaGridInputs::readRawData(
-    const std::string& fileName, const size_t timeIndex = 0) const
+ParaGridInputs::RawDataMap ParaGridInputs::readRawData(
+    const std::string& fileName, const std::set<std::string>& fields, const size_t timeIndex) const
 {
-    std::map<std::string, std::vector<FloatType>> data;
+    RawDataMap data;
     try {
         netCDF::NcFile ncFile(fileName, netCDF::NcFile::read);
 
         auto availableForcings = ncFile.getVars();
-        for (const std::string& varName : forcings) {
+        for (const std::string& varName : fields) {
             // Don't try to read non-existent data
             if (!availableForcings.count(varName)) {
                 continue;
@@ -206,14 +487,19 @@ std::map<std::string, std::vector<FloatType>> ParaGridInputs::readRawData(
                 }
             }
 
-            data[varName] = std::vector<FloatType>(
-                std::accumulate(count.begin(), count.end(), 1, std::multiplies<size_t>()));
-            readNetCDFVar(var, start, count, data[varName].data());
+            data.data[varName] = std::vector<FloatType>(std::accumulate(
+                count.begin(), count.end(), static_cast<size_t>(1), std::multiplies<>()));
+            readNetCDFVar(var, start, count, data.data[varName].data());
+
+            if (varName == ncLonName || varName == ncLatName) {
+                data.dims = count;
+                std::reverse(data.dims.begin(), data.dims.end());
+            }
         }
         ncFile.close();
     } catch (const netCDF::exceptions::NcException& nce) {
         std::string ncWhat(nce.what());
-        ncWhat += ": " + filePath;
+        ncWhat += ": " + fileName;
         throw std::runtime_error(ncWhat);
     }
     return data;

--- a/core/src/include/NetCDFUtils.hpp
+++ b/core/src/include/NetCDFUtils.hpp
@@ -27,11 +27,24 @@ namespace Details {
     void readConvertNetCDFVar(const netCDF::NcVar& var, const std::vector<size_t>& start,
         const std::vector<size_t>& size, DestT* dest)
     {
-        const size_t numElem = std::reduce(size.begin(), size.end(), 1, std::multiplies<>());
+        const size_t numElem
+            = std::reduce(size.begin(), size.end(), static_cast<size_t>(1), std::multiplies<>());
         std::vector<ReadT> buf(numElem, 0.f);
         var.getVar(start, size, buf.data());
+        DestT offset;
+        DestT scale;
+        try {
+            const netCDF::NcVarAtt scaleAtt = var.getAtt("scale_factor");
+            const netCDF::NcVarAtt offsetAtt = var.getAtt("add_offset");
+            scaleAtt.getValues(&scale);
+            offsetAtt.getValues(&offset);
+        } catch (const netCDF::exceptions::NcException&) {
+            // Ignore missing attributes
+            offset = 0;
+            scale = 1;
+        }
         for (size_t i = 0; i < numElem; ++i) {
-            dest[i] = static_cast<DestT>(buf[i]);
+            dest[i] = static_cast<DestT>(buf[i] * scale + offset);
         }
     }
 
@@ -42,7 +55,7 @@ void readNetCDFVar(const netCDF::NcVar& var, const std::vector<size_t>& start,
     const std::vector<size_t>& size, T* dest)
 {
     static_assert(std::is_same_v<T, float> || std::is_same_v<T, double>,
-        "Currently only conversion between floating point types is supported during load.");
+        "Currently only conversion to floating point types is supported during load.");
 
     const netCDF::NcType ncType = var.getType();
 
@@ -53,8 +66,10 @@ void readNetCDFVar(const netCDF::NcVar& var, const std::vector<size_t>& start,
             Details::readConvertNetCDFVar<float>(var, start, size, dest);
         } else if (ncType == netCDF::ncDouble) {
             Details::readConvertNetCDFVar<double>(var, start, size, dest);
+        } else if (ncType == netCDF::ncShort) {
+            Details::readConvertNetCDFVar<short>(var, start, size, dest);
         } else {
-            throw std::domain_error("Unsupported type of input field.");
+            throw std::domain_error("Unsupported type of input field " + var.getName() + ".\n");
         }
     }
 }

--- a/core/src/include/NetCDFUtils.hpp
+++ b/core/src/include/NetCDFUtils.hpp
@@ -54,7 +54,7 @@ template <typename T>
 void readNetCDFVar(const netCDF::NcVar& var, const std::vector<size_t>& start,
     const std::vector<size_t>& size, T* dest)
 {
-    static_assert(std::is_same_v<T, float> || std::is_same_v<T, double>,
+    static_assert(std::is_same_v<T, float> || std::is_same_v<T, double> || std::is_same_v<T, short>,
         "Currently only conversion to floating point types is supported during load.");
 
     const netCDF::NcType ncType = var.getType();

--- a/core/src/include/ParaGridInputs.hpp
+++ b/core/src/include/ParaGridInputs.hpp
@@ -20,76 +20,139 @@ class ParaGridInputs {
 public:
     ParaGridInputs() = default;
 
-    void setData(const TimePoint& time, const std::string& filePathIn,
+    /*!
+     *@brief Initialise object parameters and calculate interpolation weights. To be called by
+     * parent's setData function.
+     *
+     * @param time Initial time
+     * @param pathSpecIn Pathspec for the input file(s). This will be formatted with any time
+     * formats (e.g. %Y or %m) for the current time. For datasets comprising of multiple files with
+     * one file per variable, the key %v will be replaced by the variable name.
+     * @param ncLonNameIn Name of the longitude variable in the netCDF file
+     * @param ncLatNameIn Name of the latitude variable in the netCDF file
+     * @param ncTimeNameIn Name of the time variable in the netCDF file
+     * @param forcingsIn Set of forcing variables to read
+     * @param vectorsIn Set of vector variables to read
+     * @param modelLonsIn Model longitudes
+     * @param modelLatsIn Model latitudes
+     */
+    void setData(const TimePoint& time, const std::string& pathSpecIn,
         const std::string& ncLonNameIn, const std::string& ncLatNameIn,
         const std::string& ncTimeNameIn, const std::set<std::string>& forcingsIn,
         const std::set<std::pair<std::string, std::string>>& vectorsIn,
         const ModelArray& modelLonsIn, const ModelArray& modelLatsIn);
 
+    /*!
+     * @brief Update the forcing data for the current time step.
+     *
+     * @param time Current model time
+     */
     void update(const TimePoint& time);
+
+    /*!
+     * @brief Get the forcing data for a specific field interpolated in time to currentTime.
+     *
+     * @param fieldName Name of the field to retrieve
+     * @return Forcing data for the specified field
+     */
     [[nodiscard]] ModelArray getField(const std::string& fieldName);
+
+    /*!
+     * @brief Check if a field can be read in from the forcing data set.
+     *
+     * @param fieldName Name of the field to check
+     * @return True if the field is valid, false otherwise
+     */
     [[nodiscard]] bool isValid(const std::string& fieldName) const
     {
         return forcingStateBefore.data.count(fieldName) && forcingStateAfter.data.count(fieldName);
     }
 
 private:
+    // Useful structs
     typedef struct {
         std::map<std::string, std::vector<size_t>> dims;
         std::map<std::string, std::vector<FloatType>> data;
     } RawDataMap;
 
-    void setWeights();
-    void setWeights1D();
-    void setWeights2D();
-    bool recursiveBisectSearch(size_t k, FloatType targetLon, FloatType targetLat, size_t i,
-        size_t ii, size_t j, size_t jj);
-    void orthographicProjection(FloatType lon, FloatType lat, FloatType lon0, FloatType lat0,
-        FloatType& x, FloatType& y) const;
-    [[nodiscard]] bool pointInBoundingBox(
-        const std::vector<FloatType>& xCorners, const std::vector<FloatType>& yCorners);
-    [[nodiscard]] bool findLocalCoordinates(size_t k, FloatType x00, FloatType y00, FloatType x10,
-        FloatType y10, FloatType x01, FloatType y01, FloatType x11, FloatType y11);
-    [[nodiscard]] ModelState interpolateSpatially(const RawDataMap& rawData);
-    void rotateInputVectors(RawDataMap& rawData);
-
-    std::string filePath, ncTimeName, ncLonName, ncLatName;
-    ModelArray modelLons, modelLats;
-    RawDataMap forcingLonLats;
-    std::set<std::string> forcings;
-    std::set<std::pair<std::string, std::string>> vectors;
-    std::vector<size_t> ij00, ij01, ij10, ij11;
-    ModelArray xi, eta;
-
     struct {
+        /* The initialisation is important, because init time should always be larger than
+         * timeRange.after
+         */
         TimePoint before = std::numeric_limits<TimePoint>::min(),
                   after = std::numeric_limits<TimePoint>::min();
     } timeRange;
 
+    // Weights and coordinate pointers for the bi-linear interpolation
+    ModelArray xi, eta;
+    std::vector<size_t> ij00, ij01, ij10, ij11;
+
+    // Some (hopefully) self explanatory state variables
     TimePoint currentTime;
-
     ModelState forcingStateBefore, forcingStateAfter;
+    std::string pathSpec, ncTimeName, ncLonName, ncLatName;
+    ModelArray modelLons, modelLats;
+    RawDataMap forcingLonLats;
+    std::set<std::string> forcings;
+    std::set<std::pair<std::string, std::string>> vectors;
 
+    // Basic weight-setting functions
+    void setWeights();
+    void setWeights1D();
+    void setWeights2D();
+
+    /* Does a recursive search for the grid cell with corners i, ii, j, and jj, in which the point
+     * {targetLon, targetLat} is found.
+     */
+    bool recursiveBisectSearch(size_t k, FloatType targetLon, FloatType targetLat, size_t i,
+        size_t ii, size_t j, size_t jj);
+
+    // Project {lon, lat} onto the orthographic coordinates {x,y} with {lon0, lat0} at its centre.
+    void orthographicProjection(FloatType lon, FloatType lat, FloatType lon0, FloatType lat0,
+        FloatType& x, FloatType& y) const;
+
+    /* Do a quick axis-aligned bounding box check to see if a point is (probably) in the grid cell.
+     * This is a necessary condition, not a sufficient one.
+     */
+    [[nodiscard]] bool pointInBoundingBox(
+        const std::vector<FloatType>& xCorners, const std::vector<FloatType>& yCorners);
+
+    /* Find the local coordinates and weights {xi, eta} for a bi-linear interpolation on a
+     * curvilinear grid
+     */
+    [[nodiscard]] bool findLocalCoordinates(size_t k, FloatType x00, FloatType y00, FloatType x10,
+        FloatType y10, FloatType x01, FloatType y01, FloatType x11, FloatType y11);
+
+    // Apply the weights to do a bi-linear interpolation
+    [[nodiscard]] ModelState interpolateSpatially(const RawDataMap& rawData);
+
+    // Rotate the vectors from the input to model grid
+    void rotateInputVectors(RawDataMap& rawData);
+
+    // A placeholder for the actual vector rotation logic
     void vectorRotationLogic(const std::vector<FloatType>& vectorIn1st,
         const std::vector<FloatType>& vectorIn2nd, std::vector<FloatType>& vectorOut1st,
         std::vector<FloatType>& vectorOut2nd);
 
+    // Read the forcing listed in ``forcings`` at times bracketing ``currentTime``.
     void readRawForcing(RawDataMap& rawDataBefore, RawDataMap& rawDataAfter);
 
+    // The function that actually reads data from the netCDF file
     [[nodiscard]] RawDataMap readRawData(
         const TimePoint& time, const std::set<std::string>& fields, size_t timeIndex = 0) const;
 
-    [[nodiscard]] double wrapLon(const double lon, const double lon0 = 360.) const
+    // Wrap longitudes, so that lon0 is the largest value (usually either [-180 180] or [0 360]
+    [[nodiscard]] FloatType wrapLon(const FloatType lon, const FloatType lon0 = 360.) const
     {
         return std::fmod(std::fmod(lon, lon0) + lon0, lon0);
     }
 
-    [[nodiscard]] std::string formatFileName(const std::string& filePathIn, const TimePoint& time,
-        const std::string& variable = "NONE") const
+    // Format the pathspec, replacing %v with a given variable name and using TimePoint.format()
+    [[nodiscard]] std::string formatFileName(
+        const TimePoint& time, const std::string& variable = "NONE") const
     {
         const std::regex pattern("%v");
-        const std::string temp = std::regex_replace(filePathIn, pattern, variable);
-        return time.format(temp);
+        return time.format(std::regex_replace(pathSpec, pattern, variable));
     }
 };
 

--- a/core/src/include/ParaGridInputs.hpp
+++ b/core/src/include/ParaGridInputs.hpp
@@ -1,0 +1,67 @@
+/*!
+ * @author  Einar Olason <einar.olason@nersc.no>
+ */
+
+#ifndef NEXTSIM_DG_PARAGRIDINPUTS_HPP
+#define NEXTSIM_DG_PARAGRIDINPUTS_HPP
+
+#include "ModelArray.hpp"
+#include "ModelState.hpp"
+#include "Time.hpp"
+
+#include <set>
+#include <string>
+
+namespace Nextsim {
+
+class ParaGridInputs {
+
+public:
+    ParaGridInputs() = default;
+
+    void configure(const std::string& filePathIn, const std::string& ncLonNameIn,
+        const std::string& ncLatNameIn, const std::string& ncTimeNameIn,
+        const std::set<std::string>& forcingsIn,
+        const std::set<std::pair<std::string, std::string>>& vectorsIn,
+        const ModelArray& modelLonsIn, const ModelArray& modelLatsIn);
+
+    void update(const TimePoint& time);
+    [[nodiscard]] ModelArray getField(const std::string& fieldName);
+    [[nodiscard]] bool isValid(const std::string& fieldName) const
+    {
+        return forcingStateBefore.data.count(fieldName) && forcingStateAfter.data.count(fieldName);
+    }
+
+private:
+    [[nodiscard]] ModelState interpolateSpatially(
+        const std::map<std::string, std::vector<FloatType>>& rawData);
+    void rotateInputVectors(std::map<std::string, std::vector<FloatType>>& rawData);
+
+    std::string filePath, ncTimeName, ncLonName, ncLatName;
+    std::set<std::string> forcings;
+    std::set<std::pair<std::string, std::string>> vectors;
+    ModelArray modelLons, modelLats;
+
+    struct {
+        TimePoint before = std::numeric_limits<TimePoint>::min(),
+                  after = std::numeric_limits<TimePoint>::min();
+    } timeRange;
+
+    TimePoint currentTime;
+
+    ModelState forcingStateBefore, forcingStateAfter;
+
+    void vectorRotationLogic(const std::vector<FloatType>& vectorIn1st,
+        const std::vector<FloatType>& vectorIn2nd, std::vector<FloatType>& vectorOut1st,
+        std::vector<FloatType>& vectorOut2nd);
+
+    void readRawForcing(std::map<std::string, std::vector<FloatType>>& rawDataBefore,
+        std::map<std::string, std::vector<FloatType>>& rawDataAfter);
+
+    [[nodiscard]] std::map<std::string, std::vector<FloatType>> readRawData(
+        const std::string& fileName, size_t timeIndex) const;
+};
+
+}
+
+#endif // NEXTSIM_DG_PARAGRIDINPUTS_HPP

--- a/core/src/include/ParaGridInputs.hpp
+++ b/core/src/include/ParaGridInputs.hpp
@@ -9,6 +9,7 @@
 #include "ModelState.hpp"
 #include "Time.hpp"
 
+#include <regex>
 #include <set>
 #include <string>
 
@@ -75,8 +76,8 @@ private:
 
     void readRawForcing(RawDataMap& rawDataBefore, RawDataMap& rawDataAfter);
 
-    [[nodiscard]] RawDataMap readRawData(const std::string& fileName,
-        const std::set<std::string>& fields, size_t timeIndex = 0) const;
+    [[nodiscard]] RawDataMap readRawData(
+        const TimePoint& time, const std::set<std::string>& fields, size_t timeIndex = 0) const;
 
     [[nodiscard]] double wrapLon(const double lon) const
     {
@@ -86,6 +87,14 @@ private:
 
         wrappedLon -= 180.;
         return wrappedLon;
+    }
+
+    [[nodiscard]] std::string formatFileName(const std::string& filePathIn, const TimePoint& time,
+        const std::string& variable = "NONE") const
+    {
+        const std::regex pattern("%v");
+        const std::string temp = std::regex_replace(filePathIn, pattern, variable);
+        return time.format(temp);
     }
 };
 

--- a/core/src/include/ParaGridInputs.hpp
+++ b/core/src/include/ParaGridInputs.hpp
@@ -35,7 +35,7 @@ public:
 
 private:
     typedef struct {
-        std::vector<size_t> dims;
+        std::map<std::string, std::vector<size_t>> dims;
         std::map<std::string, std::vector<FloatType>> data;
     } RawDataMap;
 
@@ -79,14 +79,9 @@ private:
     [[nodiscard]] RawDataMap readRawData(
         const TimePoint& time, const std::set<std::string>& fields, size_t timeIndex = 0) const;
 
-    [[nodiscard]] double wrapLon(const double lon) const
+    [[nodiscard]] double wrapLon(const double lon, const double lon0 = 360.) const
     {
-        double wrappedLon = std::fmod(lon + 180., 360.);
-        if (wrappedLon < 0.0)
-            wrappedLon += 360.;
-
-        wrappedLon -= 180.;
-        return wrappedLon;
+        return std::fmod(std::fmod(lon, lon0) + lon0, lon0);
     }
 
     [[nodiscard]] std::string formatFileName(const std::string& filePathIn, const TimePoint& time,

--- a/core/src/include/ParaGridInputs.hpp
+++ b/core/src/include/ParaGridInputs.hpp
@@ -19,9 +19,9 @@ class ParaGridInputs {
 public:
     ParaGridInputs() = default;
 
-    void configure(const std::string& filePathIn, const std::string& ncLonNameIn,
-        const std::string& ncLatNameIn, const std::string& ncTimeNameIn,
-        const std::set<std::string>& forcingsIn,
+    void setData(const TimePoint& time, const std::string& filePathIn,
+        const std::string& ncLonNameIn, const std::string& ncLatNameIn,
+        const std::string& ncTimeNameIn, const std::set<std::string>& forcingsIn,
         const std::set<std::pair<std::string, std::string>>& vectorsIn,
         const ModelArray& modelLonsIn, const ModelArray& modelLatsIn);
 
@@ -33,14 +33,32 @@ public:
     }
 
 private:
-    [[nodiscard]] ModelState interpolateSpatially(
-        const std::map<std::string, std::vector<FloatType>>& rawData);
-    void rotateInputVectors(std::map<std::string, std::vector<FloatType>>& rawData);
+    typedef struct {
+        std::vector<size_t> dims;
+        std::map<std::string, std::vector<FloatType>> data;
+    } RawDataMap;
+
+    void setWeights();
+    void setWeights1D();
+    void setWeights2D();
+    bool recursiveBisectSearch(size_t k, FloatType targetLon, FloatType targetLat, size_t i,
+        size_t ii, size_t j, size_t jj);
+    void orthographicProjection(FloatType lon, FloatType lat, FloatType lon0, FloatType lat0,
+        FloatType& x, FloatType& y) const;
+    [[nodiscard]] bool pointInBoundingBox(
+        const std::vector<FloatType>& xCorners, const std::vector<FloatType>& yCorners);
+    [[nodiscard]] bool findLocalCoordinates(size_t k, FloatType x00, FloatType y00, FloatType x10,
+        FloatType y10, FloatType x01, FloatType y01, FloatType x11, FloatType y11);
+    [[nodiscard]] ModelState interpolateSpatially(const RawDataMap& rawData);
+    void rotateInputVectors(RawDataMap& rawData);
 
     std::string filePath, ncTimeName, ncLonName, ncLatName;
+    ModelArray modelLons, modelLats;
+    RawDataMap forcingLonLats;
     std::set<std::string> forcings;
     std::set<std::pair<std::string, std::string>> vectors;
-    ModelArray modelLons, modelLats;
+    std::vector<size_t> ij00, ij01, ij10, ij11;
+    ModelArray xi, eta;
 
     struct {
         TimePoint before = std::numeric_limits<TimePoint>::min(),
@@ -55,11 +73,20 @@ private:
         const std::vector<FloatType>& vectorIn2nd, std::vector<FloatType>& vectorOut1st,
         std::vector<FloatType>& vectorOut2nd);
 
-    void readRawForcing(std::map<std::string, std::vector<FloatType>>& rawDataBefore,
-        std::map<std::string, std::vector<FloatType>>& rawDataAfter);
+    void readRawForcing(RawDataMap& rawDataBefore, RawDataMap& rawDataAfter);
 
-    [[nodiscard]] std::map<std::string, std::vector<FloatType>> readRawData(
-        const std::string& fileName, size_t timeIndex) const;
+    [[nodiscard]] RawDataMap readRawData(const std::string& fileName,
+        const std::set<std::string>& fields, size_t timeIndex = 0) const;
+
+    [[nodiscard]] double wrapLon(const double lon) const
+    {
+        double wrappedLon = std::fmod(lon + 180., 360.);
+        if (wrappedLon < 0.0)
+            wrappedLon += 360.;
+
+        wrappedLon -= 180.;
+        return wrappedLon;
+    }
 };
 
 }

--- a/core/src/include/Time.hpp
+++ b/core/src/include/Time.hpp
@@ -180,7 +180,8 @@ public:
     TimePoint()
         : m_t() {};
     TimePoint(const std::string& str) { this->parse(str); }
-    TimePoint(const TimePoint&, const Duration&);
+    TimePoint(const TimePoint& t, const Duration& d)
+        : m_t(t.m_t + d.m_d) {};
 
     //! Calculate the Duration between two TimePoints.
     Duration operator-(const TimePoint& a) const { return Duration(m_t - a.m_t); }

--- a/physics/src/modules/AtmosphereBoundaryModule/ERA5Atmosphere.cpp
+++ b/physics/src/modules/AtmosphereBoundaryModule/ERA5Atmosphere.cpp
@@ -4,10 +4,10 @@
 
 #include "include/ERA5Atmosphere.hpp"
 
-#include "include/constants.hpp"
 #include "include/Finalizer.hpp"
 #include "include/NextsimModule.hpp"
 #include "include/ParaGridIO.hpp"
+#include "include/constants.hpp"
 
 namespace Nextsim {
 

--- a/physics/src/modules/AtmosphereBoundaryModule/ERA5Atmosphere.cpp
+++ b/physics/src/modules/AtmosphereBoundaryModule/ERA5Atmosphere.cpp
@@ -47,8 +47,8 @@ void ERA5Atmosphere::configure()
 
     filePath = Configured::getConfiguration(keyMap.at(FILEPATH_KEY), std::string());
 
-    fluxImpl = &Module::getImplementation<IFluxCalculation>();
-    tryConfigure(fluxImpl);
+    fluxImpl = std::move(Module::getInstance<IFluxCalculation>());
+    tryConfigure(*fluxImpl);
 
     addChecks({
         { "tair", tairAccessor },
@@ -69,24 +69,21 @@ ConfigMap ERA5Atmosphere::getConfiguration() const
 
 void ERA5Atmosphere::update(const TimestepTime& tst)
 {
-    // TODO: Get more authoritative names for the forcings
-    std::set<std::string> forcings
-        = { "tair", "dew2m", "pair", "sw_in", "lw_in", "wind_speed", "u", "v" };
+    forcingState.update(tst.start);
 
-    // Read ERA5 forcings at the top of the hour
-    if (std::fmod((tst.start - TimePoint()).seconds(), 3600.) == 0.0_ft) {
-        forcingState = ParaGridIO::readForcingTimeStatic(forcings, tst.start, filePath);
-    }
-    tairAccessor.getHostRW() = forcingState.data.at("tair");
-    tdewAccessor.getHostRW() = forcingState.data.at("dew2m");
-    pairAccessor.getHostRW() = forcingState.data.at("pair");
-    sw_inAccessor.getHostRW() = forcingState.data.at("sw_in");
-    lw_inAccessor.getHostRW() = forcingState.data.at("lw_in");
-    windAccessor.getHostRW() = forcingState.data.at("wind_speed");
-    uwindAccessor.getHostRW() = forcingState.data.at("u");
-    vwindAccessor.getHostRW() = forcingState.data.at("v");
-    snowAccessor.getHostRW() = 0; // FIXME get snow data
-    rainAccessor.getHostRW() = 0; // FIXME get rain data
+    tairAccessor.getHostRW() = forcingState.getField(tAirName);
+    tdewAccessor.getHostRW() = forcingState.getField(dew2mName);
+    pairAccessor.getHostRW() = forcingState.getField(pAirName);
+    sw_inAccessor.getHostRW() = forcingState.getField(swInName);
+    lw_inAccessor.getHostRW() = forcingState.getField(lwInName);
+    uwindAccessor.getHostRW() = forcingState.getField(uName);
+    vwindAccessor.getHostRW() = forcingState.getField(vName);
+    snowAccessor.getHostRW() = forcingState.getField(snowName);
+    rainAccessor.getHostRW() = forcingState.getField(rainName);
+
+    windAccessor.getHostRW()
+        = (uwindAccessor.getHostRW().data().pow(2) + vwindAccessor.getHostRW().data().pow(2))
+              .sqrt();
 
     fluxImpl->update(tst);
 
@@ -103,6 +100,12 @@ void ERA5Atmosphere::setData(const ModelState::DataMap& ms)
 {
     IAtmosphereBoundary::setData(ms);
     fluxImpl->setData(ms);
+
+    ModelState state;
+    const ModelMetadata& metadata = ModelMetadata::getInstance();
+    metadata.affixCoordinates(state);
+    forcingState.setData(metadata.startTime(), filePath, ncLonName, ncLatName, ncTimeName, forcings,
+        vectors, state.data[longitudeName], state.data[latitudeName]);
 }
 
 } /* namespace Nextsim */

--- a/physics/src/modules/AtmosphereBoundaryModule/ERA5Atmosphere.cpp
+++ b/physics/src/modules/AtmosphereBoundaryModule/ERA5Atmosphere.cpp
@@ -4,6 +4,7 @@
 
 #include "include/ERA5Atmosphere.hpp"
 
+#include "include/constants.hpp"
 #include "include/Finalizer.hpp"
 #include "include/NextsimModule.hpp"
 #include "include/ParaGridIO.hpp"
@@ -71,8 +72,8 @@ void ERA5Atmosphere::update(const TimestepTime& tst)
 {
     forcingState.update(tst.start);
 
-    tairAccessor.getHostRW() = forcingState.getField(tAirName);
-    tdewAccessor.getHostRW() = forcingState.getField(dew2mName);
+    tairAccessor.getHostRW() = forcingState.getField(tAirName) - Water::Tf;
+    tdewAccessor.getHostRW() = forcingState.getField(dew2mName) - Water::Tf;
     pairAccessor.getHostRW() = forcingState.getField(pAirName);
     sw_inAccessor.getHostRW() = forcingState.getField(swInName);
     lw_inAccessor.getHostRW() = forcingState.getField(lwInName);

--- a/physics/src/modules/AtmosphereBoundaryModule/ERA5Atmosphere.cpp
+++ b/physics/src/modules/AtmosphereBoundaryModule/ERA5Atmosphere.cpp
@@ -79,8 +79,9 @@ void ERA5Atmosphere::update(const TimestepTime& tst)
     lw_inAccessor.getHostRW() = forcingState.getField(lwInName);
     uwindAccessor.getHostRW() = forcingState.getField(uName);
     vwindAccessor.getHostRW() = forcingState.getField(vName);
-    snowAccessor.getHostRW() = forcingState.getField(snowName);
-    rainAccessor.getHostRW() = forcingState.getField(rainName);
+    // TODO: Check the precipitation fields
+    snowAccessor.getHostRW() = 0.; // forcingState.getField(snowName);
+    rainAccessor.getHostRW() = 0.; // forcingState.getField(rainName);
 
     windAccessor.getHostRW()
         = (uwindAccessor.getHostRW().data().pow(2) + vwindAccessor.getHostRW().data().pow(2))

--- a/physics/src/modules/AtmosphereBoundaryModule/include/ERA5Atmosphere.hpp
+++ b/physics/src/modules/AtmosphereBoundaryModule/include/ERA5Atmosphere.hpp
@@ -10,6 +10,7 @@
 
 #include "include/Configured.hpp"
 #include "include/IFluxCalculation.hpp"
+#include "include/ParaGridInputs.hpp"
 
 namespace Nextsim {
 
@@ -37,14 +38,33 @@ public:
     //! Calculates the fluxes from the given values
     void update(const TimestepTime&) override;
 
-    void setFilePath(const std::string& filePathIn);
+    static void setFilePath(const std::string& filePathIn);
 
 private:
     // Since the configuration is global, it makes sense for the file path to
     // be static.
     static std::string filePath;
 
-    ModelState forcingState;
+    // A list of variable names for the ERA5 inputs
+    const std::string tAirName = "t2m";
+    const std::string dew2mName = "d2m";
+    const std::string pAirName = "msl";
+    const std::string swInName = "msdwswrf";
+    const std::string lwInName = "msdwlwrf";
+    const std::string snowName = "msr";
+    const std::string rainName = "mtpr";
+    const std::string uName = "u10";
+    const std::string vName = "v10";
+
+    const std::string ncLonName = "longitude";
+    const std::string ncLatName = "latitude";
+    const std::string ncTimeName = "time";
+
+    const std::set<std::string> forcings
+        = { tAirName, dew2mName, pAirName, swInName, lwInName, uName, vName };
+    const std::set<std::pair<std::string, std::string>> vectors = { { uName, vName } };
+
+    ParaGridInputs forcingState;
 
     ModelArrayAccessor<Protected::T_AIR, RW> tairAccessor;
     ModelArrayAccessor<Protected::DEW_2M, RW> tdewAccessor;
@@ -53,7 +73,7 @@ private:
     ModelArrayAccessor<Protected::LW_IN, RW> lw_inAccessor;
     ModelArrayAccessor<Protected::WIND_SPEED, RW> windAccessor;
 
-    IFluxCalculation* fluxImpl;
+    std::unique_ptr<IFluxCalculation> fluxImpl;
 };
 
 } /* namespace Nextsim */

--- a/physics/src/modules/OceanBoundaryModule/TOPAZOcean.cpp
+++ b/physics/src/modules/OceanBoundaryModule/TOPAZOcean.cpp
@@ -9,7 +9,6 @@
 #include "include/NextsimModule.hpp"
 #include "include/ParaGridIO.hpp"
 #include "include/constants.hpp"
-#include "include/gridNames.hpp"
 
 // testing
 #include "kokkos/include/KokkosTimer.hpp"
@@ -56,30 +55,30 @@ void TOPAZOcean::configure()
     tryConfigure(*pFreezingPoint);
 
     filePath = Configured::getConfiguration(keyMap.at(FILEPATH_KEY), std::string());
+    ModelState state;
+    ModelMetadata& metadata = ModelMetadata::getInstance();
+    metadata.affixCoordinates(state);
+    forcingState.configure(filePath, ncLonName, ncLatName, ncTimeName, forcings, vectors,
+        state.data[longitudeName], state.data[latitudeName]);
 
     slabOcean.configure();
 }
 
 ConfigMap TOPAZOcean::getConfiguration() const { return { { keyMap.at(FILEPATH_KEY), filePath } }; }
 
-static const std::set<std::string> forcings = { sstName, sssName, mldName, uName, vName, sshName };
-
 void TOPAZOcean::updateBefore(const TimestepTime& tst)
 {
-    // Read TOPAZ forcings at midnight
-    if (std::fmod((tst.start - TimePoint()).seconds(), 86400.) == 0.0_ft) {
-        forcingState = ParaGridIO::readForcingTimeStatic(forcings, tst.start, filePath);
-    }
+    forcingState.update(tst.start);
 
-    sstExtAccessor.getHostRW() = forcingState.data.at(sstName);
-    sssExtAccessor.getHostRW() = forcingState.data.at(sssName);
-    mldAccessor.getHostRW() = forcingState.data.at(mldName);
-    uAccessor.getHostRW() = forcingState.data.at(uName);
-    vAccessor.getHostRW() = forcingState.data.at(vName);
+    sstExtAccessor.getHostRW() = forcingState.getField(sstName);
+    sssExtAccessor.getHostRW() = forcingState.getField(sssName);
+    mldAccessor.getHostRW() = forcingState.getField(mldName);
+    uAccessor.getHostRW() = forcingState.getField(uName);
+    vAccessor.getHostRW() = forcingState.getField(vName);
     HField& ssh = sshAccessor.getHostRW();
 
-    if (forcingState.data.count(sshName)) {
-        ssh = forcingState.data.at(sshName);
+    if (forcingState.isValid(sshName)) {
+        ssh = forcingState.getField(sshName);
     } else {
         ssh = 0.;
     }

--- a/physics/src/modules/OceanBoundaryModule/TOPAZOcean.cpp
+++ b/physics/src/modules/OceanBoundaryModule/TOPAZOcean.cpp
@@ -55,11 +55,6 @@ void TOPAZOcean::configure()
     tryConfigure(*pFreezingPoint);
 
     filePath = Configured::getConfiguration(keyMap.at(FILEPATH_KEY), std::string());
-    ModelState state;
-    ModelMetadata& metadata = ModelMetadata::getInstance();
-    metadata.affixCoordinates(state);
-    forcingState.configure(filePath, ncLonName, ncLatName, ncTimeName, forcings, vectors,
-        state.data[longitudeName], state.data[latitudeName]);
 
     slabOcean.configure();
 }
@@ -128,6 +123,12 @@ void TOPAZOcean::setFilePath(const std::string& filePathIn) { filePath = filePat
 void TOPAZOcean::setData(const ModelState::DataMap& ms)
 {
     IOceanBoundary::setData(ms);
+
+    ModelState state;
+    const ModelMetadata& metadata = ModelMetadata::getInstance();
+    metadata.affixCoordinates(state);
+    forcingState.setData(metadata.startTime(), filePath, ncLonName, ncLatName, ncTimeName, forcings,
+        vectors, state.data[longitudeName], state.data[latitudeName]);
 
     HField& sstExt = sstExtAccessor.getHostRW();
     sstExt.reinitialize();

--- a/physics/src/modules/OceanBoundaryModule/include/TOPAZOcean.hpp
+++ b/physics/src/modules/OceanBoundaryModule/include/TOPAZOcean.hpp
@@ -63,12 +63,12 @@ private:
 
     // A list of variable names for the TOPAZ inputs
     // This overrides the canonical names in gridNames.hpp
-    const std::string sstName = "sst";
-    const std::string sssName = "sss";
-    const std::string mldName = "mld";
-    const std::string uName = "u";
-    const std::string vName = "v";
-    const std::string sshName = "ssh";
+    const std::string sstName = "thetao";
+    const std::string sssName = "so";
+    const std::string mldName = "mlotst";
+    const std::string uName = "vxo";
+    const std::string vName = "vyo";
+    const std::string sshName = "zos";
 
     const std::string ncLonName = "longitude";
     const std::string ncLatName = "latitude";

--- a/physics/src/modules/OceanBoundaryModule/include/TOPAZOcean.hpp
+++ b/physics/src/modules/OceanBoundaryModule/include/TOPAZOcean.hpp
@@ -10,6 +10,7 @@
 #include "include/IFreezingPoint.hpp"
 #include "include/IIceOceanHeatFlux.hpp"
 #include "include/IOceanBoundary.hpp"
+#include "include/ParaGridInputs.hpp"
 #include "include/SlabOcean.hpp"
 
 namespace Nextsim {
@@ -49,8 +50,6 @@ private:
     // be static.
     static std::string filePath;
 
-    ModelState forcingState;
-
     ModelArrayAccessor<Protected::EXT_SST, RW> sstExtAccessor;
     ModelArrayAccessor<Protected::EXT_SSS, RW> sssExtAccessor;
 
@@ -61,6 +60,24 @@ private:
 
     std::unique_ptr<IIceOceanHeatFlux> pIOHeatFlux;
     std::unique_ptr<IFreezingPoint> pFreezingPoint;
+
+    // A list of variable names for the TOPAZ inputs
+    // This overrides the canonical names in gridNames.hpp
+    const std::string sstName = "sst";
+    const std::string sssName = "sss";
+    const std::string mldName = "mld";
+    const std::string uName = "u";
+    const std::string vName = "v";
+    const std::string sshName = "ssh";
+
+    const std::string ncLonName = "longitude";
+    const std::string ncLatName = "latitude";
+    const std::string ncTimeName = "time";
+
+    const std::set<std::string> forcings = { sstName, sssName, mldName, uName, vName, sshName };
+    const std::set<std::pair<std::string, std::string>> vectors = { { uName, vName } };
+
+    ParaGridInputs forcingState;
 };
 
 } /* namespace Nextsim */

--- a/run/flood_TOPAZ.py
+++ b/run/flood_TOPAZ.py
@@ -1,0 +1,55 @@
+import glob, os
+import xarray as xr
+from pathlib import Path
+
+"""
+Create a flooded version of TOPAZ input files. Assume we have a directory structure like this:
+
+daily_mean
+├── 2006
+│   ├── topaz_rean_200610.nc
+│   ├── topaz_rean_200611.nc
+│   └── topaz_rean_200612.nc
+└── 2007
+    ├── topaz_rean_200701.nc
+    ├── topaz_rean_200702.nc
+    ├── topaz_rean_200703.nc
+    ├── topaz_rean_200704.nc
+    └── topaz_rean_200705.nc
+    
+and create this:
+
+daily_mean_flooded
+├── 2006
+│   ├── topaz_rean_200610.nc
+│   ├── topaz_rean_200611.nc
+│   └── topaz_rean_200612.nc
+└── 2007
+    ├── topaz_rean_200701.nc
+    ├── topaz_rean_200702.nc
+    ├── topaz_rean_200703.nc
+    ├── topaz_rean_200704.nc
+    └── topaz_rean_200705.nc
+"""
+
+# Create an output directory. Fail if it exists
+out_dir = root_dir.rstrip('/') + '_flooded'
+os.makedirs(out_dir, exist_ok=False)
+
+# Just pick a random netCDF in "dir" to build the FloodInterpolator
+ds = xr.load_dataset(list(Path(root_dir).rglob("*.nc"))[0])
+flooder = FloodInterpolator(ds.x.values, ds.y.values, ds.mask.values.astype(bool))
+ds.close()
+
+for dir in glob.glob(root_dir + '/*'):
+    basedir = os.path.basename(dir)
+    os.mkdir(out_dir + '/' + basedir)
+    for file in glob.glob(root_dir + '/' + basedir + '/*.nc'):
+        ds = xr.open_dataset(file)
+        flooder.flood_dataset(ds)
+        flooder.flood_zeros(ds, ['vxo', 'vyo', 'vxsi', 'vysi'])
+
+        encoding = {var: {"zlib": True, "complevel": 9, "shuffle": True} for var in ds.data_vars}
+        print(os.path.join(out_dir, basedir, os.path.basename(file)))
+        ds.to_netcdf(os.path.join(out_dir, basedir, os.path.basename(file)), encoding=encoding)
+        ds.close()

--- a/run/flood_TOPAZ.py
+++ b/run/flood_TOPAZ.py
@@ -1,6 +1,8 @@
-import glob, os
-import xarray as xr
+import glob
+import os
 from pathlib import Path
+
+import xarray as xr
 
 """
 Create a flooded version of TOPAZ input files. Assume we have a directory structure like this:
@@ -16,7 +18,7 @@ daily_mean
     ├── topaz_rean_200703.nc
     ├── topaz_rean_200704.nc
     └── topaz_rean_200705.nc
-    
+
 and create this:
 
 daily_mean_flooded
@@ -33,23 +35,27 @@ daily_mean_flooded
 """
 
 # Create an output directory. Fail if it exists
-out_dir = root_dir.rstrip('/') + '_flooded'
+out_dir = root_dir.rstrip("/") + "_flooded"
 os.makedirs(out_dir, exist_ok=False)
 
-# Just pick a random netCDF in "dir" to build the FloodInterpolator
-ds = xr.load_dataset(list(Path(root_dir).rglob("*.nc"))[0])
+# Just pick a random netCDF in "root_dir" to build the FloodInterpolator
+ds = xr.load_dataset(next(iter(Path(root_dir).rglob("*.nc"))))
 flooder = FloodInterpolator(ds.x.values, ds.y.values, ds.mask.values.astype(bool))
 ds.close()
 
-for dir in glob.glob(root_dir + '/*'):
-    basedir = os.path.basename(dir)
-    os.mkdir(out_dir + '/' + basedir)
-    for file in glob.glob(root_dir + '/' + basedir + '/*.nc'):
+for directory in glob.glob(root_dir + "/*"):
+    basedir = os.path.basename(directory)
+    os.mkdir(out_dir + "/" + basedir)
+    for file in glob.glob(root_dir + "/" + basedir + "/*.nc"):
         ds = xr.open_dataset(file)
         flooder.flood_dataset(ds)
-        flooder.flood_zeros(ds, ['vxo', 'vyo', 'vxsi', 'vysi'])
+        flooder.flood_zeros(ds, ["vxo", "vyo", "vxsi", "vysi"])
 
-        encoding = {var: {"zlib": True, "complevel": 9, "shuffle": True} for var in ds.data_vars}
+        encoding = {
+            var: {"zlib": True, "complevel": 9, "shuffle": True} for var in ds.data_vars
+        }
         print(os.path.join(out_dir, basedir, os.path.basename(file)))
-        ds.to_netcdf(os.path.join(out_dir, basedir, os.path.basename(file)), encoding=encoding)
+        ds.to_netcdf(
+            os.path.join(out_dir, basedir, os.path.basename(file)), encoding=encoding
+        )
         ds.close()

--- a/run/flooding.py
+++ b/run/flooding.py
@@ -13,12 +13,14 @@ class FloodInterpolator:
 
     def __init__(self, x, y, land_mask):
         """
-        Initialise an object containing the Delaunay triangulation used for flooding. Example usage:
+        Initialise an object containing the Delaunay triangulation used for flooding.
+
+        Example usage:
 
         >> from flooding import FloodInterpolator
         >> flooder = FloodInterpolator(ds.x.values, ds.y.values, ds.mask.values.astype(bool))
 
-        where ds is an xarray Dataset object containing the selected variables.
+        where ds is a xarray Dataset object containing the selected variables.
 
         Parameters
         ----------
@@ -29,13 +31,14 @@ class FloodInterpolator:
         land_mask : (ny,nx) bool
             True over land, False over ocean.
         """
-        self.A, self.ocean, self.land, self.valid = self.__build_flood_operator(x, y, land_mask)
+        self.A, self.ocean, self.land, self.valid = self.__build_flood_operator(
+            x, y, land_mask
+        )
         self.land_mask = land_mask
 
     def __build_flood_operator(self, x, y, land_mask):
         """
-        Construct a sparse interpolation operator that floods land cells
-        from neighbouring ocean cells using linear interpolation.
+        Construct a sparse interpolation operator that floods land cells from neighbouring ocean cells using linear interpolation.
 
         Parameters
         ----------
@@ -57,7 +60,6 @@ class FloodInterpolator:
         valid : bool array
             Land points inside the convex hull.
         """
-
         ocean = ~land_mask
         land = land_mask
 
@@ -82,7 +84,10 @@ class FloodInterpolator:
 
         rows = np.repeat(np.arange(valid.sum()), 3)
 
-        A = csr_matrix((weights.ravel(), (rows, vertices.ravel())), shape=(valid.sum(), ocean.sum()))
+        A = csr_matrix(
+            (weights.ravel(), (rows, vertices.ravel())),
+            shape=(valid.sum(), ocean.sum()),
+        )
 
         return A, ocean, land, valid
 
@@ -97,7 +102,6 @@ class FloodInterpolator:
             correspond to the grid used to build the interpolation operator.
             The input array is modified in place.
         """
-
         nland = self.land.sum()
 
         # Choose an appropriate floating-point dtype
@@ -105,13 +109,11 @@ class FloodInterpolator:
         filled_land = np.empty(nland, dtype=dtype)
 
         if data.ndim == 2:
-
             filled_land.fill(np.nan)
             filled_land[self.valid] = self.A @ data[self.ocean]
             data[self.land] = filled_land
 
         else:
-
             for index in np.ndindex(data.shape[:-2]):
                 field = data[index]
 
@@ -122,18 +124,18 @@ class FloodInterpolator:
 
         return data
 
-    def flood_dataset(self, ds, fields = "all"):
+    def flood_dataset(self, ds, fields="all"):
         """
-        Flood selected variables of an xarray dataset.
+        Flood selected variables of a xarray dataset.
 
         Parameters
         ----------
-        ds : xarray dataset to be flooded.
+        ds : xarray dataset
+            The dataset to be flooded.
         fields : iterable of str
             A list of the variable names to be flooded, or the keyword "all" to
             process all fields which have more than two dimensions.
         """
-
         my_fields = []
         if fields == "all":
             for var in list(ds.variables):
@@ -147,14 +149,14 @@ class FloodInterpolator:
 
     def flood_zeros(self, ds, fields):
         """
-        Flood selected variables of an xarray dataset with zeros
+        Flood selected variables of a xarray dataset with zeros.
 
         Parameters
         ----------
-        ds : xarray dataset to be flooded.
+        ds : xarray dataset
+            The dataset to be flooded.
         fields : iterable of str
             A list of the variable names to be flooded.
         """
-
         for var in fields:
             ds[var].values[np.stack([self.land_mask] * ds[var].values.shape[0])] = 0

--- a/run/flooding.py
+++ b/run/flooding.py
@@ -1,0 +1,160 @@
+import numpy as np
+from scipy.sparse import csr_matrix
+from scipy.spatial import Delaunay
+
+
+class FloodInterpolator:
+    """
+    Flood land cells using a precomputed Delaunay interpolation operator.
+
+    The expensive geometric preprocessing is performed once during
+    construction and can then be reused to flood any number of fields.
+    """
+
+    def __init__(self, x, y, land_mask):
+        """
+        Initialise an object containing the Delaunay triangulation used for flooding. Example usage:
+
+        >> from flooding import FloodInterpolator
+        >> flooder = FloodInterpolator(ds.x.values, ds.y.values, ds.mask.values.astype(bool))
+
+        where ds is an xarray Dataset object containing the selected variables.
+
+        Parameters
+        ----------
+        x : (nx,) array
+            x coordinates
+        y : (ny,) array
+            y coordinates
+        land_mask : (ny,nx) bool
+            True over land, False over ocean.
+        """
+        self.A, self.ocean, self.land, self.valid = self.__build_flood_operator(x, y, land_mask)
+        self.land_mask = land_mask
+
+    def __build_flood_operator(self, x, y, land_mask):
+        """
+        Construct a sparse interpolation operator that floods land cells
+        from neighbouring ocean cells using linear interpolation.
+
+        Parameters
+        ----------
+        x : (nx,) array
+            x coordinates
+        y : (ny,) array
+            y coordinates
+        land_mask : (ny,nx) bool
+            True over land, False over ocean.
+
+        Returns
+        -------
+        A : csr_matrix
+            Sparse interpolation matrix.
+        ocean : bool array
+            Ocean mask.
+        land : bool array
+            Land mask.
+        valid : bool array
+            Land points inside the convex hull.
+        """
+
+        ocean = ~land_mask
+        land = land_mask
+
+        X, Y = np.meshgrid(x, y)
+
+        pts = np.c_[X[ocean], Y[ocean]]
+        targets = np.c_[X[land], Y[land]]
+
+        tri = Delaunay(pts)
+
+        simplex = tri.find_simplex(targets)
+        valid = simplex >= 0
+
+        vertices = tri.simplices[simplex[valid]]
+
+        T = tri.transform[simplex[valid]]
+        delta = targets[valid] - T[:, 2]
+
+        bary = np.einsum("ijk,ik->ij", T[:, :2], delta)
+
+        weights = np.column_stack((bary, 1.0 - bary.sum(axis=1)))
+
+        rows = np.repeat(np.arange(valid.sum()), 3)
+
+        A = csr_matrix((weights.ravel(), (rows, vertices.ravel())), shape=(valid.sum(), ocean.sum()))
+
+        return A, ocean, land, valid
+
+    def flood_field(self, data):
+        """
+        Flood a field using a precomputed sparse interpolation operator.
+
+        Parameters
+        ----------
+        data : ndarray
+            Array with shape (..., ny, nx). The last two dimensions must
+            correspond to the grid used to build the interpolation operator.
+            The input array is modified in place.
+        """
+
+        nland = self.land.sum()
+
+        # Choose an appropriate floating-point dtype
+        dtype = np.result_type(data.dtype, np.float32)
+        filled_land = np.empty(nland, dtype=dtype)
+
+        if data.ndim == 2:
+
+            filled_land.fill(np.nan)
+            filled_land[self.valid] = self.A @ data[self.ocean]
+            data[self.land] = filled_land
+
+        else:
+
+            for index in np.ndindex(data.shape[:-2]):
+                field = data[index]
+
+                filled_land.fill(np.nan)
+                filled_land[self.valid] = self.A @ field[self.ocean]
+
+                field[self.land] = filled_land
+
+        return data
+
+    def flood_dataset(self, ds, fields = "all"):
+        """
+        Flood selected variables of an xarray dataset.
+
+        Parameters
+        ----------
+        ds : xarray dataset to be flooded.
+        fields : iterable of str
+            A list of the variable names to be flooded, or the keyword "all" to
+            process all fields which have more than two dimensions.
+        """
+
+        my_fields = []
+        if fields == "all":
+            for var in list(ds.variables):
+                if len(ds.variables[var].dims) > 2:
+                    my_fields.append(var)
+        else:
+            my_fields = fields
+
+        for var in my_fields:
+            self.flood_field(ds[var].values)
+
+    def flood_zeros(self, ds, fields):
+        """
+        Flood selected variables of an xarray dataset with zeros
+
+        Parameters
+        ----------
+        ds : xarray dataset to be flooded.
+        fields : iterable of str
+            A list of the variable names to be flooded.
+        """
+
+        for var in fields:
+            ds[var].values[np.stack([self.land_mask] * ds[var].values.shape[0])] = 0

--- a/run/interpolators.py
+++ b/run/interpolators.py
@@ -30,15 +30,7 @@ def topaz4_interpolate(target_lon, target_lat, data, data_x, data_y, proj_string
 
     field = interpolate.griddata(points, data.ravel()[nanmask], xi)
 
-    # Use griddata again to extrapolate outside the convex hull using the nearest neighbour
-    nanmask = ~np.isnan(field)
-
-    points = np.array([target_x.ravel()[nanmask], target_y.ravel()[nanmask]]).T
-    xi = np.array([target_x.ravel(), target_y.ravel()]).T
-
-    return interpolate.griddata(
-        points, field.ravel()[nanmask], xi, method="nearest"
-    ).reshape(target_lon.shape)
+    return field.reshape(target_lon.shape)
 
 
 def bilinear(eyes, jays, data):

--- a/run/make_init_geographic.py
+++ b/run/make_init_geographic.py
@@ -1,8 +1,10 @@
-import time
-from pathlib import Path
+#! /usr/bin/env python3
 
 import netCDF4
 import numpy as np
+import time
+from pathlib import Path
+
 from interpolators import topaz4_interpolate
 from make_init_base import initMaker
 
@@ -75,13 +77,13 @@ if __name__ == "__main__":
 
     if args.grid_type == "regular":
         init_base.make_geographic_grid(
-            grid_name + ".nc", "p", plon_name="plon", plat_name="plat"
+            grid_file, "p", plon_name="plon", plat_name="plat"
         )
-        mask = netCDF4.Dataset(grid_name + ".nc", "r")
+        mask = netCDF4.Dataset(grid_file, "r")
         init_base.mask[:, :] = mask["mask"][:, :]
     elif args.grid_type == "NEMO":
         init_base.make_geographic_grid(
-            grid_name + ".nc",
+            grid_file,
             "ur",
             plon_name="glamt",
             plat_name="gphit",
@@ -169,3 +171,5 @@ if __name__ == "__main__":
         source_y,
         proj_string,
     )
+
+    init_base.mask[:, :] *= ~np.isnan(init_base.sst[:, :])

--- a/run/make_init_geographic.py
+++ b/run/make_init_geographic.py
@@ -1,10 +1,10 @@
 #! /usr/bin/env python3
 
-import netCDF4
-import numpy as np
 import time
 from pathlib import Path
 
+import netCDF4
+import numpy as np
 from interpolators import topaz4_interpolate
 from make_init_base import initMaker
 


### PR DESCRIPTION
# Bilinear interpolation for ParaGrid

Fixes subs 1 and 2 of #1101 

### Task List
- [x] Linked an issue above that captures the requirements of this PR
- [ ] Defined the tests that specify a complete and functioning change
- [ ] Implemented the source code change that satisfies the tests
- [x] Commented all code so that it can be understood without additional context
- [x] No new warnings are generated or they are mentioned below
- [ ] The documentation has been updated (or an issue has been created to do so)
- [x] Relevant labels (e.g., enhancement, bug) have been applied to this PR
- [x] This change conforms to the conventions described in the README

---
# Change Description

I've implemented a new class for reading in forcing data, called ParaGridInputs. The name will change, and this class will be integrated into the IParaGridIO interface later. The idea here is to submit the initial working example to a different branch, so the final PR won't be too large.

Key changes:
 - A new class for reading data in from the "raw" netCDF files for TOPAZ4 and ERA5
 - Bilinear interpolation for both lat/lon grids and grids with lat and lon as 2D arrays.
 - TOPAZOCean and ERA5Atmosphere both use this class now
 - Python scripts to "flood" the TOPAZ4 fields to handle mismatches in land mask

---
# Test Description

No tests so far, beyond checking that the interpolated fields look ok on output. The vectors still point in the wrong directions, so don't expect dynamics to run correctly for very long.

---
# Documentation Impact

Documentation about using different I/O interfaces needs to come later.

---
# Other Details

Switching between different I/O interfaces and vector rotation comes later.
