### PR TITLE
Use the pinned version of the `domain_decomp` in image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,6 +45,11 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          submodules: true
+
+      - name: Get domain_decomp revision
+        id: decomp
+        run: echo "DECOMP_REVISION=$(git rev-parse HEAD:domain_decomp)" >> $GITHUB_ENV
 
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e  # v4.3.0
@@ -63,3 +68,5 @@ jobs:
           push: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
           file: Dockerfiles/Dockerfile.devenv
           tags: ghcr.io/nextsimhub/nextsimdg-dev-env:latest
+          build-args: |
+            DECOMP_REV=${{ env.DECOMP_REVISION }}

--- a/Dockerfiles/Dockerfile.devenv
+++ b/Dockerfiles/Dockerfile.devenv
@@ -1,6 +1,10 @@
 # Build stage with Spack pre-installed and ready to be used
 FROM spack/ubuntu-noble:latest AS builder
 
+# Specify git revision (commit hash, branch name, or tag) of domain_decomp to be used
+# in the image
+ARG DECOMP_REV=main
+
 # Install perl
 RUN apt update \
     && apt install -y --no-install-recommends libany-uri-escape-perl \
@@ -32,6 +36,7 @@ RUN git clone --branch xios-3.0.6.0 https://gitlab.in2p3.fr/ipsl/projets/xios-pr
 RUN spack env activate /opt/spack-environment \
     && git clone https://github.com/nextsimhub/domain_decomp.git /decomp \
     && cd /decomp \
+    && git checkout ${DECOMP_REV} \
     && cmake -G "Unix Makefiles" -B build -S . -DCMAKE_BUILD_TYPE=Release \
     && cmake --build build \
     && cd - \


### PR DESCRIPTION
# Use the pinned version of the `domain_decomp` in image

Partially addresses #1116 

### Task List
- [x] Linked an issue above that captures the requirements of this PR
- [ ] Defined the tests that specify a complete and functioning change
- [x] Implemented the source code change that satisfies the tests
- [x] Commented all code so that it can be understood without additional context
- [x] No new warnings are generated or they are mentioned below
- [ ] The documentation has been updated (or an issue has been created to do so)
- [ ] Relevant labels (e.g., enhancement, bug) have been applied to this PR
- [x] This change conforms to the conventions described in the README

---
# Change Description

Currently the image always fetches the latest version of the `domain_decomp` main. This is not good since these may contain breaking changes in the interface. Since the pre-installed version of the decomp in the image is not used for tests, this will not be caught in the CI. It may however impact a user of the image.

The solution is to use the submodule as the 'single source of truth' for the compatible decomp version and use it to build the image. This will enable pushing breaking changes to the `main` in decomp without impacting nextsimdg.

---
# Test Description

We don't test Docker builds.

---
# Documentation Impact

Technically impacts instruction on locally building the Docker image. But these are not really documented at the moment. The instruction is really in the GitHub workflow and there the change is reflected.

---
# Other Details
