### PR TITLE
Fix the Docker image for the MPI tests

### DIFF
--- a/Dockerfiles/Dockerfile.devenv
+++ b/Dockerfiles/Dockerfile.devenv
@@ -70,12 +70,6 @@ ENV LD_LIBRARY_PATH=/opt/views/view/lib
 # Unanswered prompts may lead to failures
 ENV DEBIAN_FRONTEND=noninteractive
 
-# We need to explicitly point ncgen to the view libraries
-# to resolve a problem of location of HDF5 libraries not being provided
-# in the executable's RPATH. See:
-# https://github.com/spack/spack/issues/52555
-ENV LD_LIBRARY_PATH=/opt/views/view/lib
-
 # Create entrypoint script
 RUN { \
       echo '#!/bin/sh'; \

--- a/Dockerfiles/Dockerfile.devenv
+++ b/Dockerfiles/Dockerfile.devenv
@@ -22,7 +22,7 @@ RUN cd /opt/spack-environment \
 # Add the view `lib` to the LD_LIBRARY_PATH
 # This is required to make `ncgen` find  the libraries correctly
 # see: https://github.com/spack/spack/issues/52555
-ENV LD_LIBRARY_PATH=/opt/views/view/lib:$LD_LIBRARY_PATH
+ENV LD_LIBRARY_PATH=/opt/views/view/lib
 
 # Pre-fetch XIOS source code
 COPY Dockerfiles/install-xios.sh .
@@ -60,13 +60,26 @@ COPY --from=builder /usr /usr
 # paths.view is a symlink, so copy the parent to avoid dereferencing and duplicating it
 COPY --from=builder /opt/views /opt/views
 
-# Create entrypoint script
-# We need to explicitly point ncgen to the view libraries:
+# We need to explicitly point ncgen to the view libraries
+# to resolve a problem of location of HDF5 libraries not being provided
+# in the executable's RPATH. See:
 # https://github.com/spack/spack/issues/52555
+ENV LD_LIBRARY_PATH=/opt/views/view/lib
+
+# Prevent apt from any prompting of the user (e.g. to select region)
+# Unanswered prompts may lead to failures
+ENV DEBIAN_FRONTEND=noninteractive
+
+# We need to explicitly point ncgen to the view libraries
+# to resolve a problem of location of HDF5 libraries not being provided
+# in the executable's RPATH. See:
+# https://github.com/spack/spack/issues/52555
+ENV LD_LIBRARY_PATH=/opt/views/view/lib
+
+# Create entrypoint script
 RUN { \
       echo '#!/bin/sh'; \
       echo '. /opt/spack-environment/activate.sh'; \
-      echo 'export LD_LIBRARY_PATH=/opt/views/view/lib:$LD_LIBRARY_PATH'; \
       echo 'exec "$@"'; \
     } > /entrypoint.sh \
     && chmod a+x /entrypoint.sh \

--- a/Dockerfiles/Dockerfile.devenv
+++ b/Dockerfiles/Dockerfile.devenv
@@ -49,7 +49,7 @@ RUN cd /opt/spack-environment && \
     spack env activate --sh -d . > activate.sh
 
 # Bare OS image to run the installed executables
-FROM ubuntu:latest
+FROM ubuntu:noble
 
 # Copy necessary files from the builder stage
 COPY --from=builder /opt/spack-environment /opt/spack-environment


### PR DESCRIPTION

# Fix the Docker image for the MPI tests

Fixes #1110 

### Task List
- [x] Linked an issue above that captures the requirements of this PR
- [ ] ~~Defined the tests that specify a complete and functioning change~~
- [x] Implemented the source code change that satisfies the tests
- [x] Commented all code so that it can be understood without additional context
- [x] No new warnings are generated or they are mentioned below
- [ ] ~~The documentation has been updated (or an issue has been created to do so)~~
- [ ] Relevant labels (e.g., enhancement, bug) have been applied to this PR
- [x] This change conforms to the conventions described in the README

---
# Change Description

In 4cc4ec7d a value was set to LD_LIBRARY_PATH in the Docker image to resolve the known Spack issue with the RPATH in the ncgen utility.

However, the value was set in the entrypoint script. While it works fine if running the container interactively, in GitHub CI the value of the environmental variable is not propagated into individual job steps, which causes any MPI build to fail.

The solution is to properly bake the value into the image using the `ENV` Dockerfile instruction.

---
# Test Description

At the moment we don't have any good provision to test Docker containers.

---
# Documentation Impact

The changes are fully internal and do not impact user-facing documentation? 

---
# Other Details

