### PR TITLE
Issue1088 slab ocean bug

### DIFF
--- a/core/src/ModelArray.cpp
+++ b/core/src/ModelArray.cpp
@@ -342,7 +342,8 @@ void ModelArray::checkLimits(const ModelArray& mask) const
 
     throw std::runtime_error("Field contains out-of-bounds value(s), " + std::to_string(value)
         + " not in [" + std::to_string(lowerPhysicalLimit) + ","
-        + std::to_string(upperPhysicalLimit) + "]. Error at index " + locStr + ".");
+        + std::to_string(upperPhysicalLimit) + "]. Error at " + locStr + " and index "
+        + std::to_string(i) + ".\n");
 }
 
 void ModelArray::validateMaps()

--- a/physics/src/SlabOcean.cpp
+++ b/physics/src/SlabOcean.cpp
@@ -128,10 +128,8 @@ void SlabOcean::update(const TimestepTime& tst)
         // a template function: "Water::rhoOcean" is undefined in device code"
         const FloatType rhoOcean = Water::rhoOcean;
         // Mass per unit area after all the changes in water volume
-        // Clamp the denominator to be at least 1 m deep, i.e. at least Water::rho kg m⁻²
-        const FloatType denominator
-            = Utils::max(arealDensity - (fwFlux[i] - fdw[i]) * dt, rhoOcean);
-        sssSlab[i] = (sss[i] * arealDensity - sFlux[i] * dt) / denominator;
+        sssSlab[i]
+            = (sss[i] * arealDensity - sFlux[i] * dt) / (arealDensity - (fwFlux[i] - fdw[i]) * dt);
     });
     timer.stop();
 }

--- a/physics/src/SlabOcean.cpp
+++ b/physics/src/SlabOcean.cpp
@@ -97,6 +97,7 @@ void SlabOcean::update(const TimestepTime& tst)
     auto& qdw = qdwAccessor.getAutoRW(execSpace);
     auto& sssSlab = sssSlabAccessor.getAutoRW(execSpace);
     const auto& fwFlux = fwFluxAccessor.getAutoRO(execSpace);
+    const auto& sFlux = sFluxAccessor.getAutoRO(execSpace);
     const auto& sssExt = sssExtAccessor.getAutoRO(execSpace);
     const auto& sst = sstAccessor.getAutoRO(execSpace);
     const auto& sstExt = sstExtAccessor.getAutoRO(execSpace);
@@ -120,6 +121,7 @@ void SlabOcean::update(const TimestepTime& tst)
         // This is simplified compared to the finiteelement.cpp calculation
         // Fdw = delS * mld * physical::rhow /(timeS*M_sss[i] - ddt*delS) where delS = sssSlab -
         // sssExt
+        // See e.g. Griffies (2004), p233
         fdw[i] = (1 - sssExt[i] / sss[i]) * arealDensity / relaxationTimeS;
 
         // the device compiler does not like a global constant appearing in the argument list of
@@ -129,7 +131,7 @@ void SlabOcean::update(const TimestepTime& tst)
         // Clamp the denominator to be at least 1 m deep, i.e. at least Water::rho kg m⁻²
         const FloatType denominator
             = Utils::max(arealDensity - (fwFlux[i] - fdw[i]) * dt, rhoOcean);
-        sssSlab[i] = sss[i] + (sss[i] * (fwFlux[i] - fdw[i]) * dt) / denominator;
+        sssSlab[i] = (sss[i] * arealDensity - sFlux[i] * dt) / denominator;
     });
     timer.stop();
 }

--- a/physics/src/SlabOcean.cpp
+++ b/physics/src/SlabOcean.cpp
@@ -107,12 +107,12 @@ void SlabOcean::update(const TimestepTime& tst)
     const auto& cpml = cpmlAccessor.getAutoRO(execSpace);
 
     const FloatType dt = tst.step.seconds();
-    const FloatType relaxationTimeT = SlabOcean::relaxationTimeT;
-    const FloatType relaxationTimeS = SlabOcean::relaxationTimeS;
+    const FloatType rRelaxationTimeT = 1. / relaxationTimeT;
+    const FloatType rRelaxationTimeS = 1. / relaxationTimeS;
 
     overElementsAuto(OVER_ELEMENTS_LAMBDA(const ElementIndex i) {
         // Slab SST update
-        qdw[i] = (sstExt[i] - sst[i]) * cpml[i] / relaxationTimeT;
+        qdw[i] = (sstExt[i] - sst[i]) * cpml[i] * rRelaxationTimeT;
         sstSlab[i] = sst[i] - dt * (qswNet[i] + qNoSun[i] - qdw[i]) / cpml[i];
 
         // Slab SSS update
@@ -122,7 +122,7 @@ void SlabOcean::update(const TimestepTime& tst)
         // Fdw = delS * mld * physical::rhow /(timeS*M_sss[i] - ddt*delS) where delS = sssSlab -
         // sssExt
         // See e.g. Griffies (2004), p233
-        fdw[i] = (1 - sssExt[i] / sss[i]) * arealDensity / relaxationTimeS;
+        fdw[i] = (1 - sssExt[i] / sss[i]) * arealDensity * rRelaxationTimeS;
 
         // the device compiler does not like a global constant appearing in the argument list of
         // a template function: "Water::rhoOcean" is undefined in device code"

--- a/physics/src/SlabOcean.cpp
+++ b/physics/src/SlabOcean.cpp
@@ -15,7 +15,7 @@
 
 namespace Nextsim {
 
-const FloatType SlabOcean::defaultRelaxationTime = 30 * 24 * 60 * 60; // 30 days in seconds
+const FloatType SlabOcean::defaultRelaxationTime = 30; // 30 days in seconds
 
 // Configuration strings
 static const std::string className = "SlabOcean";
@@ -64,10 +64,10 @@ SlabOcean::HelpMap& SlabOcean::getHelpText(HelpMap& map, bool getAll)
 {
     map[className] = {
         { keyMap.at(TIMET_KEY), ConfigType::NUMERIC, { "0", "∞" },
-            ConfigurationHelp::toString(defaultRelaxationTime), "s",
+            ConfigurationHelp::toString(defaultRelaxationTime), "days",
             "Relaxation time of the slab ocean to external temperature forcing." },
         { keyMap.at(TIMES_KEY), ConfigType::NUMERIC, { "0", "∞" },
-            ConfigurationHelp::toString(defaultRelaxationTime), "s",
+            ConfigurationHelp::toString(defaultRelaxationTime), "days",
             "Relaxation time of the slab ocean to external salinity forcing." },
     };
     return map;
@@ -107,8 +107,8 @@ void SlabOcean::update(const TimestepTime& tst)
     const auto& cpml = cpmlAccessor.getAutoRO(execSpace);
 
     const FloatType dt = tst.step.seconds();
-    const FloatType rRelaxationTimeT = 1. / relaxationTimeT;
-    const FloatType rRelaxationTimeS = 1. / relaxationTimeS;
+    const FloatType rRelaxationTimeT = 1 / (relaxationTimeT * 86400);
+    const FloatType rRelaxationTimeS = 1 / (relaxationTimeS * 86400);
 
     overElementsAuto(OVER_ELEMENTS_LAMBDA(const ElementIndex i) {
         // Slab SST update
@@ -129,6 +129,10 @@ void SlabOcean::update(const TimestepTime& tst)
         sssSlab[i] = (sss[i] * arealDensity - 1e3_ft * sFlux[i] * dt)
             / (arealDensity - (fwFlux[i] - fdw[i]) * dt);
     });
+    constexpr size_t i = 52619;
+    std::cout << "SSS: " << sss[i] << " fwFlux: " << fwFlux[i] << " sFlux: " << sFlux[i]
+              << " mld: " << cpml[i] / Water::cp / Water::rhoOcean << std::endl;
+
     timer.stop();
 }
 

--- a/physics/src/SlabOcean.cpp
+++ b/physics/src/SlabOcean.cpp
@@ -124,9 +124,6 @@ void SlabOcean::update(const TimestepTime& tst)
         // See e.g. Griffies (2004), p233
         fdw[i] = (1 - sssExt[i] / sss[i]) * arealDensity * rRelaxationTimeS;
 
-        // the device compiler does not like a global constant appearing in the argument list of
-        // a template function: "Water::rhoOcean" is undefined in device code"
-        const FloatType rhoOcean = Water::rhoOcean;
         // Mass per unit area after all the changes in water volume
         sssSlab[i]
             = (sss[i] * arealDensity - sFlux[i] * dt) / (arealDensity - (fwFlux[i] - fdw[i]) * dt);

--- a/physics/src/SlabOcean.cpp
+++ b/physics/src/SlabOcean.cpp
@@ -118,16 +118,17 @@ void SlabOcean::update(const TimestepTime& tst)
         // Slab SSS update
         const FloatType arealDensity
             = cpml[i] / Water::cp; // density times depth, or cpml divided by cp
-        // This is simplified compared to the finiteelement.cpp calculation
-        // Fdw = delS * mld * physical::rhow /(timeS*M_sss[i] - ddt*delS) where delS = sssSlab -
-        // sssExt
-        // See e.g. Griffies (2004), p233
-        fdw[i] = (1 - sssExt[i] / sss[i]) * arealDensity * rRelaxationTimeS;
+        /* Just use a salt flux as the nudging flux. This is simplified compared to the
+         * finiteelement.cpp calculation
+         * Fdw = delS * mld * physical::rhow /(timeS*M_sss[i] - ddt*delS)
+         * where delS = sssSlab - sssExt
+         */
+        fdw[i] = (sssExt[i] - sss[i]) * arealDensity * rRelaxationTimeS;
 
         // Mass per unit area after all the changes in water volume
         // sFlux is in kg/m^2/s, but we need PSU/m^2/s
-        sssSlab[i] = (sss[i] * arealDensity - 1e3_ft * sFlux[i] * dt)
-            / (arealDensity - (fwFlux[i] - fdw[i]) * dt);
+        sssSlab[i] = (sss[i] * arealDensity - 1e3_ft * sFlux[i] * dt + fdw[i])
+            / (arealDensity - fwFlux[i] * dt);
     });
     timer.stop();
 }

--- a/physics/src/SlabOcean.cpp
+++ b/physics/src/SlabOcean.cpp
@@ -127,7 +127,7 @@ void SlabOcean::update(const TimestepTime& tst)
 
         // Mass per unit area after all the changes in water volume
         // sFlux is in kg/m^2/s, but we need PSU/m^2/s
-        sssSlab[i] = (sss[i] * arealDensity - 1e3_ft * sFlux[i] * dt + fdw[i])
+        sssSlab[i] = (sss[i] * arealDensity * (fdw[i] - 1e3_ft * sFlux[i]) * dt)
             / (arealDensity - fwFlux[i] * dt);
     });
     timer.stop();

--- a/physics/src/SlabOcean.cpp
+++ b/physics/src/SlabOcean.cpp
@@ -129,10 +129,6 @@ void SlabOcean::update(const TimestepTime& tst)
         sssSlab[i] = (sss[i] * arealDensity - 1e3_ft * sFlux[i] * dt)
             / (arealDensity - (fwFlux[i] - fdw[i]) * dt);
     });
-    constexpr size_t i = 52619;
-    std::cout << "SSS: " << sss[i] << " fwFlux: " << fwFlux[i] << " sFlux: " << sFlux[i]
-              << " mld: " << cpml[i] / Water::cp / Water::rhoOcean << std::endl;
-
     timer.stop();
 }
 

--- a/physics/src/SlabOcean.cpp
+++ b/physics/src/SlabOcean.cpp
@@ -127,7 +127,7 @@ void SlabOcean::update(const TimestepTime& tst)
 
         // Mass per unit area after all the changes in water volume
         // sFlux is in kg/m^2/s, but we need PSU/m^2/s
-        sssSlab[i] = (sss[i] * arealDensity * (fdw[i] - 1e3_ft * sFlux[i]) * dt)
+        sssSlab[i] = (sss[i] * arealDensity + (fdw[i] - 1e3_ft * sFlux[i]) * dt)
             / (arealDensity - fwFlux[i] * dt);
     });
     timer.stop();

--- a/physics/src/SlabOcean.cpp
+++ b/physics/src/SlabOcean.cpp
@@ -15,7 +15,7 @@
 
 namespace Nextsim {
 
-const FloatType SlabOcean::defaultRelaxationTime = 30; // 30 days in seconds
+const FloatType SlabOcean::defaultRelaxationTime = 7; // Unit is days
 
 // Configuration strings
 static const std::string className = "SlabOcean";

--- a/physics/src/SlabOcean.cpp
+++ b/physics/src/SlabOcean.cpp
@@ -125,8 +125,9 @@ void SlabOcean::update(const TimestepTime& tst)
         fdw[i] = (1 - sssExt[i] / sss[i]) * arealDensity * rRelaxationTimeS;
 
         // Mass per unit area after all the changes in water volume
-        sssSlab[i]
-            = (sss[i] * arealDensity - sFlux[i] * dt) / (arealDensity - (fwFlux[i] - fdw[i]) * dt);
+        // sFlux is in kg/m^2/s, but we need PSU/m^2/s
+        sssSlab[i] = (sss[i] * arealDensity - 1e3_ft * sFlux[i] * dt)
+            / (arealDensity - (fwFlux[i] - fdw[i]) * dt);
     });
     timer.stop();
 }

--- a/physics/src/modules/AtmosphereBoundaryModule/ERA5Atmosphere.cpp
+++ b/physics/src/modules/AtmosphereBoundaryModule/ERA5Atmosphere.cpp
@@ -24,8 +24,8 @@ ERA5Atmosphere::ERA5Atmosphere()
     , tairAccessor(getStore(), RO, ModelArray::Type::H, std::pair(-100.0, 100.0))
     , tdewAccessor(getStore(), RO, ModelArray::Type::H, std::pair(-100.0, 100.0))
     , pairAccessor(getStore(), RO, ModelArray::Type::H, std::pair(500e2, 2000e2))
-    , sw_inAccessor(getStore(), RO, ModelArray::Type::H, std::pair(-1e-6, 1e4))
-    , lw_inAccessor(getStore(), RO, ModelArray::Type::H, std::pair(-1e-6, 1e4))
+    , sw_inAccessor(getStore(), RO, ModelArray::Type::H, std::pair(-1e-3, 1e4))
+    , lw_inAccessor(getStore(), RO, ModelArray::Type::H, std::pair(-1e-3, 1e4))
     , windAccessor(getStore(), RO, ModelArray::Type::H, std::pair(0.0, 100.0))
 {
 }

--- a/physics/src/modules/ColumnPhysicsModule/NSColumnPhysics.cpp
+++ b/physics/src/modules/ColumnPhysicsModule/NSColumnPhysics.cpp
@@ -3,8 +3,8 @@
  * @author  Einar Ólason <einar.olason@nersc.no>
  */
 
-#include "include/Finalizer.hpp"
 #include "include/NSColumnPhysics.hpp"
+#include "include/Finalizer.hpp"
 #include "include/NextsimModule.hpp"
 #include "include/constants.hpp"
 
@@ -17,16 +17,6 @@ static const std::map<int, std::string> keyMap = {
     { NSColumnPhysics::MINH_KEY, "nextsim_thermo.min_thick" },
     { NSColumnPhysics::USE_THERMO_KEY, "nextsim_thermo.use_thermo_forcing" },
 };
-
-NSColumnPhysics::NSColumnPhysics()
-    : IColumnPhysics()
-    , hiceAccessor(getStore())
-    , ciceAccessor(getStore())
-    , hsnowAccessor(getStore())
-    , qowAccessor(getStore())
-    , deltaHiAccessor(getStore())
-{
-}
 
 void NSColumnPhysics::setData(const ModelState::DataMap& ms)
 {

--- a/physics/src/modules/ColumnPhysicsModule/include/NSColumnPhysics.hpp
+++ b/physics/src/modules/ColumnPhysicsModule/include/NSColumnPhysics.hpp
@@ -15,7 +15,7 @@ namespace Nextsim {
  */
 class NSColumnPhysics : public IColumnPhysics, public Configured<NSColumnPhysics> {
 public:
-    NSColumnPhysics();
+    NSColumnPhysics() = default;
     virtual ~NSColumnPhysics() = default;
 
     enum {
@@ -47,15 +47,6 @@ private:
     std::unique_ptr<ILateralIceSpread> iLateral;
     // Damage Healing ModuleComponent & Module
     std::unique_ptr<IDamageHealing> iHealing;
-
-    // Data fields
-    ModelArrayAccessor<Shared::H_ICE_DG>
-        hiceAccessor; // Timestep initial cell averaged ice thickness, m
-    ModelArrayAccessor<Shared::H_SNOW_DG>
-        hsnowAccessor; // Timestep initial cell averaged snow thickness, m
-    ModelArrayAccessor<Shared::C_ICE_DG> ciceAccessor; // Timestep initial ice concentration
-    ModelArrayAccessor<Shared::Q_OW, RW> qowAccessor; // open water heat flux, from FluxCalculation
-    ModelArrayAccessor<Shared::DELTA_HICE> deltaHiAccessor; // New ice thickness this timestep, m
 
     bool doThermo = true; // Perform any thermodynamics calculations at all
 };

--- a/physics/src/modules/IceThermodynamicsModule/ThermoIce0.cpp
+++ b/physics/src/modules/IceThermodynamicsModule/ThermoIce0.cpp
@@ -69,18 +69,27 @@ void ThermoIce0::update(const TimestepTime& tsTime)
 
         // If there is too little ice, do nothing and zero out the computed arrays
         if (hice[i] <= hMin || cice[i] <= cMin) {
-            deltaHi[i] = 0.;
-            snowToIce[i] = 0.;
-            snowMelt[i] = 0.;
-            qswBase[i] = 0.;
+            if (cice[i] > 0) {
+                deltaHi[i] = hice[i] / cice[i];
+                botMelt[i] = topMelt[i] = 0.5 * deltaHi[i];
+                snowMelt[i] = hsnow[i] / cice[i];
+            } else {
+                deltaHi[i] = 0.;
+                botMelt[i] = topMelt[i] = 0.;
+                snowMelt[i] = 0.;
+            }
 
-            tsurf[i] = freezingPointIce;
+            snowToIce[i] = 0.;
+            qswBase[i] = 0.;
 
             // Add to open water flux, since cice will be set to zero
             qow[i] += (hice[i] * bulkLHFusionIce + hsnow[i] * bulkLHFusionSnow) / dt;
-            cice[i] = 0.;
-            hice[i] = 0.;
-            hsnow[i] = 0.;
+
+            cice[i] = 0;
+            hice[i] = 0;
+            hsnow[i] = 0;
+
+            tsurf[i] = freezingPointIce;
 
             return;
         }

--- a/physics/src/modules/IceThermodynamicsModule/ThermoIce0.cpp
+++ b/physics/src/modules/IceThermodynamicsModule/ThermoIce0.cpp
@@ -70,9 +70,9 @@ void ThermoIce0::update(const TimestepTime& tsTime)
         // If there is too little ice, do nothing and zero out the computed arrays
         if (hice[i] <= hMin || cice[i] <= cMin) {
             if (cice[i] > 0) {
-                deltaHi[i] = hice[i] / cice[i];
+                deltaHi[i] = -hice[i];
                 botMelt[i] = topMelt[i] = 0.5 * deltaHi[i];
-                snowMelt[i] = hsnow[i] / cice[i];
+                snowMelt[i] = -hsnow[i];
             } else {
                 deltaHi[i] = 0.;
                 botMelt[i] = topMelt[i] = 0.;
@@ -162,7 +162,7 @@ void ThermoIce0::update(const TimestepTime& tsTime)
             snowToIce[i] = 0.;
 
             // Change in thickness is all of the old thickness
-            deltaHi[i] = -oldHi;
+            deltaHi[i] = -oldHi * cice[i];
 
             // Add the melt flux to open water flux, since cice will be set to zero
             qow[i] += cice[i] * (hi * bulkLHFusionIce + hs * bulkLHFusionSnow) / dt;
@@ -177,6 +177,8 @@ void ThermoIce0::update(const TimestepTime& tsTime)
             // new values
             hice[i] = hi * cice[i];
             hsnow[i] = hs * cice[i];
+            deltaHi[i] *= cice[i];
+            snowMelt[i] *= cice[i];
         }
     });
 }

--- a/physics/src/modules/IceThermodynamicsModule/ThermoIce0.cpp
+++ b/physics/src/modules/IceThermodynamicsModule/ThermoIce0.cpp
@@ -69,15 +69,9 @@ void ThermoIce0::update(const TimestepTime& tsTime)
 
         // If there is too little ice, do nothing and zero out the computed arrays
         if (hice[i] <= hMin || cice[i] <= cMin) {
-            if (cice[i] > 0) {
-                deltaHi[i] = -hice[i];
-                botMelt[i] = topMelt[i] = 0.5 * deltaHi[i];
-                snowMelt[i] = -hsnow[i];
-            } else {
-                deltaHi[i] = 0.;
-                botMelt[i] = topMelt[i] = 0.;
-                snowMelt[i] = 0.;
-            }
+            deltaHi[i] = -hice[i];
+            botMelt[i] = topMelt[i] = 0.5 * deltaHi[i];
+            snowMelt[i] = -hsnow[i];
 
             snowToIce[i] = 0.;
             qswBase[i] = 0.;

--- a/physics/src/modules/IceThermodynamicsModule/ThermoWinton.cpp
+++ b/physics/src/modules/IceThermodynamicsModule/ThermoWinton.cpp
@@ -241,17 +241,24 @@ void ThermoWinton::update(const TimestepTime& tst)
         static const double bulkLHFusionSnow = Water::Lf * Ice::rhoSnow;
         static const double bulkLHFusionIce = Water::Lf * Ice::rho;
 
-        // Don't do anything if there is no ice
+        // Take care of too thin (or no) ice
         if (cice[i] <= cMin || hice[i] <= hMin) {
+            if (cice[i] > 0) {
+                deltaHi[i] = hice[i] / cice[i];
+                botMelt[i] = topMelt[i] = 0.5 * deltaHi[i];
+                snowMelt[i] = hsnow[i] / cice[i];
+            } else {
+                deltaHi[i] = 0.;
+                botMelt[i] = topMelt[i] = 0.;
+                snowMelt[i] = 0.;
+            }
 
             snowToIce[i] = 0.;
-            snowMelt[i] = 0.;
             qswBase[i] = 0.;
 
             // Add to open water flux, since cice will be set to zero
             qow[i] += (hice[i] * bulkLHFusionIce + hsnow[i] * bulkLHFusionSnow) / dt;
 
-            deltaHi[i] = 0;
             cice[i] = 0;
             hice[i] = 0;
             hsnow[i] = 0;

--- a/physics/src/modules/IceThermodynamicsModule/ThermoWinton.cpp
+++ b/physics/src/modules/IceThermodynamicsModule/ThermoWinton.cpp
@@ -244,9 +244,9 @@ void ThermoWinton::update(const TimestepTime& tst)
         // Take care of too thin (or no) ice
         if (cice[i] <= cMin || hice[i] <= hMin) {
             if (cice[i] > 0) {
-                deltaHi[i] = hice[i] / cice[i];
+                deltaHi[i] = -hice[i];
                 botMelt[i] = topMelt[i] = 0.5 * deltaHi[i];
-                snowMelt[i] = hsnow[i] / cice[i];
+                snowMelt[i] = -hsnow[i];
             } else {
                 deltaHi[i] = 0.;
                 botMelt[i] = topMelt[i] = 0.;
@@ -446,6 +446,8 @@ void ThermoWinton::update(const TimestepTime& tst)
 
         hice[i] = hi * cice[i];
         hsnow[i] = hs * cice[i];
+        deltaHi[i] *= cice[i];
+        snowMelt[i] *= cice[i];
     });
 }
 

--- a/physics/src/modules/IceThermodynamicsModule/ThermoWinton.cpp
+++ b/physics/src/modules/IceThermodynamicsModule/ThermoWinton.cpp
@@ -243,15 +243,9 @@ void ThermoWinton::update(const TimestepTime& tst)
 
         // Take care of too thin (or no) ice
         if (cice[i] <= cMin || hice[i] <= hMin) {
-            if (cice[i] > 0) {
-                deltaHi[i] = -hice[i];
-                botMelt[i] = topMelt[i] = 0.5 * deltaHi[i];
-                snowMelt[i] = -hsnow[i];
-            } else {
-                deltaHi[i] = 0.;
-                botMelt[i] = topMelt[i] = 0.;
-                snowMelt[i] = 0.;
-            }
+            deltaHi[i] = -hice[i];
+            botMelt[i] = topMelt[i] = 0.5 * deltaHi[i];
+            snowMelt[i] = -hsnow[i];
 
             snowToIce[i] = 0.;
             qswBase[i] = 0.;

--- a/physics/src/modules/LateralIceSpreadModule/HiblerSpread.cpp
+++ b/physics/src/modules/LateralIceSpreadModule/HiblerSpread.cpp
@@ -13,27 +13,19 @@
 namespace Nextsim {
 
 FloatType HiblerSpread::h0 = 0;
-FloatType HiblerSpread::phiM = 0;
 
 static constexpr FloatType h0Default = 0.25;
-static constexpr FloatType phimDefault = 0.5;
 
 static const std::map<int, std::string> keyMap = {
     { HiblerSpread::H0_KEY, "Hibler.h0" },
-    { HiblerSpread::PHIM_KEY, "Hibler.phiM" },
 };
 
-void HiblerSpread::configure()
-{
-    h0 = Configured::getConfiguration(keyMap.at(H0_KEY), h0Default);
-    phiM = Configured::getConfiguration(keyMap.at(PHIM_KEY), phimDefault);
-}
+void HiblerSpread::configure() { h0 = Configured::getConfiguration(keyMap.at(H0_KEY), h0Default); }
 
 ConfigMap HiblerSpread::getConfiguration() const
 {
     return {
         { keyMap.at(H0_KEY), h0 },
-        { keyMap.at(PHIM_KEY), phiM },
     };
 }
 
@@ -44,8 +36,6 @@ HiblerSpread::HelpMap& HiblerSpread::getHelpText(HelpMap& map, bool getAll)
     map["HiblerSpread"] = {
         { keyMap.at(H0_KEY), ConfigType::NUMERIC, { "0", "∞" },
             ConfigurationHelp::toString(h0Default), "m", "The thickness of newly frozen ice." },
-        { keyMap.at(PHIM_KEY), ConfigType::NUMERIC, { "0", "∞" },
-            ConfigurationHelp::toString(phimDefault), "", "Power-law exponent for melting ice." },
     };
     return map;
 }
@@ -73,15 +63,15 @@ KERNEL_IMPL_FUNCTION FloatType freeze(const FloatType newIce, const FloatType h0
  * @param hice The ice-average ice thickness.
  */
 KERNEL_IMPL_FUNCTION FloatType melt(
-    const FloatType deltaHi, const FloatType cice, const FloatType hice, const FloatType phiM)
+    const FloatType deltaHi, const FloatType cice, const FloatType hice)
 {
     /* We only decrease the concentration if the ice is melting, if the ice cover is not 100%, and
      * if there's ice there in the first place. */
-    if (deltaHi < 0 && 0 < cice && cice < 1) {
+    if (deltaHi < 0._ft && 0._ft < cice && cice < 1._ft) {
         const FloatType hiOld = hice / cice - deltaHi;
-        return deltaHi * cice * phiM / hiOld;
+        return deltaHi * cice / (2._ft * hiOld);
     } else {
-        return 0.;
+        return 0._ft;
     }
 }
 
@@ -105,7 +95,6 @@ void HiblerSpread::update(const TimestepTime& tstep)
 
     // static members can not be captured directly
     const FloatType h0Local = h0;
-    const FloatType phiMLocal = phiM;
     const FloatType dt = tstep.step.seconds();
     const FloatType cMin = IceMinima::c();
     const FloatType hMin = IceMinima::h();
@@ -136,7 +125,7 @@ void HiblerSpread::update(const TimestepTime& tstep)
         }
 
         // lateralIceSpread
-        const FloatType deltaCMelt = melt(deltaHi[i], cIce[i], hIce[i], phiMLocal);
+        const FloatType deltaCMelt = melt(deltaHi[i], cIce[i], hIce[i]);
         const FloatType deltaCFreeze = freeze(newIce[i], h0Local);
         deltaCIce[i] = deltaCFreeze + deltaCMelt;
 

--- a/physics/src/modules/LateralIceSpreadModule/HiblerSpread.cpp
+++ b/physics/src/modules/LateralIceSpreadModule/HiblerSpread.cpp
@@ -135,7 +135,9 @@ void HiblerSpread::update(const TimestepTime& tstep)
         /* Snow is lost if the concentration decreases, and energy is returned to the ocean. We
          * reduce the snow volume by a "slice" of snow with the dimensions hs * deltaCIce.
          */
-        const FloatType hs = hSnow[i] / std::max(cMin, cIce[i]);
+        // Workaround: I can't use std::max(cMin, cIce[i]) with Kokkos/GPU
+        const FloatType c = cIce[i] > cMin ? cIce[i] : cMin;
+        const FloatType hs = hSnow[i] / c;
         qow[i] -= deltaCMelt * hs * Water::Lf * Ice::rhoSnow / dt;
         hSnow[i] += hs * deltaCMelt;
 

--- a/physics/src/modules/LateralIceSpreadModule/HiblerSpread.cpp
+++ b/physics/src/modules/LateralIceSpreadModule/HiblerSpread.cpp
@@ -15,8 +15,8 @@ namespace Nextsim {
 FloatType HiblerSpread::h0 = 0;
 FloatType HiblerSpread::phiM = 0;
 
-static const FloatType h0Default = 0.25;
-static const FloatType phimDefault = 0.5;
+static constexpr FloatType h0Default = 0.25;
+static constexpr FloatType phimDefault = 0.5;
 
 static const std::map<int, std::string> keyMap = {
     { HiblerSpread::H0_KEY, "Hibler.h0" },
@@ -57,9 +57,8 @@ HiblerSpread::HelpMap& HiblerSpread::getHelpRecursive(HelpMap& map, bool getAll)
 /*!
  * Updates the freezing of open water for the timestep.
  *
- * @param tStep The object containing the timestep start and duration times.
  * @param newIce The positive change in ice thickness this timestep.
- * @param deltaCFreeze The change in concentration due to freezing.
+ * @param h0 The demarcation thickness between thick and thin ice
  */
 KERNEL_IMPL_FUNCTION FloatType freeze(const FloatType newIce, const FloatType h0)
 {
@@ -69,13 +68,12 @@ KERNEL_IMPL_FUNCTION FloatType freeze(const FloatType newIce, const FloatType h0
 /*!
  * Updates the lateral melting of ice for the timestep.
  *
- * @param tStep The object containing the timestep start and duration times.
  * @param deltaHi The change in ice thickness this timestep.
  * @param cice The ice concentration.
  * @param hice The ice-average ice thickness.
  */
 KERNEL_IMPL_FUNCTION FloatType melt(
-    FloatType deltaHi, FloatType cice, FloatType hice, FloatType phiM)
+    const FloatType deltaHi, const FloatType cice, const FloatType hice, const FloatType phiM)
 {
     /* We only decrease the concentration if the ice is melting, if the ice cover is not 100%, and
      * if there's ice there in the first place. */
@@ -92,12 +90,12 @@ void HiblerSpread::update(const TimestepTime& tstep)
     static KokkosTimer<true> timer("HiblerSpread");
     timer.start();
 
-    auto execSpace = DefaultExecutionSpace();
-    auto& hsnow = hsnowAccessor.getAutoRW(execSpace);
+    constexpr auto execSpace = DefaultExecutionSpace();
+    auto& hSnow = hsnowAccessor.getAutoRW(execSpace);
     auto& qow = qowAccessor.getAutoRW(execSpace);
-    auto& cice = ciceAccessor.getAutoRW(execSpace);
-    auto& newice = newiceAccessor.getAutoRW(execSpace);
-    auto& hice = hiceAccessor.getAutoRW(execSpace);
+    auto& cIce = ciceAccessor.getAutoRW(execSpace);
+    auto& newIce = newiceAccessor.getAutoRW(execSpace);
+    auto& hIce = hiceAccessor.getAutoRW(execSpace);
     auto& deltaCIce = deltaCIceAccessor.getAutoRW(execSpace);
     const auto& mixedLayerBulkHeatCapacity
         = mixedLayerBulkHeatCapacityAccessor.getAutoRO(execSpace);
@@ -106,8 +104,8 @@ void HiblerSpread::update(const TimestepTime& tstep)
     const auto& sst = sstAccessor.getAutoRO(execSpace);
 
     // static members can not be captured directly
-    const FloatType h0 = HiblerSpread::h0;
-    const FloatType phiM = HiblerSpread::phiM;
+    const FloatType h0Local = h0;
+    const FloatType phiMLocal = phiM;
     const FloatType dt = tstep.step.seconds();
     const FloatType cMin = IceMinima::c();
     const FloatType hMin = IceMinima::h();
@@ -116,55 +114,52 @@ void HiblerSpread::update(const TimestepTime& tstep)
         // newIceFormation
         // Flux cooling the ocean from open water
         // TODO Add assimilation fluxes here
-        FloatType coolingFlux = qow[i];
+        const FloatType coolingFlux = qow[i];
         // Temperature change of the mixed layer during this timestep
-        FloatType deltaTml = -coolingFlux / mixedLayerBulkHeatCapacity[i] * dt;
+        const FloatType deltaTml = -coolingFlux / mixedLayerBulkHeatCapacity[i] * dt;
         // Initial temperature
-        FloatType t0 = sst[i];
+        const FloatType t0 = sst[i];
         // Freezing point temperature
-        FloatType tf0 = tf[i];
-        // Final temperature
-        FloatType t1 = t0 + deltaTml;
+        const FloatType tf0 = tf[i];
 
         // deal with cooling below the freezing point
-        if (t1 < tf0) {
+        if (const FloatType t1 = t0 + deltaTml; t1 < tf0) {
             // Heat lost cooling the mixed layer to freezing point
-            FloatType sensibleFlux = (tf0 - t0) / deltaTml * coolingFlux;
+            const FloatType sensibleFlux = (tf0 - t0) / deltaTml * coolingFlux;
             // Any heat beyond that is latent heat forming new ice
-            FloatType latentFlux = coolingFlux - sensibleFlux;
+            const FloatType latentFlux = coolingFlux - sensibleFlux;
 
             qow[i] = sensibleFlux;
-            newice[i] = latentFlux * dt * (1 - cice[i]) / (Ice::Lf * Ice::rho);
+            newIce[i] = latentFlux * dt * (1._ft - cIce[i]) / (Ice::Lf * Ice::rho);
         } else {
-            newice[i] = 0;
+            newIce[i] = 0._ft;
         }
 
         // lateralIceSpread
-        const FloatType deltaCMelt = melt(deltaHi[i], cice[i], hice[i], phiM);
-        const FloatType deltaCFreeze = freeze(newice[i], h0);
-
+        const FloatType deltaCMelt = melt(deltaHi[i], cIce[i], hIce[i], phiMLocal);
+        const FloatType deltaCFreeze = freeze(newIce[i], h0Local);
         deltaCIce[i] = deltaCFreeze + deltaCMelt;
-        cice[i] = (hice[i] > 0 || newice[i] > 0) ? cice[i] + deltaCIce[i] : 0;
-        if (cice[i] >= cMin) {
-            // The updated ice thickness must conserve volume
-            hice[i] += newice[i];
-            if (deltaCIce[i] < 0) {
-                /* Snow is lost if the concentration decreases, and energy is returned
-                 * to the ocean. We reduce the snow volume by a "slice" of snow with the
-                 * dimensions hs * deltaCIce. */
-                const FloatType hs = hsnow[i] / (cice[i] - deltaCIce[i]);
-                qow[i] -= deltaCIce[i] * hs * Water::Lf * Ice::rhoSnow / dt;
-                hsnow[i] += hs * deltaCIce[i];
-            } // else: Snow volume is conserved, so no change to hsnow[i]
-        }
+
+        /* Snow is lost if the concentration decreases, and energy is returned to the ocean. We
+         * reduce the snow volume by a "slice" of snow with the dimensions hs * deltaCIce.
+         */
+        if (deltaCIce[i] < 0._ft && cIce[i] > 0._ft) {
+            const FloatType hs = hSnow[i] / cIce[i];
+            qow[i] -= deltaCIce[i] * hs * Water::Lf * Ice::rhoSnow / dt;
+            hSnow[i] += hs * deltaCIce[i];
+        } // else: Snow volume is conserved, so no change to hSnow[i]
+
+        // Update ice concentration and volume
+        cIce[i] += deltaCIce[i];
+        hIce[i] += newIce[i];
 
         // applyLimits
-        if (cice[i] < cMin || hice[i] < hMin) {
-            qow[i] += Water::Lf * (hice[i] * Ice::rho + hsnow[i] * Ice::rhoSnow) / dt;
-            hice[i] = 0;
-            cice[i] = 0;
-            hsnow[i] = 0;
-            newice[i] = 0._ft;
+        if (cIce[i] < cMin || hIce[i] < hMin) {
+            qow[i] += Water::Lf * (hIce[i] * Ice::rho + hSnow[i] * Ice::rhoSnow) / dt;
+            hIce[i] = 0._ft;
+            cIce[i] = 0._ft;
+            hSnow[i] = 0._ft;
+            newIce[i] = 0._ft;
         }
     });
     timer.stop();

--- a/physics/src/modules/LateralIceSpreadModule/HiblerSpread.cpp
+++ b/physics/src/modules/LateralIceSpreadModule/HiblerSpread.cpp
@@ -164,6 +164,7 @@ void HiblerSpread::update(const TimestepTime& tstep)
             hice[i] = 0;
             cice[i] = 0;
             hsnow[i] = 0;
+            newice[i] = 0._ft;
         }
     });
     timer.stop();

--- a/physics/src/modules/LateralIceSpreadModule/HiblerSpread.cpp
+++ b/physics/src/modules/LateralIceSpreadModule/HiblerSpread.cpp
@@ -135,9 +135,7 @@ void HiblerSpread::update(const TimestepTime& tstep)
         /* Snow is lost if the concentration decreases, and energy is returned to the ocean. We
          * reduce the snow volume by a "slice" of snow with the dimensions hs * deltaCIce.
          */
-        // Workaround: I can't use std::max(cMin, cIce[i]) with Kokkos/GPU
-        const FloatType c = cIce[i] > cMin ? cIce[i] : cMin;
-        const FloatType hs = hSnow[i] / c;
+        const FloatType hs = hSnow[i] / Utils::max(cMin, cIce[i]);
         qow[i] -= deltaCMelt * hs * Water::Lf * Ice::rhoSnow / dt;
         hSnow[i] += hs * deltaCMelt;
 

--- a/physics/src/modules/LateralIceSpreadModule/HiblerSpread.cpp
+++ b/physics/src/modules/LateralIceSpreadModule/HiblerSpread.cpp
@@ -68,8 +68,8 @@ KERNEL_IMPL_FUNCTION FloatType melt(
     /* We only decrease the concentration if the ice is melting, if the ice cover is not 100%, and
      * if there's ice there in the first place. */
     if (deltaHi < 0._ft && 0._ft < cice && cice < 1._ft) {
-        const FloatType hiOld = hice / cice - deltaHi;
-        return deltaHi * cice / (2._ft * hiOld);
+        const FloatType hiOld = (hice - deltaHi) / cice;
+        return deltaHi / (2._ft * hiOld);
     } else {
         return 0._ft;
     }

--- a/physics/src/modules/LateralIceSpreadModule/HiblerSpread.cpp
+++ b/physics/src/modules/LateralIceSpreadModule/HiblerSpread.cpp
@@ -135,11 +135,9 @@ void HiblerSpread::update(const TimestepTime& tstep)
         /* Snow is lost if the concentration decreases, and energy is returned to the ocean. We
          * reduce the snow volume by a "slice" of snow with the dimensions hs * deltaCIce.
          */
-        if (deltaCIce[i] < 0._ft && cIce[i] > 0._ft) {
-            const FloatType hs = hSnow[i] / cIce[i];
-            qow[i] -= deltaCIce[i] * hs * Water::Lf * Ice::rhoSnow / dt;
-            hSnow[i] += hs * deltaCIce[i];
-        } // else: Snow volume is conserved, so no change to hSnow[i]
+        const FloatType hs = hSnow[i] / std::max(cMin, cIce[i]);
+        qow[i] -= deltaCMelt * hs * Water::Lf * Ice::rhoSnow / dt;
+        hSnow[i] += hs * deltaCMelt;
 
         // Update ice concentration and volume
         cIce[i] += deltaCIce[i];

--- a/physics/src/modules/LateralIceSpreadModule/HiblerSpread.cpp
+++ b/physics/src/modules/LateralIceSpreadModule/HiblerSpread.cpp
@@ -80,7 +80,7 @@ void HiblerSpread::update(const TimestepTime& tstep)
     static KokkosTimer<true> timer("HiblerSpread");
     timer.start();
 
-    constexpr auto execSpace = DefaultExecutionSpace();
+    const auto execSpace = DefaultExecutionSpace();
     auto& hSnow = hsnowAccessor.getAutoRW(execSpace);
     auto& qow = qowAccessor.getAutoRW(execSpace);
     auto& cIce = ciceAccessor.getAutoRW(execSpace);

--- a/physics/src/modules/LateralIceSpreadModule/HiblerSpread.cpp
+++ b/physics/src/modules/LateralIceSpreadModule/HiblerSpread.cpp
@@ -87,6 +87,9 @@ void HiblerSpread::update(const TimestepTime& tstep)
     auto& newIce = newiceAccessor.getAutoRW(execSpace);
     auto& hIce = hiceAccessor.getAutoRW(execSpace);
     auto& deltaCIce = deltaCIceAccessor.getAutoRW(execSpace);
+    auto& deltaHice = deltaHiceAccessor.getAutoRW();
+    auto& deltaSmelt = deltaSmeltAccessor.getAutoRW();
+
     const auto& mixedLayerBulkHeatCapacity
         = mixedLayerBulkHeatCapacityAccessor.getAutoRO(execSpace);
     const auto& deltaHi = deltaHiAccessor.getAutoRO(execSpace);
@@ -119,9 +122,9 @@ void HiblerSpread::update(const TimestepTime& tstep)
             const FloatType latentFlux = coolingFlux - sensibleFlux;
 
             qow[i] = sensibleFlux;
-            newIce[i] = latentFlux * dt * (1._ft - cIce[i]) / (Ice::Lf * Ice::rho);
+            newIce[i] = latentFlux * dt * (1 - cIce[i]) / (Ice::Lf * Ice::rho);
         } else {
-            newIce[i] = 0._ft;
+            newIce[i] = 0;
         }
 
         // lateralIceSpread
@@ -145,10 +148,14 @@ void HiblerSpread::update(const TimestepTime& tstep)
         // applyLimits
         if (cIce[i] < cMin || hIce[i] < hMin) {
             qow[i] += Water::Lf * (hIce[i] * Ice::rho + hSnow[i] * Ice::rhoSnow) / dt;
-            hIce[i] = 0._ft;
-            cIce[i] = 0._ft;
-            hSnow[i] = 0._ft;
-            newIce[i] = 0._ft;
+            deltaCIce[i] = -cIce[i];
+            deltaHice[i] = -hIce[i];
+            deltaSmelt[i] = -hSnow[i];
+
+            hIce[i] = 0;
+            cIce[i] = 0;
+            hSnow[i] = 0;
+            newIce[i] = 0;
         }
     });
     timer.stop();

--- a/physics/src/modules/LateralIceSpreadModule/include/HiblerSpread.hpp
+++ b/physics/src/modules/LateralIceSpreadModule/include/HiblerSpread.hpp
@@ -22,6 +22,8 @@ public:
         , mixedLayerBulkHeatCapacityAccessor(getStore())
         , sstAccessor(getStore())
         , tfAccessor(getStore())
+        , deltaHiceAccessor(getStore())
+        , deltaSmeltAccessor(getStore())
     {
     }
     virtual ~HiblerSpread() = default;
@@ -50,6 +52,8 @@ private:
     ModelArrayAccessor<Protected::SST> sstAccessor; // sea surface temperature, ˚C
     ModelArrayAccessor<Protected::TF> tfAccessor; // ocean freezing point, ˚C
     ModelArrayAccessor<Shared::H_ICE_DG, RW> hiceAccessor; // Timestep initial true ice thickness, m
+    ModelArrayAccessor<Shared::DELTA_HICE, RW> deltaHiceAccessor;
+    ModelArrayAccessor<Shared::HSNOW_MELT, RW> deltaSmeltAccessor;
 };
 
 }

--- a/physics/src/modules/include/IAtmosphereBoundary.hpp
+++ b/physics/src/modules/include/IAtmosphereBoundary.hpp
@@ -18,7 +18,7 @@ public:
     IAtmosphereBoundary()
         : qiaAccessor(getStore(), RW, ModelArray::Type::H, std::pair(-1e4, 1e4))
         , dqia_dtAccessor(getStore(), RW, ModelArray::Type::H)
-        , qowAccessor(getStore(), RW, ModelArray::Type::H, std::pair(-1e4, 1e4))
+        , qowAccessor(getStore(), RW, ModelArray::Type::H)
         , sublAccessor(getStore(), RW, ModelArray::Type::H)
         , snowAccessor(getStore(), RO, ModelArray::Type::H, std::pair(0.0, 1e-3))
         , rainAccessor(getStore(), RO, ModelArray::Type::H, std::pair(0.0, 1e-3))

--- a/physics/src/modules/include/IOceanBoundary.hpp
+++ b/physics/src/modules/include/IOceanBoundary.hpp
@@ -170,9 +170,7 @@ public:
 
             // Mass fluxes - fresh water and salt
             // ice volume change, both laterally and vertically
-            const FloatType deltaIceVol = newIce[i] + deltaHice[i] * cice[i];
-            // change in snow volume due to melting (should be < 0)
-            const FloatType meltSnowVol = deltaSmelt[i] * cice[i];
+            const FloatType deltaIceVol = newIce[i] + deltaHice[i];
             // the device compiler does not like a global constant appearing in the argument list of
             // a template function: "identifier "Ice::s" is undefined in device code"
             const FloatType s = Ice::s;
@@ -182,7 +180,8 @@ public:
 
             // Positive flux is up!
             fwFlux[i]
-                = ((1 - effectiveIceSal) * Ice::rho * deltaIceVol + Ice::rhoSnow * meltSnowVol) / dt
+                = ((1 - effectiveIceSal) * Ice::rho * deltaIceVol + Ice::rhoSnow * deltaSmelt[i])
+                    / dt
                 + (evap[i] - rain[i]) * (1 - cice[i]);
             sFlux[i] = effectiveIceSal * Ice::rho * deltaIceVol / dt;
 

--- a/physics/src/modules/include/IOceanBoundary.hpp
+++ b/physics/src/modules/include/IOceanBoundary.hpp
@@ -19,7 +19,7 @@ namespace Nextsim {
 class IOceanBoundary : public CheckingModelComponent {
 public:
     IOceanBoundary()
-        : qioAccessor(getStore(), RW, ModelArray::Type::H, std::pair(-1e8, 1e8))
+        : qioAccessor(getStore(), RW, ModelArray::Type::H)
         , sstAccessor(getStore(), RO, ModelArray::Type::H, std::pair(-5.0, 50.0))
         , sssAccessor(getStore(), RO, ModelArray::Type::H, std::pair(0.0, 50.0))
         , mldAccessor(getStore(), RO, ModelArray::Type::H, std::pair(1e-3, 12e3))
@@ -28,11 +28,11 @@ public:
         , uAccessor(getStore(), RO, ModelArray::Type::H, std::pair(-1.0, 1.0))
         , vAccessor(getStore(), RO, ModelArray::Type::H, std::pair(-1.0, 1.0))
         , sshAccessor(getStore(), RO, ModelArray::Type::H, std::pair(-10.0, 10.0))
-        , qNoSunAccessor(m_couplingArrays, RO, ModelArray::Type::H, std::pair(-1e6, 1e6))
+        , qNoSunAccessor(m_couplingArrays, RO, ModelArray::Type::H)
         , qswNetAccessor(m_couplingArrays, RO, ModelArray::Type::H, std::pair(-1e3, 1e3))
         , fwFluxAccessor(m_couplingArrays, RO, ModelArray::Type::H)
         , sFluxAccessor(m_couplingArrays, RO, ModelArray::Type::H)
-        , qswowAccessor(getStore(), RW, ModelArray::Type::H, std::pair(-1e3, 1e-6))
+        , qswowAccessor(getStore(), RW, ModelArray::Type::H, std::pair(-1e3, 1e-3))
         , qswBaseAccessor(getStore(), RW, ModelArray::Type::H, std::pair(-1e3, 1e-6))
         , tauXAccessor(m_couplingArrays, RO, ModelArray::Type::H, std::pair(-10.0, 10.0))
         , tauYAccessor(m_couplingArrays, RO, ModelArray::Type::H, std::pair(-10.0, 10.0))

--- a/physics/src/modules/include/IOceanBoundary.hpp
+++ b/physics/src/modules/include/IOceanBoundary.hpp
@@ -176,7 +176,7 @@ public:
             const FloatType s = Ice::s;
             // Effective ice salinity is always less than or equal to the SSS, and here we use
             // the right units too
-            const FloatType effectiveIceSal = 1e-3 * Utils::min(s, sss[i]);
+            const FloatType effectiveIceSal = 1e-3_ft * Utils::min(s, sss[i]);
 
             // Positive flux is up!
             fwFlux[i]

--- a/physics/test/SlabOcean_test.cpp
+++ b/physics/test/SlabOcean_test.cpp
@@ -87,7 +87,8 @@ TEST_CASE("Test Qdw")
 
     constexpr FloatType prec = std::is_same_v<FloatType, float> ? 1e-6 : 1e-8;
     REQUIRE(qdw[0]
-        == doctest::Approx(tOffset * cpml[0] / SlabOcean::defaultRelaxationTime).epsilon(prec));
+        == doctest::Approx(tOffset * cpml[0] / (SlabOcean::defaultRelaxationTime * 86400))
+               .epsilon(prec));
 
     ModelArrayAccessor<Protected::SLAB_SST> sstSlabAccessor(ModelComponent::getStore());
     // scope needed because we have to access sstSlab again after update
@@ -180,7 +181,7 @@ TEST_CASE("Test Fdw")
     constexpr FloatType prec = 1e-6;
     REQUIRE(fdw[0]
         == doctest::Approx(
-            -sOffset / sss[0] * mld[0] * Water::rho / SlabOcean::defaultRelaxationTime)
+            sOffset * mld[0] * Water::rho / (SlabOcean::defaultRelaxationTime * 86400))
                .epsilon(prec));
     // Test that the finiteelement.cpp calculation of fdw is not being used
     FloatType delS = -sOffset;
@@ -196,9 +197,7 @@ TEST_CASE("Test Fdw")
 
         REQUIRE(sssSlab[0] != doctest::Approx(sss[0]).epsilon(prec / dt));
         REQUIRE(sssSlab[0]
-            == doctest::Approx(
-                sss[0] - (sss[0] * fdw[0] * dt) / (mld[0] * Water::rho + fdw[0] * dt))
-                   .epsilon(prec));
+            == doctest::Approx(sss[0] + fdw[0] * dt / (mld[0] * Water::rho)).epsilon(prec));
     }
 
     {
@@ -210,9 +209,8 @@ TEST_CASE("Test Fdw")
         const HField& sssSlab = sssSlabAccessor.getHostRO();
 
         REQUIRE(sssSlab[0]
-            == doctest::Approx(sss[0]
-                + sss[0] * (snowMeltVol - fdw[0] * dt)
-                    / (mld[0] * Water::rho - snowMeltVol + fdw[0] * dt))
+            == doctest::Approx(
+                sss[0] + (sss[0] * snowMeltVol + fdw[0] * dt) / (mld[0] * Water::rho - snowMeltVol))
                    .epsilon(prec));
     }
 }

--- a/run/era5_topaz4_maker.py
+++ b/run/era5_topaz4_maker.py
@@ -1,3 +1,5 @@
+#! /usr/bin/env python3
+
 import argparse
 import calendar
 import time
@@ -43,7 +45,7 @@ def create_era5_times(start_tm, stop_tm):
     era5_unix = calendar.timegm(era5_epoch)
     era5_hours = era5_unix / sec_per_hr
 
-    return (unix_times, hour_times - era5_hours)
+    return unix_times, hour_times - era5_hours
 
 
 def create_topaz_times(start_tm, stop_tm):
@@ -72,7 +74,7 @@ def create_topaz_times(start_tm, stop_tm):
     topaz4_unix = calendar.timegm(topaz4_epoch)
     topaz4_hours = topaz4_unix / sec_per_hr
 
-    return (unix_times, hour_times - topaz4_hours)
+    return unix_times, hour_times - topaz4_hours
 
 
 def era5_source_file_name(field, unix_time, path):
@@ -93,7 +95,6 @@ def topaz4_source_file_name(unix_time, path):
     """
     Construct the file name that holds the TOPAZ4 data for a given field at a given time.
 
-    :param field: Name of the variable to be read in from the TOPAZ4 file
     :param unix_time: Time in Unix format
     :param path: Path for the TOPAZ4 file
     :return: File name
@@ -253,7 +254,7 @@ if __name__ == "__main__":
 
     greenland_headings = heading_to_greenland(element_lat, element_lon)
 
-    nc_times = era5_ncFile.createVariable("time", "f8", ("time"))
+    nc_times = era5_ncFile.createVariable("time", "f8", "time")
     nc_times.units = "seconds since 1970-01-01T00:00:00Z"
 
     (unix_times_e, era5_times) = create_era5_times(start_time, stop_time)
@@ -277,7 +278,6 @@ if __name__ == "__main__":
                 time_index = target_time - source_times[0]
                 source_data = source_file[era5_field][time_index, :, :]
                 # Now interpolate the source data to the target grid
-                time_data = np.zeros((ny, nx))
                 time_data = era5_interpolate(
                     element_lon, element_lat, source_data, source_lons, source_lats
                 )
@@ -319,11 +319,9 @@ if __name__ == "__main__":
                     u_data_source[-1, :] = u_data_source[-2, :]
                     v_data_source[-1, :] = u_data_source[-2, :]
                 # Now interpolate the source data to the target grid
-                u_data_target = np.zeros((ny, nx))
                 u_data_target = era5_interpolate(
                     element_lon, element_lat, u_data_source, source_lons, source_lats
                 )
-                v_data_target = np.zeros((ny, nx))
                 v_data_target = era5_interpolate(
                     element_lon, element_lat, v_data_source, source_lons, source_lats
                 )
@@ -371,7 +369,7 @@ if __name__ == "__main__":
     nc_lats = topaz_ncFile.createVariable("latitude", "f8", hfield_dims)
     nc_lats[:, :] = element_lat
 
-    nc_times = topaz_ncFile.createVariable("time", "f8", ("time"))
+    nc_times = topaz_ncFile.createVariable("time", "f8", "time")
     nc_times.units = "seconds since 1970-01-01T00:00:00Z"
 
     # TOPAZ data is daily, not hourly
@@ -399,7 +397,6 @@ if __name__ == "__main__":
                 # Index the time and squeeze the time dimension away
                 source_data = source_file[topaz_field][time_index, :, :].squeeze()
                 # Now interpolate the source data to the target grid
-                time_data = np.zeros((nx, ny))
                 proj_string = source_file["stereographic"].proj4
                 source_x = source_file["x_dim"][:]
                 source_y = source_file["y_dim"][:]
@@ -433,15 +430,12 @@ if __name__ == "__main__":
         target_time = topaz4_times[target_t_index]
         source_times = u_source_file["time"]
         time_index = (target_time - source_times[0]) // hr_per_day
-        u_source_data = u_source_file["vxo"][
-            time_index, :, :
-        ].squeeze()  # Need to squeeze. Why?
+        # Need to squeeze. Why?
+        u_source_data = u_source_file["vxo"][time_index, :, :].squeeze()
         v_source_data = v_source_file["vyo"][time_index, :, :].squeeze()
         # We want the ocean velocity to be zero on land - not some interpolated value
         u_source_data[np.isnan(u_source_data)] = 0.0
         v_source_data[np.isnan(v_source_data)] = 0.0
-        u_source_data_tgrid = np.zeros((nx, ny))
-        v_source_data_tgrid = np.zeros((nx, ny))
         # Interpolate the current components on the TOPAZ basis on to the new grid
         proj_string = source_file["stereographic"].proj4
         source_x = source_file["x_dim"][:]

--- a/run/era5_topaz4_maker.py
+++ b/run/era5_topaz4_maker.py
@@ -437,6 +437,9 @@ if __name__ == "__main__":
             time_index, :, :
         ].squeeze()  # Need to squeeze. Why?
         v_source_data = v_source_file["vyo"][time_index, :, :].squeeze()
+        # We want the ocean velocity to be zero on land - not some interpolated value
+        u_source_data[np.isnan(u_source_data)] = 0.0
+        v_source_data[np.isnan(v_source_data)] = 0.0
         u_source_data_tgrid = np.zeros((nx, ny))
         v_source_data_tgrid = np.zeros((nx, ny))
         # Interpolate the current components on the TOPAZ basis on to the new grid


### PR DESCRIPTION
# Fix salinity calculation in slab ocean

Fixes #1088 

### Task List
- [x] Linked an issue above that captures the requirements of this PR
- [x] Defined the tests that specify a complete and functioning change
- [x] Implemented the source code change that satisfies the tests
- [x] Commented all code so that it can be understood without additional context
- [x] No new warnings are generated or they are mentioned below
- [x] The documentation has been updated (or an issue has been created to do so)
- [x] Relevant labels (e.g., enhancement, bug) have been applied to this PR
- [x] This change conforms to the conventions described in the README

---
# Change Description

The code wasn't using the salt flux calculated by IOCeanBoundary::mergeFluxes. This may be causing problems in the spring. Not fully tested yet!

---
# Test Description

It doesn't crash immediately, but I need @Thanduriel's help to test it on his setup.

---
# Documentation Impact

None

---
# Other Details

None
