### PR TITLE
Build Docker images for Arm64 ISA as well

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -39,9 +39,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - architecture: amd64
+          - architecture: x86_64_v3
             runner: ubuntu-latest
-          - architecture: arm64
+          - architecture: aarch64
             runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 120
@@ -71,3 +71,5 @@ jobs:
           push: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
           file: Dockerfiles/Dockerfile.devenv
           tags: ghcr.io/nextsimhub/nextsimdg-dev-env:latest
+          build-args: |
+            TARGET=${{ matrix.architecture }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -41,8 +41,10 @@ jobs:
         include:
           - architecture: x86_64_v3
             runner: ubuntu-latest
+            tag-suffix: ''
           - architecture: aarch64
             runner: ubuntu-24.04-arm
+            tag-suffix: '-arm64'
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 120
     permissions:
@@ -68,8 +70,8 @@ jobs:
       - name: Build container and push to ghcr
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83  # v6
         with:
-          push: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
+          push: ${{ github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'pull_request' }}
           file: Dockerfiles/Dockerfile.devenv
-          tags: ghcr.io/nextsimhub/nextsimdg-dev-env:latest
+          tags: ghcr.io/nextsimhub/nextsimdg-dev-env:${{ format('pr-{0}{1}', github.event.pull_request.number, matrix.tag-suffix) }}
           build-args: |
             TARGET=${{ matrix.architecture }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,9 +33,17 @@ concurrency:
 
 jobs:
 
-  # Build Docker container on latest Ubuntu OS
+  # Build Docker container on latest Ubuntu OS for both amd64 and arm64
   docker:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - architecture: amd64
+            runner: ubuntu-latest
+          - architecture: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 120
     permissions:
       contents: read

--- a/Dockerfiles/Dockerfile.devenv
+++ b/Dockerfiles/Dockerfile.devenv
@@ -70,12 +70,6 @@ ENV LD_LIBRARY_PATH=/opt/views/view/lib
 # Unanswered prompts may lead to failures
 ENV DEBIAN_FRONTEND=noninteractive
 
-# We need to explicitly point ncgen to the view libraries
-# to resolve a problem of location of HDF5 libraries not being provided
-# in the executable's RPATH. See:
-# https://github.com/spack/spack/issues/52555
-ENV LD_LIBRARY_PATH=/opt/views/view/lib
-
 # Create entrypoint script
 RUN { \
       echo '#!/bin/sh'; \

--- a/Dockerfiles/Dockerfile.devenv
+++ b/Dockerfiles/Dockerfile.devenv
@@ -22,7 +22,7 @@ RUN cd /opt/spack-environment \
 # Add the view `lib` to the LD_LIBRARY_PATH
 # This is required to make `ncgen` find  the libraries correctly
 # see: https://github.com/spack/spack/issues/52555
-ENV LD_LIBRARY_PATH=/opt/views/view/lib:$LD_LIBRARY_PATH
+ENV LD_LIBRARY_PATH=/opt/views/view/lib
 
 # Pre-fetch XIOS source code
 COPY Dockerfiles/install-xios.sh .
@@ -60,13 +60,26 @@ COPY --from=builder /usr /usr
 # paths.view is a symlink, so copy the parent to avoid dereferencing and duplicating it
 COPY --from=builder /opt/views /opt/views
 
-# Create entrypoint script
-# We need to explicitly point ncgen to the view libraries:
+# We need to explicitly point ncgen to the view libraries
+# to resolve a problem of location of HDF5 libraries not being provided
+# in the executable's RPATH. See:
 # https://github.com/spack/spack/issues/52555
+ENV LD_LIBRARY_PATH=/opt/views/view/lib
+
+# Prevent apt from any prompting of the user (e.g. to select region)
+# Unanswered prompts may lead to failures
+ENV DEBIAN_FRONTEND=noninteractive
+
+# We need to explicitly point ncgen to the view libraries
+# to resolve a problem of location of HDF5 libraries not being provided
+# in the executable's RPATH. See:
+# https://github.com/spack/spack/issues/52555
+ENV LD_LIBRARY_PATH=/opt/views/view/lib
+
+# Create entrypoint script
 RUN { \
       echo '#!/bin/sh'; \
       echo '. /opt/spack-environment/activate.sh'; \
-      echo 'export LD_LIBRARY_PATH=/opt/views/view/lib:$LD_LIBRARY_PATH'; \
       echo 'exec "$@"'; \
     } > /entrypoint.sh \
     && chmod a+x /entrypoint.sh \

--- a/Dockerfiles/Dockerfile.devenv
+++ b/Dockerfiles/Dockerfile.devenv
@@ -49,7 +49,7 @@ RUN cd /opt/spack-environment && \
     spack env activate --sh -d . > activate.sh
 
 # Bare OS image to run the installed executables
-FROM ubuntu:latest
+FROM ubuntu:noble
 
 # Copy necessary files from the builder stage
 COPY --from=builder /opt/spack-environment /opt/spack-environment

--- a/Dockerfiles/Dockerfile.devenv
+++ b/Dockerfiles/Dockerfile.devenv
@@ -1,6 +1,8 @@
 # Build stage with Spack pre-installed and ready to be used
 FROM spack/ubuntu-noble:latest AS builder
 
+ARG TARGET
+
 # Install perl
 RUN apt update \
     && apt install -y --no-install-recommends libany-uri-escape-perl \
@@ -12,12 +14,16 @@ RUN find . -type f -path "*/package_repos/*/readline/package.py" \
   -exec sed -i 's|https://ftpmirror.gnu.org|https://ftp.gnu.org/gnu|w /dev/stdout' '{}' \;
 
 # Install software from spack.yaml
+# If TARGET is null (not provided) we should use default architecture
+# otherwise use what is specified
 RUN mkdir /opt/spack-environment
 COPY Dockerfiles/spack.yaml /opt/spack-environment/spack.yaml
 RUN cd /opt/spack-environment \
     && spack env activate . \
-    && spack install --fail-fast \
-    && spack gc -y
+    && if [ -n "$TARGET" ]; then \
+         spack config --scope env:"$SPACK_ENV" add "packages:all:prefer:['target=${TARGET}']"; \
+       fi && \
+    spack install --fail-fast && spack gc -y
 
 # Add the view `lib` to the LD_LIBRARY_PATH
 # This is required to make `ncgen` find  the libraries correctly


### PR DESCRIPTION
# Build Docker images for Arm64 ISA as well


### Task List
- [ ] Linked an issue above that captures the requirements of this PR
- [ ] Defined the tests that specify a complete and functioning change
- [ ] Implemented the source code change that satisfies the tests
- [ ] Commented all code so that it can be understood without additional context
- [ ] No new warnings are generated or they are mentioned below
- [ ] The documentation has been updated (or an issue has been created to do so)
- [ ] Relevant labels (e.g., enhancement, bug) have been applied to this PR
- [ ] This change conforms to the conventions described in the README

---
# Change Description

At the moment we build the Docker images on runners running on `amd64` architecture. 
This is an experiment to try to build `arm64` version as well. The ultimate goal is to make the published container images pullable for Apple Silicon Macs as well. 

It is likely that the ISAs extensions (or version will not match exactly). We might need to specify come specific target in Spack to circumvent that. We will see how things go.

TODO: 
- [x] Figure out how we can push the containers to registry with extra tag from the PRs (and make sure they don't stay there for to long. This will enable us to test the containers (we can but a separate GC job may be required, it may be too high maintenance cost ATM) 
- [x] Identify reasonable `lowest common denominator' target for the spack on amd64 and arm64. (see bellow) 

One of the problem this PR is fixing is that by default Spack compiles for the native architecture of the machine. As the result we were leaking the instruction set architecture of a particular GitHub runner selected to build the image. This was a problem since potentially it could use some of the extension a later consumer of the image would not have which would lead to failures. 

Now we pin the Spack build architecture both for amd64 and arm64. For AMD we use a compromise `x86_64_v3` target that does not contain AVX512 extension and hence supports pre Zen 4 AMD processors. 

For ARM we default to the common lowest denominator `aarach64` for maximum portability. 

Note that we don't specify target explicitly for XIOS. We build it with the generic target of the compiler for a given architecture.

---
# Test Description

At the moment only manual testing seems feasible. 

---
# Documentation Impact

TODO

---
# Other Details

TODO
