### PR TITLE
Use GitLab repository for XIOS

### DIFF
--- a/Dockerfiles/Dockerfile.devenv
+++ b/Dockerfiles/Dockerfile.devenv
@@ -22,6 +22,11 @@ RUN cd /opt/spack-environment \
     && spack install --fail-fast \
     && spack gc -y
 
+# Add the view `lib` to the LD_LIBRARY_PATH
+# This is required to make `ncgen` find  the libraries correctly
+# see: https://github.com/spack/spack/issues/52555
+ENV LD_LIBRARY_PATH=/opt/views/view/lib:$LD_LIBRARY_PATH
+
 # Download and install domain_decomp and XIOS
 COPY Dockerfiles/install-xios.sh .
 RUN spack env activate /opt/spack-environment \
@@ -56,9 +61,12 @@ COPY --from=builder /usr /usr
 COPY --from=builder /opt/views /opt/views
 
 # Create entrypoint script
+# We need to explicitly point ncgen to the view libraries:
+# https://github.com/spack/spack/issues/52555
 RUN { \
       echo '#!/bin/sh'; \
       echo '. /opt/spack-environment/activate.sh'; \
+      echo 'export LD_LIBRARY_PATH=/opt/views/view/lib:$LD_LIBRARY_PATH'; \
       echo 'exec "$@"'; \
     } > /entrypoint.sh \
     && chmod a+x /entrypoint.sh \

--- a/Dockerfiles/Dockerfile.devenv
+++ b/Dockerfiles/Dockerfile.devenv
@@ -7,7 +7,7 @@ RUN apt update \
     && rm -rf /var/lib/apt/lists/*
 
 # Pre-fetch XIOS source code
-RUN svn checkout http://forge.ipsl.fr/ioserver/svn/XIOS3/trunk /xios
+RUN git clone --branch xios-3.0.6.0 https://gitlab.in2p3.fr/ipsl/projets/xios-projects/xios.git /xios
 
 # Install software from spack.yaml
 RUN mkdir /opt/spack-environment

--- a/Dockerfiles/Dockerfile.devenv
+++ b/Dockerfiles/Dockerfile.devenv
@@ -9,6 +9,11 @@ RUN apt update \
 # Pre-fetch XIOS source code
 RUN git clone --branch xios-3.0.6.0 https://gitlab.in2p3.fr/ipsl/projets/xios-projects/xios.git /xios
 
+# The ftpmirror.gnu.org is unreliable and often fails to point to a live mirror (returns 502 HTTP error)
+# To avoid this problem we patch the Spack recipe to use the cannonical GNU FTP server
+RUN find . -type f -path "*/package_repos/*/readline/package.py" \
+  -exec sed -i 's|https://ftpmirror.gnu.org|https://ftp.gnu.org/gnu|w /dev/stdout' '{}' \;
+
 # Install software from spack.yaml
 RUN mkdir /opt/spack-environment
 COPY Dockerfiles/spack.yaml /opt/spack-environment/spack.yaml

--- a/Dockerfiles/Dockerfile.devenv
+++ b/Dockerfiles/Dockerfile.devenv
@@ -6,9 +6,6 @@ RUN apt update \
     && apt install -y --no-install-recommends libany-uri-escape-perl \
     && rm -rf /var/lib/apt/lists/*
 
-# Pre-fetch XIOS source code
-RUN git clone --branch xios-3.0.6.0 https://gitlab.in2p3.fr/ipsl/projets/xios-projects/xios.git /xios
-
 # The ftpmirror.gnu.org is unreliable and often fails to point to a live mirror (returns 502 HTTP error)
 # To avoid this problem we patch the Spack recipe to use the cannonical GNU FTP server
 RUN find . -type f -path "*/package_repos/*/readline/package.py" \
@@ -27,8 +24,11 @@ RUN cd /opt/spack-environment \
 # see: https://github.com/spack/spack/issues/52555
 ENV LD_LIBRARY_PATH=/opt/views/view/lib:$LD_LIBRARY_PATH
 
-# Download and install domain_decomp and XIOS
+# Pre-fetch XIOS source code
 COPY Dockerfiles/install-xios.sh .
+RUN git clone --branch xios-3.0.6.0 https://gitlab.in2p3.fr/ipsl/projets/xios-projects/xios.git /xios
+
+# Download and install domain_decomp and XIOS
 RUN spack env activate /opt/spack-environment \
     && git clone https://github.com/nextsimhub/domain_decomp.git /decomp \
     && cd /decomp \

--- a/Dockerfiles/Dockerfile.devenv
+++ b/Dockerfiles/Dockerfile.devenv
@@ -1,9 +1,9 @@
 # Build stage with Spack pre-installed and ready to be used
 FROM spack/ubuntu-noble:latest AS builder
 
-# Install perl and subversion
+# Install perl
 RUN apt update \
-    && apt install -y --no-install-recommends libany-uri-escape-perl subversion \
+    && apt install -y --no-install-recommends libany-uri-escape-perl \
     && rm -rf /var/lib/apt/lists/*
 
 # Pre-fetch XIOS source code

--- a/Dockerfiles/install-xios.sh
+++ b/Dockerfiles/install-xios.sh
@@ -8,9 +8,9 @@ if [ ! -d ${INSTALL_DIR} ]; then
   INSTALL_DIR="XIOS3"
 fi
 
-# If install directory doesn't exist, checkout the latest version
+# If install directory doesn't exist, clone the pinned version
 if [ ! -d ${INSTALL_DIR} ]; then
-  svn checkout http://forge.ipsl.fr/ioserver/svn/XIOS3/trunk "${INSTALL_DIR}"
+  git clone --branch xios-3.0.6.0 https://gitlab.in2p3.fr/ipsl/projets/xios-projects/xios.git "${INSTALL_DIR}"
 fi
 cd "${INSTALL_DIR}" || exit
 

--- a/Dockerfiles/install-xios.sh
+++ b/Dockerfiles/install-xios.sh
@@ -82,6 +82,9 @@ EOF
 # Build XIOS on a Linux operating system with the GCC compiler
 ./make_xios --arch GCC_LINUX --job 8 --full --debug
 
+# Return to the previous directory
+cd -
+
 # Clean up files not needed
 rm -r \
   "${INSTALL_DIR}/arch" \

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -51,8 +51,8 @@ You must have root privilege :
 .. code::
 
         sudo apt-get update
-        sudo apt-get install netcdf-bin libnetcdf-c++4-dev libboost-all-dev cmake subversion libeigen3-dev
-        svn checkout http://forge.ipsl.fr/ioserver/svn/XIOS3/trunk xios
+        sudo apt-get install netcdf-bin libnetcdf-c++4-dev libboost-all-dev cmake git libeigen3-dev
+        git clone --branch xios-3.0.6.0 https://gitlab.in2p3.fr/ipsl/projets/xios-projects/xios.git xios
         cd xios
         ./make_xios --arch <your_architecture> --job <number_of_jobs>
 

--- a/docs/xios.rst
+++ b/docs/xios.rst
@@ -11,7 +11,7 @@ widely used in the climate modelling community. While it is traditionally
 configured using user-provided XML files, nextSIM-DG configures it directly with
 API calls to reduce user requirements.
 
-.. _XIOS: https://forge.ipsl.fr/ioserver
+.. _XIOS: https://gitlab.in2p3.fr/ipsl/projets/xios-projects/xios
 
 The integration of XIOS into nextSIM-DG is built around a static ``Xios``
 handler class, which provides a C++ API for the various XIOS functions. When the


### PR DESCRIPTION
# Use GitLab repository for XIOS

Fixes #1099 

### Task List
- [x] Linked an issue above that captures the requirements of this PR
- [] ~~Defined the tests that specify a complete and functioning change~~
- [] ~~Implemented the source code change that satisfies the tests~~
- [] ~~Commented all code so that it can be understood without additional context~~
- [] ~~No new warnings are generated or they are mentioned below~~
- [x] The documentation has been updated (or an issue has been created to do so)
- [ ] Relevant labels (e.g., enhancement, bug) have been applied to this PR
- [x] This change conforms to the conventions described in the README

---
# Change Description

Uses the new recommended repository for XIOS. 

I have pinned the version to `3.0.6.0` for now. I will need to double check which was the one we were fetching before. I guess `trank` would correspond to main, but in that case it may be good idea to pin the version to some stable release tag.

---
# Test Description

N/A

---
# Documentation Impact

Installation instructions need to be amended. (Not done yet)

---
# Other Details

Affects the Docker images and Docker build CI.